### PR TITLE
CORE-3701 Resize oversize window from saved session

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopWindowManager.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopWindowManager.java
@@ -79,6 +79,7 @@ public class DesktopWindowManager {
                     window.setContainer(desktopContainer);
                 }
                 window.show(config, constructWindowId(config), true);
+                resizeOversizeWindow(window);
                 if (sticky != null) {
                     windowManager.bringToFront(sticky);
                 }
@@ -164,12 +165,26 @@ public class DesktopWindowManager {
                 }
 
                 window.show(config, constructWindowId(config), true);
+                resizeOversizeWindow(window);
                 moveOutOfBoundsWindow(window);
                 if (sticky != null) {
                     windowManager.bringToFront(sticky);
                 }
             }
         });
+    }
+
+    private void resizeOversizeWindow(IPlantWindowInterface window) {
+        int desktopWidth = desktopContainer.getClientWidth();
+        int desktopHeight = desktopContainer.getClientHeight();
+        int windowWidth = window.asWindow().getOffsetWidth();
+        int windowHeight = window.asWindow().getOffsetHeight();
+        if (windowWidth > desktopWidth) {
+            window.asWindow().setWidth(desktopWidth);
+        }
+        if (windowHeight > desktopHeight) {
+            window.asWindow().setHeight(desktopHeight);
+        }
     }
 
     private void moveOutOfBoundsWindow(IPlantWindowInterface window) {


### PR DESCRIPTION
If a user saves their session while viewing the DE with a big monitor, then logs back in while using a smaller monitor, their windows will be too big to access any of the window buttons (close, minimize, etc.).

Now their saved windows will be resized (if needed) to fit the desktop view so they can have access to the entire window.