### PR TITLE
CORE-8163 Add more static IDs to Belphegor

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsColumnModel.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsColumnModel.java
@@ -86,4 +86,12 @@ public class AdminAppsColumnModel extends ColumnModel<App> implements AppNameSel
     public HandlerRegistration addAppInfoSelectedEventHandler(AppInfoSelectedEvent.AppInfoSelectedEventHandler handler) {
         return ensureHandlers().addHandler(AppInfoSelectedEvent.TYPE, handler);
     }
+
+    public void ensureDebugId(String baseID) {
+        for (ColumnConfig<App, ?> cc : configs) {
+            if (cc.getCell() instanceof AppInfoCell) {
+                ((AppInfoCell)cc.getCell()).setBaseDebugId(baseID);
+            }
+        }
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsGridImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsGridImpl.java
@@ -128,6 +128,7 @@ public class AdminAppsGridImpl extends ContentPanel implements AdminAppsGridView
     protected void onEnsureDebugId(String baseID) {
         super.onEnsureDebugId(baseID);
 
+        acm.ensureDebugId(baseID);
         grid.asWidget().ensureDebugId(baseID + Belphegor.AppIds.GRID);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsGridImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/apps/client/views/grid/AdminAppsGridImpl.java
@@ -11,6 +11,7 @@ import org.iplantc.de.apps.client.events.selection.AppCategorySelectionChangedEv
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppSelectionChangedEvent;
 import org.iplantc.de.client.models.apps.App;
+import org.iplantc.de.client.util.StaticIdHelper;
 
 import com.google.common.base.Joiner;
 import com.google.gwt.core.client.GWT;
@@ -25,6 +26,7 @@ import com.google.inject.assistedinject.Assisted;
 
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.ContentPanel;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
 import com.sencha.gxt.widget.core.client.grid.GridView;
@@ -125,11 +127,19 @@ public class AdminAppsGridImpl extends ContentPanel implements AdminAppsGridView
     }
 
     @Override
-    protected void onEnsureDebugId(String baseID) {
+    protected void onEnsureDebugId(final String baseID) {
         super.onEnsureDebugId(baseID);
 
         acm.ensureDebugId(baseID);
         grid.asWidget().ensureDebugId(baseID + Belphegor.AppIds.GRID);
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                StaticIdHelper.getInstance()
+                              .gridColumnHeaders(baseID + Belphegor.AppIds.GRID
+                                                 + Belphegor.AppIds.COL_HEADER, grid, cm);
+            }
+        });
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/TemplatesListingViewImpl.java
@@ -5,6 +5,7 @@ import org.iplantc.de.admin.desktop.client.metadata.events.DeleteMetadataSelecte
 import org.iplantc.de.admin.desktop.client.metadata.events.EditMetadataSelectedEvent;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
+import org.iplantc.de.client.util.StaticIdHelper;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -22,6 +23,7 @@ import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -61,13 +63,21 @@ public class TemplatesListingViewImpl extends Composite implements IsWidget, Tem
     }
 
     @Override
-    protected void onEnsureDebugId(String baseID) {
+    protected void onEnsureDebugId(final String baseID) {
         super.onEnsureDebugId(baseID);
 
         addBtn.ensureDebugId(baseID + Belphegor.MetadataIds.ADD);
         editBtn.ensureDebugId(baseID + Belphegor.MetadataIds.EDIT);
         delBtn.ensureDebugId(baseID + Belphegor.MetadataIds.DELETE);
         grid.ensureDebugId(baseID + Belphegor.MetadataIds.GRID);
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                StaticIdHelper.getInstance()
+                              .gridColumnHeaders(baseID + Belphegor.MetadataIds.GRID
+                                                 + Belphegor.MetadataIds.COL_HEADER, grid, cm);
+            }
+        });
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/OntologiesView.java
@@ -265,5 +265,7 @@ public interface OntologiesView extends IsWidget,
         OntologyHierarchy getSelectedHierarchy();
 
         Ontology getSelectedOntology();
+
+        void setViewDebugId(String id);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/model/HierarchyTree.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/model/HierarchyTree.java
@@ -1,0 +1,24 @@
+package org.iplantc.de.admin.desktop.client.ontologies.model;
+
+import org.iplantc.de.admin.desktop.shared.Belphegor;
+import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
+import org.iplantc.de.commons.client.widgets.DETree;
+
+import com.sencha.gxt.core.client.ValueProvider;
+import com.sencha.gxt.data.shared.TreeStore;
+
+/**
+ * @author aramsey
+ */
+public class HierarchyTree<O, S> extends DETree<OntologyHierarchy, String> {
+
+    public HierarchyTree(TreeStore<OntologyHierarchy> store,
+                         ValueProvider<? super OntologyHierarchy, String> valueProvider) {
+        super(store, valueProvider);
+    }
+
+    @Override
+    public java.lang.String generateDebugId(OntologyHierarchy ontologyHierarchy) {
+        return getBaseId() + "." + ontologyHierarchy.getIri() + Belphegor.CatalogIds.TREE_NODE;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/presenter/OntologiesPresenterImpl.java
@@ -21,6 +21,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.views.AppToOntologyHierarc
 import org.iplantc.de.admin.desktop.client.ontologies.views.OntologyHierarchyToAppDND;
 import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.CategorizeDialog;
 import org.iplantc.de.admin.desktop.client.services.AppAdminServiceFacade;
+import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.presenter.toolBar.proxy.AppSearchRpcProxy;
@@ -255,6 +256,11 @@ public class OntologiesPresenterImpl implements OntologiesView.Presenter,
         view.addAppSearchResultLoadEventHandler(previewGridPresenter.getView());
         view.addBeforeAppSearchEventHandler(previewGridPresenter.getView());
         view.addRestoreAppButtonClickedHandlers(this);
+    }
+
+    @Override
+    public void setViewDebugId(String id) {
+        view.asWidget().ensureDebugId(id + Belphegor.CatalogIds.VIEW);
     }
 
     PagingLoader<FilterPagingLoadConfig, PagingLoadResult<App>> getPagingLoader() {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -15,6 +15,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarc
 import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.PublishOntologyDialog;
 import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.SaveHierarchiesDialog;
+import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.BeforeAppSearchEvent;
 import org.iplantc.de.apps.client.events.selection.AppSelectionChangedEvent;
@@ -95,6 +96,7 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     @UiField(provided = true) Tree<OntologyHierarchy, String> previewTree;
     @UiField(provided = true) AdminAppsGridView previewGridView;
     @UiField(provided = true) AdminAppsGridView editorGridView;
+    @UiField ContentPanel previewPanel, editorPanel;
     @UiField CardLayoutContainer cards;
     @UiField CenterLayoutContainer noTreePanel, emptyTreePanel;
     @UiField ContentPanel editorTreePanel, previewTreePanel;
@@ -653,4 +655,37 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
         editorTreeTarget.addDropHandler(appToHierarchyDND);
     }
 
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        addButton.ensureDebugId(baseID + Belphegor.CatalogIds.ADD_ONTOLOGY_BTN);
+        deleteButton.ensureDebugId(baseID + Belphegor.CatalogIds.DELETE_ONTOLOGY_BTN);
+        ontologyDropDown.ensureDebugId(baseID + Belphegor.CatalogIds.ONTOLOGY_DROP_DOWN);
+        saveHierarchy.ensureDebugId(baseID + Belphegor.CatalogIds.SAVE_HIERARCHY_BTN);
+        deleteHierarchy.ensureDebugId(baseID + Belphegor.CatalogIds.DELETE_HIERARCHY_BTN);
+        categorize.ensureDebugId(baseID + Belphegor.CatalogIds.CATEGORIZE_BTN);
+        deleteApp.ensureDebugId(baseID + Belphegor.CatalogIds.DELETE_APP_BTN);
+        appSearchField.ensureDebugId(baseID + Belphegor.CatalogIds.APP_SEARCH);
+        restoreApp.ensureDebugId(baseID + Belphegor.CatalogIds.RESTORE_APP_BTN);
+
+        editorPanel.ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL);
+        editorPanel.getHeader().ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL + Belphegor.CatalogIds.HEADER);
+        editorTreePanel.ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL + Belphegor.CatalogIds.EDITOR_TREE_PANEL);
+        editorTreePanel.getHeader().ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL + Belphegor.CatalogIds.EDITOR_TREE_PANEL + Belphegor.CatalogIds.HEADER);
+        noTreePanel.ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL + Belphegor.CatalogIds.NO_TREE_PANEL);
+        emptyTreePanel.ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL + Belphegor.CatalogIds.EMPTY_TREE_PANEL);
+        editorTree.ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL + Belphegor.CatalogIds.EDITOR_TREE_PANEL + Belphegor.CatalogIds.EDITOR_TREE);
+        editorGridView.asWidget().ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL + Belphegor.CatalogIds.EDITOR_GRID);
+        publishButton.ensureDebugId(baseID + Belphegor.CatalogIds.EDITOR_PANEL + Belphegor.CatalogIds.PUBLISH_BTN);
+
+        previewPanel.ensureDebugId(baseID + Belphegor.CatalogIds.PREVIEW_PANEL);
+        previewPanel.getHeader().ensureDebugId(baseID + Belphegor.CatalogIds.PREVIEW_PANEL + Belphegor.CatalogIds.HEADER);
+        previewTreePanel.ensureDebugId(baseID + Belphegor.CatalogIds.PREVIEW_PANEL + Belphegor.CatalogIds.PREVIEW_TREE_PANEL);
+        previewTreePanel.getHeader().ensureDebugId(baseID + Belphegor.CatalogIds.PREVIEW_PANEL + Belphegor.CatalogIds.PREVIEW_TREE_PANEL + Belphegor.CatalogIds.HEADER);
+        previewTree.ensureDebugId(baseID + Belphegor.CatalogIds.PREVIEW_PANEL + Belphegor.CatalogIds.PREVIEW_TREE_PANEL + Belphegor.CatalogIds.PREVIEW_TREE);
+        previewGridView.asWidget().ensureDebugId(baseID + Belphegor.CatalogIds.PREVIEW_PANEL + Belphegor.CatalogIds.PREVIEW_GRID);
+        refreshPreview.ensureDebugId(baseID + Belphegor.CatalogIds.PREVIEW_PANEL + Belphegor.CatalogIds.REFRESH_PREVIEW_BTN);
+
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.java
@@ -13,6 +13,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.events.RefreshPreviewButto
 import org.iplantc.de.admin.desktop.client.ontologies.events.RestoreAppButtonClicked;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SaveOntologyHierarchyEvent;
 import org.iplantc.de.admin.desktop.client.ontologies.events.SelectOntologyVersionEvent;
+import org.iplantc.de.admin.desktop.client.ontologies.model.HierarchyTree;
 import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.PublishOntologyDialog;
 import org.iplantc.de.admin.desktop.client.ontologies.views.dialogs.SaveHierarchiesDialog;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
@@ -92,8 +93,8 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
     @UiField TextButton refreshPreview;
     @UiField TextButton restoreApp;
     @UiField(provided = true) OntologiesViewAppearance appearance;
-    @UiField(provided = true) Tree<OntologyHierarchy, String> editorTree;
-    @UiField(provided = true) Tree<OntologyHierarchy, String> previewTree;
+    @UiField(provided = true) HierarchyTree<OntologyHierarchy, String> editorTree;
+    @UiField(provided = true) HierarchyTree<OntologyHierarchy, String> previewTree;
     @UiField(provided = true) AdminAppsGridView previewGridView;
     @UiField(provided = true) AdminAppsGridView editorGridView;
     @UiField ContentPanel previewPanel, editorPanel;
@@ -596,8 +597,8 @@ public class OntologiesViewImpl extends Composite implements OntologiesView {
         fireEvent(new RestoreAppButtonClicked(targetApp));
     }
 
-    Tree<OntologyHierarchy, String> createTree(TreeStore<OntologyHierarchy> store) {
-        Tree<OntologyHierarchy, String> ontologyTree = new Tree<>(store, new ValueProvider<OntologyHierarchy, String>() {
+    HierarchyTree<OntologyHierarchy, String> createTree(TreeStore<OntologyHierarchy> store) {
+        HierarchyTree<OntologyHierarchy, String> ontologyTree = new HierarchyTree<>(store, new ValueProvider<OntologyHierarchy, String>() {
             @Override
             public String getValue(OntologyHierarchy object) {
                 return object.getLabel();

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/views/OntologiesViewImpl.ui.xml
@@ -102,7 +102,7 @@
             </toolbar:ToolBar>
         </container:north>
         <container:center layoutData="{centerData}">
-            <gxt:ContentPanel headingText="{appearance.westPanelHeader}">
+            <gxt:ContentPanel headingText="{appearance.westPanelHeader}" ui:field="editorPanel">
                 <container:BorderLayoutContainer borders="true">
                     <container:north layoutData="{northData}">
                         <toolbar:ToolBar>
@@ -140,7 +140,7 @@
             </gxt:ContentPanel>
         </container:center>
         <container:east layoutData="{eastData}">
-            <gxt:ContentPanel headingText="{appearance.eastPanelHeader}">
+            <gxt:ContentPanel headingText="{appearance.eastPanelHeader}" ui:field="previewPanel">
                 <container:BorderLayoutContainer>
                     <container:north layoutData="{northData}">
                         <toolbar:ToolBar>

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/permIdRequest/views/PermanentIdRequestViewImpl.java
@@ -7,6 +7,7 @@ import org.iplantc.de.client.models.identifiers.PermanentIdRequest;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestAutoBeanFactory;
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestType;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
+import org.iplantc.de.client.util.StaticIdHelper;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -25,6 +26,7 @@ import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent.DialogHideHandler;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -63,6 +65,7 @@ public class PermanentIdRequestViewImpl extends Composite implements PermanentId
 
     @UiField
     Grid<PermanentIdRequest> grid;
+    @UiField ColumnModel<PermanentIdRequest> cm;
 
     @UiField
     ListStore<PermanentIdRequest> store;
@@ -96,13 +99,21 @@ public class PermanentIdRequestViewImpl extends Composite implements PermanentId
     }
 
     @Override
-    protected void onEnsureDebugId(String baseID) {
+    protected void onEnsureDebugId(final String baseID) {
         super.onEnsureDebugId(baseID);
 
         updateBtn.ensureDebugId(baseID + Belphegor.PermIds.UPDATE);
         metadataBtn.ensureDebugId(baseID + Belphegor.PermIds.METADATA);
         createDOIBtn.ensureDebugId(baseID + Belphegor.PermIds.DOI);
         grid.ensureDebugId(baseID + Belphegor.PermIds.GRID);
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                StaticIdHelper.getInstance()
+                              .gridColumnHeaders(baseID + Belphegor.PermIds.GRID
+                                                 + Belphegor.PermIds.COL_HEADER, grid, cm);
+            }
+        });
     }
 
     @UiHandler("updateBtn")

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/refGenome/view/RefGenomeViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/refGenome/view/RefGenomeViewImpl.java
@@ -70,6 +70,7 @@ public class RefGenomeViewImpl extends Composite implements RefGenomeView {
     @UiField Grid<ReferenceGenome> grid;
     @UiField ListStore<ReferenceGenome> store;
     @UiField TextField filterField;
+    @UiField ColumnModel<ReferenceGenome> cm;
     @UiField(provided = true) RefGenomeAppearance appearance;
 
     private final ReferenceGenomeProperties rgProps;
@@ -211,5 +212,11 @@ public class RefGenomeViewImpl extends Composite implements RefGenomeView {
         addBtn.ensureDebugId(baseID + Belphegor.RefGenomeIds.ADD);
         filterField.setId(baseID + Belphegor.RefGenomeIds.NAME_FILTER);
         grid.ensureDebugId(baseID + Belphegor.RefGenomeIds.GRID);
+
+        for (ColumnConfig<ReferenceGenome, ?> cc : cm.getColumns()) {
+            if (cc.getCell() instanceof ReferenceGenomeNameCell) {
+                ((ReferenceGenomeNameCell)cc.getCell()).setBaseDebugId(baseID);
+            }
+        }
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/refGenome/view/RefGenomeViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/refGenome/view/RefGenomeViewImpl.java
@@ -4,6 +4,7 @@ import org.iplantc.de.admin.desktop.client.refGenome.RefGenomeView;
 import org.iplantc.de.admin.desktop.client.refGenome.view.cells.ReferenceGenomeNameCell;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.apps.refGenome.ReferenceGenome;
+import org.iplantc.de.client.util.StaticIdHelper;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
 import com.google.common.base.Strings;
@@ -25,6 +26,7 @@ import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent.SelectHandler;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.form.TextField;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
@@ -206,12 +208,20 @@ public class RefGenomeViewImpl extends Composite implements RefGenomeView {
     }
 
     @Override
-    protected void onEnsureDebugId(String baseID) {
+    protected void onEnsureDebugId(final String baseID) {
         super.onEnsureDebugId(baseID);
 
         addBtn.ensureDebugId(baseID + Belphegor.RefGenomeIds.ADD);
         filterField.setId(baseID + Belphegor.RefGenomeIds.NAME_FILTER);
         grid.ensureDebugId(baseID + Belphegor.RefGenomeIds.GRID);
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                StaticIdHelper.getInstance()
+                              .gridColumnHeaders(baseID + Belphegor.RefGenomeIds.GRID
+                                                 + Belphegor.RefGenomeIds.COL_HEADER, grid, cm);
+            }
+        });
 
         for (ColumnConfig<ReferenceGenome, ?> cc : cm.getColumns()) {
             if (cc.getCell() instanceof ReferenceGenomeNameCell) {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/refGenome/view/cells/ReferenceGenomeNameCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/refGenome/view/cells/ReferenceGenomeNameCell.java
@@ -1,9 +1,11 @@
 package org.iplantc.de.admin.desktop.client.refGenome.view.cells;
 
+import static com.google.gwt.dom.client.BrowserEvents.CLICK;
+
 import org.iplantc.de.admin.desktop.client.refGenome.RefGenomeView;
+import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.apps.refGenome.ReferenceGenome;
 
-import static com.google.gwt.dom.client.BrowserEvents.CLICK;
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.cell.client.ValueUpdater;
@@ -20,13 +22,14 @@ public class ReferenceGenomeNameCell extends AbstractCell<ReferenceGenome> {
 
     public interface ReferenceGenomeNameCellAppearance {
 
-        void renderDeletedReferenceGenomeCell(SafeHtmlBuilder sb, ReferenceGenome value);
+        void renderDeletedReferenceGenomeCell(SafeHtmlBuilder sb, ReferenceGenome value, String debugId);
 
-        void renderReferenceGenomeCell(SafeHtmlBuilder sb, ReferenceGenome value);
+        void renderReferenceGenomeCell(SafeHtmlBuilder sb, ReferenceGenome value, String debugId);
     }
 
     private final RefGenomeView view;
     private final ReferenceGenomeNameCellAppearance appearance = GWT.create(ReferenceGenomeNameCellAppearance.class);
+    private String baseID;
 
     public ReferenceGenomeNameCell(RefGenomeView view) {
         super(CLICK);
@@ -39,10 +42,12 @@ public class ReferenceGenomeNameCell extends AbstractCell<ReferenceGenome> {
             return;
         }
 
+        String debugId = baseID + "." + value.getId() + Belphegor.RefGenomeIds.NAME_CELL;
+
         if (value.isDeleted()) {
-            appearance.renderDeletedReferenceGenomeCell(sb, value);
+            appearance.renderDeletedReferenceGenomeCell(sb, value, debugId);
         } else {
-            appearance.renderReferenceGenomeCell(sb, value);
+            appearance.renderReferenceGenomeCell(sb, value, debugId);
         }
     }
 
@@ -60,4 +65,7 @@ public class ReferenceGenomeNameCell extends AbstractCell<ReferenceGenome> {
         }
     }
 
+    public void setBaseDebugId(String baseDebugId) {
+        this.baseID = baseDebugId;
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/systemMessage/view/SystemMessageViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/systemMessage/view/SystemMessageViewImpl.java
@@ -4,6 +4,7 @@ import org.iplantc.de.admin.desktop.client.systemMessage.SystemMessageView;
 import org.iplantc.de.admin.desktop.client.systemMessage.view.cells.SystemMessageNameCell;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.systemMessages.SystemMessage;
+import org.iplantc.de.client.util.StaticIdHelper;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
 import com.google.common.collect.Lists;
@@ -23,6 +24,7 @@ import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent.SelectHandler;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -69,12 +71,20 @@ public class SystemMessageViewImpl extends Composite implements SystemMessageVie
     }
 
     @Override
-    protected void onEnsureDebugId(String baseID) {
+    protected void onEnsureDebugId(final String baseID) {
         super.onEnsureDebugId(baseID);
 
         addBtn.ensureDebugId(baseID + Belphegor.SystemMessageIds.ADD);
         deleteBtn.ensureDebugId(baseID + Belphegor.SystemMessageIds.DELETE);
         grid.ensureDebugId(baseID + Belphegor.SystemMessageIds.GRID);
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                StaticIdHelper.getInstance()
+                              .gridColumnHeaders(baseID + Belphegor.SystemMessageIds.GRID
+                                                 + Belphegor.SystemMessageIds.COL_HEADER, grid, cm);
+            }
+        });
 
         for (ColumnConfig<SystemMessage, ?> cc : cm.getColumns()) {
             if (cc.getCell() instanceof SystemMessageNameCell) {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/systemMessage/view/SystemMessageViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/systemMessage/view/SystemMessageViewImpl.java
@@ -49,6 +49,7 @@ public class SystemMessageViewImpl extends Composite implements SystemMessageVie
 
     @UiField TextButton addBtn, deleteBtn;
     @UiField Grid<SystemMessage> grid;
+    @UiField ColumnModel<SystemMessage> cm;
     @UiField ListStore<SystemMessage> store;
     @UiField(provided = true) SystemMessageViewAppearance appearance;
 
@@ -74,6 +75,12 @@ public class SystemMessageViewImpl extends Composite implements SystemMessageVie
         addBtn.ensureDebugId(baseID + Belphegor.SystemMessageIds.ADD);
         deleteBtn.ensureDebugId(baseID + Belphegor.SystemMessageIds.DELETE);
         grid.ensureDebugId(baseID + Belphegor.SystemMessageIds.GRID);
+
+        for (ColumnConfig<SystemMessage, ?> cc : cm.getColumns()) {
+            if (cc.getCell() instanceof SystemMessageNameCell) {
+                ((SystemMessageNameCell)cc.getCell()).setBaseDebugId(baseID);
+            }
+        }
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/systemMessage/view/cells/SystemMessageNameCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/systemMessage/view/cells/SystemMessageNameCell.java
@@ -1,9 +1,11 @@
 package org.iplantc.de.admin.desktop.client.systemMessage.view.cells;
 
+import static com.google.gwt.dom.client.BrowserEvents.CLICK;
+
 import org.iplantc.de.admin.desktop.client.systemMessage.SystemMessageView;
+import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.systemMessages.SystemMessage;
 
-import static com.google.gwt.dom.client.BrowserEvents.CLICK;
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.cell.client.ValueUpdater;
@@ -21,11 +23,12 @@ public class SystemMessageNameCell extends AbstractCell<SystemMessage> {
     public interface SystemMessageNameCellAppearance {
         String CLICKABLE_ELEMENT_NAME = "smName";
 
-        void render(SafeHtmlBuilder sb, SystemMessage value);
+        void render(SafeHtmlBuilder sb, SystemMessage value, String debugID);
     }
 
     private final SystemMessageView view;
     private final SystemMessageNameCellAppearance appearance = GWT.create(SystemMessageNameCellAppearance.class);
+    private String baseDebugId;
 
     public SystemMessageNameCell(final SystemMessageView view) {
         super(CLICK);
@@ -34,7 +37,8 @@ public class SystemMessageNameCell extends AbstractCell<SystemMessage> {
 
     @Override
     public void render(Cell.Context arg0, SystemMessage value, SafeHtmlBuilder sb) {
-        appearance.render(sb, value);
+        String debugID = baseDebugId + "." + value.getId() + Belphegor.SystemMessageIds.NAME_CELL;
+        appearance.render(sb, value, debugID);
     }
 
     @Override
@@ -53,5 +57,9 @@ public class SystemMessageNameCell extends AbstractCell<SystemMessage> {
                 && eventTarget.getAttribute("name").equalsIgnoreCase(appearance.CLICKABLE_ELEMENT_NAME)) {
             view.editSystemMessage(value);
         }
+    }
+
+    public void setBaseDebugId(String baseDebugId) {
+        this.baseDebugId = baseDebugId;
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/systemMessage/view/cells/SystemMessageNameCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/systemMessage/view/cells/SystemMessageNameCell.java
@@ -37,7 +37,7 @@ public class SystemMessageNameCell extends AbstractCell<SystemMessage> {
 
     @Override
     public void render(Cell.Context arg0, SystemMessage value, SafeHtmlBuilder sb) {
-        String debugID = baseDebugId + "." + value.getId() + Belphegor.SystemMessageIds.NAME_CELL;
+        String debugID = baseDebugId + "." + value.getId() + Belphegor.SystemMessageIds.MESSAGE_CELL;
         appearance.render(sb, value, debugID);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/ToolAdminViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/ToolAdminViewImpl.java
@@ -10,6 +10,7 @@ import org.iplantc.de.admin.desktop.client.toolAdmin.view.cells.ToolAdminNameCel
 import org.iplantc.de.admin.desktop.client.toolAdmin.view.dialogs.ToolAdminDetailsDialog;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.tool.Tool;
+import org.iplantc.de.client.util.StaticIdHelper;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.shared.AsyncProviderWrapper;
 
@@ -37,6 +38,7 @@ import com.sencha.gxt.widget.core.client.box.ConfirmMessageBox;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.form.TextField;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
@@ -105,13 +107,21 @@ public class ToolAdminViewImpl extends Composite implements ToolAdminView {
     }
 
     @Override
-    protected void onEnsureDebugId(String baseID) {
+    protected void onEnsureDebugId(final String baseID) {
         super.onEnsureDebugId(baseID);
 
         addButton.ensureDebugId(baseID + Belphegor.ToolAdminIds.ADD);
         deleteButton.ensureDebugId(baseID + Belphegor.ToolAdminIds.DELETE);
         filterField.setId(baseID + Belphegor.ToolAdminIds.FILTER);
         grid.ensureDebugId(baseID + Belphegor.ToolAdminIds.GRID);
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                StaticIdHelper.getInstance()
+                              .gridColumnHeaders(baseID + Belphegor.ToolAdminIds.GRID
+                                                 + Belphegor.ToolAdminIds.COL_HEADER, grid, cm);
+            }
+        });
 
         for (ColumnConfig<Tool, ?> cc : cm.getColumns()) {
             if (cc.getCell() instanceof ToolAdminNameCell) {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/ToolAdminViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/ToolAdminViewImpl.java
@@ -84,6 +84,7 @@ public class ToolAdminViewImpl extends Composite implements ToolAdminView {
     @UiField TextButton deleteButton;
     @UiField Grid<Tool> grid;
     @UiField TextField filterField;
+    @UiField ColumnModel<Tool> cm;
     @UiField(provided = true) ListStore<Tool> listStore;
     @UiField(provided = true) ToolAdminViewAppearance appearance;
     @Inject AsyncProviderWrapper<ToolAdminDetailsDialog> toolDetailsDialog;
@@ -111,6 +112,12 @@ public class ToolAdminViewImpl extends Composite implements ToolAdminView {
         deleteButton.ensureDebugId(baseID + Belphegor.ToolAdminIds.DELETE);
         filterField.setId(baseID + Belphegor.ToolAdminIds.FILTER);
         grid.ensureDebugId(baseID + Belphegor.ToolAdminIds.GRID);
+
+        for (ColumnConfig<Tool, ?> cc : cm.getColumns()) {
+            if (cc.getCell() instanceof ToolAdminNameCell) {
+                ((ToolAdminNameCell)cc.getCell()).setBaseDebugId(baseID);
+            }
+        }
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/cells/ToolAdminNameCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolAdmin/view/cells/ToolAdminNameCell.java
@@ -3,6 +3,7 @@ package org.iplantc.de.admin.desktop.client.toolAdmin.view.cells;
 import static com.google.gwt.dom.client.BrowserEvents.CLICK;
 
 import org.iplantc.de.admin.desktop.client.toolAdmin.ToolAdminView;
+import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.tool.Tool;
 
 import com.google.gwt.cell.client.AbstractCell;
@@ -21,11 +22,12 @@ public class ToolAdminNameCell extends AbstractCell<Tool> {
     public interface ToolAdminNameCellAppearance {
         String CLICKABLE_ELEMENT_NAME = "toolName";
 
-        void render(SafeHtmlBuilder safeHtmlBuilder, Tool tool);
+        void render(SafeHtmlBuilder safeHtmlBuilder, Tool tool, String debugID);
     }
 
     private final ToolAdminView view;
     private final ToolAdminNameCellAppearance appearance = GWT.create(ToolAdminNameCellAppearance.class);
+    private String baseDebugId;
 
     public ToolAdminNameCell(ToolAdminView view) {
         super(CLICK);
@@ -34,7 +36,8 @@ public class ToolAdminNameCell extends AbstractCell<Tool> {
 
     @Override
     public void render(Context context, Tool value, SafeHtmlBuilder sb) {
-        appearance.render(sb, value);
+        String debugID = baseDebugId + "." + value.getId() + Belphegor.ToolAdminIds.NAME_CELL;
+        appearance.render(sb, value, debugID);
     }
 
     @Override
@@ -54,5 +57,9 @@ public class ToolAdminNameCell extends AbstractCell<Tool> {
                                  .equalsIgnoreCase(ToolAdminNameCellAppearance.CLICKABLE_ELEMENT_NAME)) {
             view.toolSelected(value);
         }
+    }
+
+    public void setBaseDebugId(String baseDebugId) {
+        this.baseDebugId = baseDebugId;
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolRequest/view/ToolRequestViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/toolRequest/view/ToolRequestViewImpl.java
@@ -6,6 +6,7 @@ import org.iplantc.de.client.models.toolRequest.ToolRequest;
 import org.iplantc.de.client.models.toolRequest.ToolRequestAutoBeanFactory;
 import org.iplantc.de.client.models.toolRequest.ToolRequestDetails;
 import org.iplantc.de.client.models.toolRequest.ToolRequestUpdate;
+import org.iplantc.de.client.util.StaticIdHelper;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
@@ -22,6 +23,7 @@ import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent.SelectHandler;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -43,6 +45,7 @@ public class ToolRequestViewImpl extends Composite implements ToolRequestView, S
 
     @UiField TextButton updateBtn;
     @UiField Grid<ToolRequest> grid;
+    @UiField ColumnModel<ToolRequest> cm;
     @UiField ListStore<ToolRequest> store;
     @UiField ToolRequestDetailsPanel detailsPanel;
     @UiField(provided = true) ToolRequestViewAppearance appearance;
@@ -167,11 +170,20 @@ public class ToolRequestViewImpl extends Composite implements ToolRequestView, S
     }
 
     @Override
-    protected void onEnsureDebugId(String baseID) {
+    protected void onEnsureDebugId(final String baseID) {
         super.onEnsureDebugId(baseID);
 
         updateBtn.ensureDebugId(baseID + Belphegor.ToolRequestIds.UPDATE);
         grid.ensureDebugId(baseID + Belphegor.ToolRequestIds.GRID);
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                StaticIdHelper.getInstance()
+                              .gridColumnHeaders(baseID + Belphegor.ToolRequestIds.GRID
+                                                 + Belphegor.ToolRequestIds.COL_HEADER, grid, cm);
+            }
+        });
+
         detailsPanel.ensureDebugId(baseID + Belphegor.ToolRequestIds.DETAILS_PANEL);
 
     }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorView.ui.xml
@@ -3,6 +3,7 @@
              xmlns:g='urn:import:com.google.gwt.user.client.ui'
              xmlns:gxt='urn:import:com.sencha.gxt.widget.core.client'
              xmlns:con='urn:import:com.sencha.gxt.widget.core.client.container'
+             xmlns:de="urn:import:org.iplantc.de.commons.client.widgets"
              >
     <ui:with field="appearance"
              type="org.iplantc.de.admin.desktop.client.views.BelphegorView.BelphegorViewAppearance"/>
@@ -67,34 +68,34 @@
             </con:north>
 
             <con:center layoutData="{centerData}">
-                <gxt:TabPanel>
-                    <gxt:child config="{ontologiesTabConfig}">
+                <de:DETabPanel ui:field="deTabPanel">
+                    <de:child config="{ontologiesTabConfig}">
                         <con:SimpleContainer ui:field="ontologiesPanel"/>
-                    </gxt:child>
-                    <gxt:child config="{refGenTabConfig}">
+                    </de:child>
+                    <de:child config="{refGenTabConfig}">
                         <con:SimpleContainer ui:field="refGenomePanel"/>
-                    </gxt:child>
-                    <gxt:child config="{toolReqTabConfig}">
+                    </de:child>
+                    <de:child config="{toolReqTabConfig}">
                         <con:SimpleContainer ui:field="toolRequestPanel"/>
-                    </gxt:child>
-                    <gxt:child config="{toolAdminConfig}">
+                    </de:child>
+                    <de:child config="{toolAdminConfig}">
                         <con:SimpleContainer ui:field="toolAdminPanel"/>
-                    </gxt:child>
-                    <gxt:child config="{sysMsgTabConfig}">
+                    </de:child>
+                    <de:child config="{sysMsgTabConfig}">
                         <con:SimpleContainer ui:field="systemMessagesPanel"/>
-                    </gxt:child>
-                     <gxt:child config="{detemplateConfig}">
+                    </de:child>
+                     <de:child config="{detemplateConfig}">
                         <con:SimpleContainer ui:field="metadataPanel">
                         </con:SimpleContainer>
-                    </gxt:child>
-                    <gxt:child config="{permIdConfig}">
+                    </de:child>
+                    <de:child config="{permIdConfig}">
                         <con:SimpleContainer ui:field="permIdPanel">
                         </con:SimpleContainer>
-                    </gxt:child>
-                    <gxt:child config="{workshopAdminConfig}">
+                    </de:child>
+                    <de:child config="{workshopAdminConfig}">
                         <con:SimpleContainer ui:field="workshopAdminPanel" />
-                    </gxt:child>
-                </gxt:TabPanel>
+                    </de:child>
+                </de:DETabPanel>
             </con:center>
 
             <con:south layoutData="{southData}">

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorViewImpl.java
@@ -10,6 +10,7 @@ import org.iplantc.de.admin.desktop.client.toolRequest.ToolRequestView;
 import org.iplantc.de.admin.desktop.client.workshopAdmin.WorkshopAdminView;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.models.UserInfo;
+import org.iplantc.de.commons.client.widgets.DETabPanel;
 import org.iplantc.de.commons.client.widgets.IPlantAnchor;
 
 import com.google.gwt.core.client.GWT;
@@ -41,6 +42,7 @@ public class BelphegorViewImpl extends Composite implements BelphegorView {
     interface BelphegorViewUiBinder extends UiBinder<Widget, BelphegorViewImpl> {}
 
     @UiField HtmlLayoutContainer northCon;
+    @UiField DETabPanel deTabPanel;
     @UiField SimpleContainer ontologiesPanel, refGenomePanel, toolRequestPanel, systemMessagesPanel, metadataPanel,
             permIdPanel, toolAdminPanel, workshopAdminPanel;
     @UiField(provided = true) BelphegorViewAppearance appearance;
@@ -140,26 +142,34 @@ public class BelphegorViewImpl extends Composite implements BelphegorView {
 
         menuButton.ensureDebugId(baseID + Belphegor.Ids.MENU_BUTTON);
 
-        ontologiesPanel.ensureDebugId(baseID + Belphegor.Ids.ONTOLOGIES);
+        deTabPanel.setTabDebugId(ontologiesPanel, baseID + Belphegor.Ids.CATALOG_TAB);
+        ontologiesPanel.ensureDebugId(baseID + Belphegor.Ids.CATALOG);
 
+        deTabPanel.setTabDebugId(refGenomePanel, baseID + Belphegor.Ids.REFERENCE_GENOME_TAB);
         refGenomePanel.ensureDebugId(baseID + Belphegor.Ids.REFERENCE_GENOME);
         refGenPresenter.setViewDebugId(baseID + Belphegor.Ids.REFERENCE_GENOME);
 
+        deTabPanel.setTabDebugId(toolRequestPanel, baseID + Belphegor.Ids.TOOL_REQUEST_TAB);
         toolRequestPanel.ensureDebugId(baseID + Belphegor.Ids.TOOL_REQUEST);
         toolReqPresenter.setViewDebugId(baseID + Belphegor.Ids.TOOL_REQUEST);
 
+        deTabPanel.setTabDebugId(toolAdminPanel, baseID + Belphegor.Ids.TOOL_ADMIN_TAB);
         toolAdminPanel.ensureDebugId(baseID + Belphegor.Ids.TOOL_ADMIN);
         toolAdminPresenter.setViewDebugId(baseID + Belphegor.Ids.TOOL_ADMIN);
 
+        deTabPanel.setTabDebugId(systemMessagesPanel, baseID + Belphegor.Ids.SYSTEM_MESSAGE_TAB);
         systemMessagesPanel.ensureDebugId(baseID + Belphegor.Ids.SYSTEM_MESSAGE);
         sysMsgPresenter.setViewDebugId(baseID + Belphegor.Ids.SYSTEM_MESSAGE);
 
+        deTabPanel.setTabDebugId(metadataPanel, baseID + Belphegor.Ids.METADATA_TAB);
         metadataPanel.ensureDebugId(baseID + Belphegor.Ids.METADATA);
         tempPresenter.setViewDebugId(baseID + Belphegor.Ids.METADATA);
 
+        deTabPanel.setTabDebugId(permIdPanel, baseID + Belphegor.Ids.PERMID_TAB);
         permIdPanel.ensureDebugId(baseID + Belphegor.Ids.PERMID);
         permIdPresenter.setViewDebugId(baseID + Belphegor.Ids.PERMID);
 
+        deTabPanel.setTabDebugId(workshopAdminPanel, baseID + Belphegor.Ids.WORKSHOP_ADMIN_TAB);
         workshopAdminPanel.ensureDebugId(baseID + Belphegor.Ids.WORKSHOP_ADMIN);
         workshopAdminPresenter.setViewDebugId(baseID + Belphegor.Ids.WORKSHOP_ADMIN);
     }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/views/BelphegorViewImpl.java
@@ -144,6 +144,7 @@ public class BelphegorViewImpl extends Composite implements BelphegorView {
 
         deTabPanel.setTabDebugId(ontologiesPanel, baseID + Belphegor.Ids.CATALOG_TAB);
         ontologiesPanel.ensureDebugId(baseID + Belphegor.Ids.CATALOG);
+        ontologiesPresenter.setViewDebugId(baseID + Belphegor.Ids.CATALOG);
 
         deTabPanel.setTabDebugId(refGenomePanel, baseID + Belphegor.Ids.REFERENCE_GENOME_TAB);
         refGenomePanel.ensureDebugId(baseID + Belphegor.Ids.REFERENCE_GENOME);

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/workshopAdmin/view/WorkshopAdminViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/workshopAdmin/view/WorkshopAdminViewImpl.java
@@ -5,6 +5,7 @@ import org.iplantc.de.admin.desktop.client.workshopAdmin.events.DeleteMembersCli
 import org.iplantc.de.admin.desktop.client.workshopAdmin.events.RefreshMembersClickedEvent;
 import org.iplantc.de.admin.desktop.client.workshopAdmin.events.SaveMembersClickedEvent;
 import org.iplantc.de.admin.desktop.client.workshopAdmin.model.MemberProperties;
+import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.groups.Member;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
@@ -42,7 +43,7 @@ public class WorkshopAdminViewImpl extends Composite implements WorkshopAdminVie
     interface WorkshopAdminViewImplUiBinder extends UiBinder<Widget, WorkshopAdminViewImpl> {}
 
     @UiField(provided = true) UserSearchField userSearch;
-    @UiField TextButton deleteButton;
+    @UiField TextButton deleteButton, saveButton, refreshButton;
     @UiField Grid<Member> grid;
     @UiField(provided = true) ListStore<Member> listStore;
     @UiField(provided = true) WorkshopAdminViewAppearance appearance;
@@ -120,5 +121,15 @@ public class WorkshopAdminViewImpl extends Composite implements WorkshopAdminVie
     @UiHandler("refreshButton")
     void refreshButtonClicked(SelectEvent event) {
         fireEvent(new RefreshMembersClickedEvent());
+    }
+
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        userSearch.asWidget().ensureDebugId(baseID + Belphegor.WorkshopAdminIds.USER_SEARCH);
+        deleteButton.ensureDebugId(baseID + Belphegor.WorkshopAdminIds.DELETE_BTN);
+        saveButton.ensureDebugId(baseID + Belphegor.WorkshopAdminIds.SAVE_BTN);
+        refreshButton.ensureDebugId(baseID + Belphegor.WorkshopAdminIds.REFRESH_BTN);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/workshopAdmin/view/WorkshopAdminViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/workshopAdmin/view/WorkshopAdminViewImpl.java
@@ -8,6 +8,7 @@ import org.iplantc.de.admin.desktop.client.workshopAdmin.model.MemberProperties;
 import org.iplantc.de.admin.desktop.shared.Belphegor;
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.groups.Member;
+import org.iplantc.de.client.util.StaticIdHelper;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
 
 import com.google.common.collect.Lists;
@@ -28,6 +29,7 @@ import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -45,6 +47,7 @@ public class WorkshopAdminViewImpl extends Composite implements WorkshopAdminVie
     @UiField(provided = true) UserSearchField userSearch;
     @UiField TextButton deleteButton, saveButton, refreshButton;
     @UiField Grid<Member> grid;
+    @UiField ColumnModel<Member> cm;
     @UiField(provided = true) ListStore<Member> listStore;
     @UiField(provided = true) WorkshopAdminViewAppearance appearance;
 
@@ -124,12 +127,21 @@ public class WorkshopAdminViewImpl extends Composite implements WorkshopAdminVie
     }
 
     @Override
-    protected void onEnsureDebugId(String baseID) {
+    protected void onEnsureDebugId(final String baseID) {
         super.onEnsureDebugId(baseID);
 
         userSearch.asWidget().ensureDebugId(baseID + Belphegor.WorkshopAdminIds.USER_SEARCH);
         deleteButton.ensureDebugId(baseID + Belphegor.WorkshopAdminIds.DELETE_BTN);
         saveButton.ensureDebugId(baseID + Belphegor.WorkshopAdminIds.SAVE_BTN);
         refreshButton.ensureDebugId(baseID + Belphegor.WorkshopAdminIds.REFRESH_BTN);
+        grid.ensureDebugId(baseID + Belphegor.WorkshopAdminIds.GRID);
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                StaticIdHelper.getInstance()
+                              .gridColumnHeaders(baseID + Belphegor.WorkshopAdminIds.GRID
+                                                 + Belphegor.WorkshopAdminIds.COL_HEADER, grid, cm);
+            }
+        });
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -15,8 +15,16 @@ public interface Belphegor {
         String SYSTEM_MESSAGE = ".systemMessage";
         String TOOL_ADMIN = ".toolAdmin";
         String TOOL_REQUEST = ".toolRequest";
-        String ONTOLOGIES = ".ontologies";
+        String CATALOG = ".catalog";
         String WORKSHOP_ADMIN = ".workshopAdmin";
+        String CATALOG_TAB = ".catalogTab";
+        String REFERENCE_GENOME_TAB = ".referenceGenomeTab";
+        String TOOL_REQUEST_TAB = ".toolRequestTab";
+        String TOOL_ADMIN_TAB = ".toolAdminTab";
+        String SYSTEM_MESSAGE_TAB = ".systemMessageTab";
+        String METADATA_TAB = ".metadataTab";
+        String PERMID_TAB = ".permIdTab";
+        String WORKSHOP_ADMIN_TAB = ".workshopAdminTab";
     }
 
     interface AppIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -262,5 +262,6 @@ public interface Belphegor {
         String PREVIEW_GRID = ".previewGrid";
         String REFRESH_PREVIEW_BTN = ".refreshPreviewBtn";
         String HEADER = ".header";
+        String TREE_NODE = ".treeNode";
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -210,7 +210,8 @@ public interface Belphegor {
         String LOGINS_DISABLED = ".loginsDisabled";
         String MESSAGE = ".message";
         String TYPE = ".type";
-        String NAME_CELL = ".nameCell";
+        String MESSAGE_CELL = ".messageCell";
+        String COL_HEADER = ".colHeader";
     }
 
     interface MetadataIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -64,6 +64,7 @@ public interface Belphegor {
         String TEMPLATE_LINK = ".templateLink";
         String CLOSE_BTN = ".closeBtn";
         String BETA = ".beta";
+        String COL_HEADER = ".colHeader";
     }
 
     interface RefGenomeIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -203,6 +203,7 @@ public interface Belphegor {
         String LOGINS_DISABLED = ".loginsDisabled";
         String MESSAGE = ".message";
         String TYPE = ".type";
+        String NAME_CELL = ".nameCell";
     }
 
     interface MetadataIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -84,6 +84,7 @@ public interface Belphegor {
         String EDITOR_VIEW = ".view";
         String GENOME_EDITOR = "genomeEditorWindow";
         String SAVE_BTN = ".saveBtn";
+        Object NAME_CELL = ".nameCell";
     }
 
     interface ToolRequestIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -113,6 +113,7 @@ public interface Belphegor {
         String SUBMIT_BTN = ".submitBtn";
         String DIALOG_VIEW = ".view";
         String ATTRIBUTION = ".attribution";
+        String COL_HEADER = ".colHeader";
     }
 
     interface ToolAdminIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -181,6 +181,7 @@ public interface Belphegor {
         String CONFIRM_DELETE = "confirmToolDelete";
         String YES = ".yesBtn";
         String NO = ".noBtn";
+        String NAME_CELL = ".nameCell";
     }
 
     interface WorkshopAdminIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -246,6 +246,7 @@ public interface Belphegor {
         String STATUS_COMBO = ".statusCombo";
         String COMMENTS = ".comments";
         String CANCEL = ".cancelBtn";
+        String COL_HEADER = ".colHeader";
     }
 
     interface CatalogIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -237,4 +237,30 @@ public interface Belphegor {
         String COMMENTS = ".comments";
         String CANCEL = ".cancelBtn";
     }
+
+    interface CatalogIds {
+        String VIEW = ".view";
+        String ADD_ONTOLOGY_BTN = ".addOntologyBtn";
+        String DELETE_ONTOLOGY_BTN = ".deleteOntologyBtn";
+        String ONTOLOGY_DROP_DOWN = ".ontologyDropDown";
+        String SAVE_HIERARCHY_BTN = ".saveHierarchyBtn";
+        String DELETE_HIERARCHY_BTN = ".deleteHierarchyBtn";
+        String CATEGORIZE_BTN = ".categorizeBtn";
+        String DELETE_APP_BTN = ".deleteAppBtn";
+        String APP_SEARCH = ".appSearch";
+        String RESTORE_APP_BTN = ".restoreAppBtn";
+        String EDITOR_PANEL = ".editorPanel";
+        String EDITOR_TREE_PANEL = ".editorTreePanel";
+        String NO_TREE_PANEL = ".noTreePanel";
+        String EMPTY_TREE_PANEL = ".emptyTreePanel";
+        String EDITOR_TREE = ".editorTree";
+        String EDITOR_GRID = ".editorGrid";
+        String PUBLISH_BTN = ".publishBtn";
+        String PREVIEW_PANEL = ".previewPanel";
+        String PREVIEW_TREE_PANEL = ".previewTreePanel";
+        String PREVIEW_TREE = ".previewTree";
+        String PREVIEW_GRID = ".previewGrid";
+        String REFRESH_PREVIEW_BTN = ".refreshPreviewBtn";
+        String HEADER = ".header";
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -86,6 +86,7 @@ public interface Belphegor {
         String GENOME_EDITOR = "genomeEditorWindow";
         String SAVE_BTN = ".saveBtn";
         Object NAME_CELL = ".nameCell";
+        String COL_HEADER = ".colHeader";
     }
 
     interface ToolRequestIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -226,6 +226,7 @@ public interface Belphegor {
         String YES = ".yesBtn";
         String NO = ".noBtn";
         String TEMPLATE_DESCRIPTION = ".description";
+        String COL_HEADER = ".colHeader";
     }
 
     interface PermIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -194,6 +194,8 @@ public interface Belphegor {
         String DELETE_BTN = ".deleteBtn";
         String SAVE_BTN = ".saveBtn";
         String REFRESH_BTN = ".refreshBtn";
+        String GRID = ".grid";
+        String COL_HEADER = ".colHeader";
     }
 
     interface SystemMessageIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -182,6 +182,7 @@ public interface Belphegor {
         String YES = ".yesBtn";
         String NO = ".noBtn";
         String NAME_CELL = ".nameCell";
+        String COL_HEADER = ".colHeader";
     }
 
     interface WorkshopAdminIds {

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/shared/Belphegor.java
@@ -186,6 +186,10 @@ public interface Belphegor {
 
     interface WorkshopAdminIds {
         String VIEW = ".view";
+        String USER_SEARCH = ".userSearch";
+        String DELETE_BTN = ".deleteBtn";
+        String SAVE_BTN = ".saveBtn";
+        String REFRESH_BTN = ".refreshBtn";
     }
 
     interface SystemMessageIds {

--- a/de-lib/src/main/java/org/iplantc/de/client/util/StaticIdHelper.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/util/StaticIdHelper.java
@@ -1,0 +1,65 @@
+package org.iplantc.de.client.util;
+
+import com.google.common.base.Preconditions;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NodeList;
+
+import com.sencha.gxt.core.client.dom.XElement;
+import com.sencha.gxt.widget.core.client.grid.ColumnHeader;
+import com.sencha.gxt.widget.core.client.grid.ColumnModel;
+import com.sencha.gxt.widget.core.client.grid.Grid;
+
+/**
+ * @author aramsey
+ */
+public class StaticIdHelper {
+
+    private static StaticIdHelper INSTANCE;
+
+    StaticIdHelper() {
+
+    }
+
+    public static StaticIdHelper getInstance(){
+        if(INSTANCE == null) {
+            INSTANCE = new StaticIdHelper();
+        }
+
+        return INSTANCE;
+    }
+
+    /**
+     * Sets the static IDs for the column headers in a grid
+     * This does not work if called simply within a view's onEnsureDebugId method
+     * as the headers will not have been rendered yet.
+     * This can be called successfully using the grid's ViewReadyHandler (which can
+     * then be added to the grid within the onEnsureDebugId method)
+     * @param baseID
+     * @param grid
+     * @param cm
+     */
+    public void gridColumnHeaders(String baseID, Grid<?> grid, ColumnModel<?> cm) {
+        Preconditions.checkNotNull(baseID);
+        Preconditions.checkNotNull(grid);
+        Preconditions.checkNotNull(cm);
+
+        ColumnHeader<?> header = grid.getView().getHeader();
+
+        String columnWrapSelectorClassName = header.getAppearance().columnsWrapSelector();
+        String headRowClassName = "." + header.getAppearance().styles().headRow();
+
+        XElement colWrapElement = (XElement)header.getElement().select(columnWrapSelectorClassName).getItem(0);
+        Element table = colWrapElement.getElementsByTagName("table").getItem(0);
+        //There are two tbody elements, the first holds only H/W information for the header cells
+        //The second tbody has the column header information
+        XElement tbody = (XElement)table.getElementsByTagName("tbody").getItem(1);
+        XElement tr = (XElement)tbody.select(headRowClassName).getItem(0);
+        NodeList<Element> tds = tr.getElementsByTagName("td");
+
+        for (int i = 0; i < tds.getLength(); i++) {
+            String headerName = cm.getColumn(i).getHeader().asString().replace(" ", "_");
+            tds.getItem(i).setId(baseID + "." + headerName);
+        }
+    }
+
+}

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/DETree.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/DETree.java
@@ -1,0 +1,67 @@
+package org.iplantc.de.commons.client.widgets;
+
+import com.google.common.base.Preconditions;
+
+import com.sencha.gxt.core.client.ValueProvider;
+import com.sencha.gxt.data.shared.TreeStore;
+import com.sencha.gxt.widget.core.client.tree.Tree;
+
+/**
+ * @author aramsey
+ *
+ * This is basically a clone-and-one of Sencha's Tree, but with the ability
+ * to define a way to set the debug IDs on the TreeNodes.
+ *
+ * A class will need to extend DETree and fill out the generateDebugId method
+ * The view that uses the class then has to call tree.ensureDebugId(id) in the
+ * view's onEnsureDebugId(String baseID) method like you would for any other
+ * UI component
+ */
+public abstract class DETree<M, C> extends Tree<M, C> {
+
+    private String baseId;
+
+    public DETree(TreeStore<M> store, ValueProvider<? super M, C> valueProvider) {
+        super(store, valueProvider);
+    }
+
+    public DETree(TreeStore<M> store,
+                  ValueProvider<? super M, C> valueProvider,
+                  TreeAppearance appearance) {
+        super(store, valueProvider, appearance);
+    }
+
+    public static class DETreeNode<M> extends TreeNode<M> {
+
+        protected DETreeNode(String modelId, M m, String domId) {
+            super(modelId, m, domId);
+        }
+    }
+
+    @Override
+    protected String register(M m) {
+        String id = generateModelId(m);
+        if (nodes.containsKey(id)) {
+            return nodes.get(id).getDomId();
+        } else {
+            String domId = generateDebugId(m);
+            TreeNode<M> node = new DETreeNode<>(id, m, domId);
+            nodes.put(id, node);
+            nodesByDom.put(domId, node);
+            return domId;
+        }
+    }
+
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+        this.baseId = baseID;
+    }
+
+    public String getBaseId() {
+        Preconditions.checkNotNull(baseId);
+        return baseId;
+    }
+
+    public abstract String generateDebugId(M m);
+}

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -656,8 +656,10 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
    }
 
     void restoreWindows(List<WindowState> windowStates) {
-        for (WindowState ws : windowStates) {
-            desktopWindowManager.show(ws);
+        if (windowStates != null && windowStates.size() > 0) {
+            for (WindowState ws : windowStates) {
+                desktopWindowManager.show(ws);
+            }
         }
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/refGenome/ReferenceGenomeNameCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/refGenome/ReferenceGenomeNameCellDefaultAppearance.java
@@ -17,11 +17,11 @@ import com.sencha.gxt.core.client.XTemplates;
  */
 public class ReferenceGenomeNameCellDefaultAppearance implements ReferenceGenomeNameCell.ReferenceGenomeNameCellAppearance {
     interface Templates extends XTemplates {
-        @XTemplate("<span><span class='{appStyle.unavailable}'> </span>&nbsp;<span name='rgName' class='{style.nameStyle}' >{refGenome.name}</span></span>")
-        SafeHtml genomeDeleted(FavoriteCellStyle appStyle, DiskResourceNameCellStyle style, ReferenceGenome refGenome);
+        @XTemplate("<span><span class='{appStyle.unavailable}'> </span>&nbsp;<span name='rgName' class='{style.nameStyle}' id='{debugId}' >{refGenome.name}</span></span>")
+        SafeHtml genomeDeleted(FavoriteCellStyle appStyle, DiskResourceNameCellStyle style, ReferenceGenome refGenome, String debugId);
 
-        @XTemplates.XTemplate("<span name='rgName' class='{style.nameStyle}' >{refGenome.name}</span>")
-        SafeHtml genome(DiskResourceNameCellStyle style, ReferenceGenome refGenome);
+        @XTemplates.XTemplate("<span name='rgName' class='{style.nameStyle}' id='{debugId}' >{refGenome.name}</span>")
+        SafeHtml genome(DiskResourceNameCellStyle style, ReferenceGenome refGenome, String debugId);
     }
 
     private final DiskResourceNameCellStyle diskResourceNameCellStyle;
@@ -46,12 +46,12 @@ public class ReferenceGenomeNameCellDefaultAppearance implements ReferenceGenome
     }
 
     @Override
-    public void renderDeletedReferenceGenomeCell(SafeHtmlBuilder sb, ReferenceGenome value) {
-        sb.append(templates.genomeDeleted(favoriteCellStyle, diskResourceNameCellStyle, value));
+    public void renderDeletedReferenceGenomeCell(SafeHtmlBuilder sb, ReferenceGenome value, String debugId) {
+        sb.append(templates.genomeDeleted(favoriteCellStyle, diskResourceNameCellStyle, value, debugId));
     }
 
     @Override
-    public void renderReferenceGenomeCell(SafeHtmlBuilder sb, ReferenceGenome value) {
-        sb.append(templates.genome(diskResourceNameCellStyle, value));
+    public void renderReferenceGenomeCell(SafeHtmlBuilder sb, ReferenceGenome value, String debugId) {
+        sb.append(templates.genome(diskResourceNameCellStyle, value, debugId));
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/systemMessage/cells/SystemMessageNameCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/systemMessage/cells/SystemMessageNameCellDefaultAppearance.java
@@ -16,8 +16,8 @@ import com.sencha.gxt.core.client.XTemplates;
  */
 public class SystemMessageNameCellDefaultAppearance implements SystemMessageNameCell.SystemMessageNameCellAppearance {
      interface Templates extends XTemplates {
-        @XTemplates.XTemplate("<span name='{elementName}' class='{style.nameStyle}' >{sysMessage.body}</span>")
-        SafeHtml genome(String elementName, DiskResourceNameCellStyle style, SystemMessage sysMessage);
+        @XTemplates.XTemplate("<span name='{elementName}' class='{style.nameStyle}' id='{debugID}' >{sysMessage.body}</span>")
+        SafeHtml genome(String elementName, DiskResourceNameCellStyle style, SystemMessage sysMessage, String debugID);
     }
 
     private final DiskResourceNameCellStyle diskResourceNameCellStyle;
@@ -40,11 +40,11 @@ public class SystemMessageNameCellDefaultAppearance implements SystemMessageName
     }
 
     @Override
-    public void render(SafeHtmlBuilder sb, SystemMessage value) {
+    public void render(SafeHtmlBuilder sb, SystemMessage value, String debugID) {
          if(value == null){
              return;
          }
 
-        sb.append(templates.genome(CLICKABLE_ELEMENT_NAME, diskResourceNameCellStyle, value));
+        sb.append(templates.genome(CLICKABLE_ELEMENT_NAME, diskResourceNameCellStyle, value, debugID));
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/toolAdmin/cells/ToolAdminViewCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/admin/toolAdmin/cells/ToolAdminViewCellDefaultAppearance.java
@@ -18,8 +18,8 @@ public class ToolAdminViewCellDefaultAppearance
         implements ToolAdminNameCell.ToolAdminNameCellAppearance {
 
     interface Templates extends XTemplates {
-        @XTemplates.XTemplate("<span name='{elementName}' class='{style.nameStyle}' >{tool.name}</span>")
-        SafeHtml tool(String elementName, DiskResourceNameCellStyle style, Tool tool);
+        @XTemplates.XTemplate("<span name='{elementName}' class='{style.nameStyle}' id='{debugID}'>{tool.name}</span>")
+        SafeHtml tool(String elementName, DiskResourceNameCellStyle style, Tool tool, String debugID);
     }
 
     private final Templates templates;
@@ -36,11 +36,11 @@ public class ToolAdminViewCellDefaultAppearance
     }
 
     @Override
-    public void render(SafeHtmlBuilder safeHtmlBuilder, Tool tool) {
+    public void render(SafeHtmlBuilder safeHtmlBuilder, Tool tool, String debugID) {
         if (tool == null) {
             return;
         }
 
-        safeHtmlBuilder.append(templates.tool(CLICKABLE_ELEMENT_NAME, defaultStyle, tool));
+        safeHtmlBuilder.append(templates.tool(CLICKABLE_ELEMENT_NAME, defaultStyle, tool, debugID));
     }
 }


### PR DESCRIPTION
This PR is to add more static IDs to Belphegor as requested by QA.

* Each tab in Belphegor should have its own ID (switched to `DETabPanel` class instead of Sencha's `TabPanel` which allows for the tabs to have IDs)
* The App Catalog tab didn't have any IDs so those were added
  * I created `DETree` abstract class which allows any child class to specify a `generateDebugID` method for debug IDs on the tree nodes
* The column headers in grids all got static IDs (with use from StaticIDHelper class)

* I also patched up a random NPE that happens if you have saved sessions enabled, save a session with no windows open, and then log in.