### PR TITLE
CORE-4364 Disable rating private apps

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/list/cells/AppRatingCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/list/cells/AppRatingCell.java
@@ -114,7 +114,7 @@ public class AppRatingCell extends AbstractCell<App> implements HasCell<App, App
     }
 
     private void onRatingClicked(final Element eventTarget, final App value) {
-        if (!value.getAppType().equalsIgnoreCase(App.EXTERNAL_APP)) {
+        if (!value.getAppType().equalsIgnoreCase(App.EXTERNAL_APP) && value.isPublic()) {
             if (appearance.isRatingCell(eventTarget)) {
                 final int score = appearance.getRatingScore(eventTarget);
                 if (hasHandlers != null) {

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
@@ -139,4 +139,6 @@ public interface AppsMessages extends Messages {
     String privateToolTip();
 
     String sortLabel();
+
+    String privateAppRatingNotSupported();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
@@ -64,3 +64,4 @@ betaToolTip = This app is currently in the Beta phase and has not yet been revie
 ontologyAttrMatchingFailure = Unable to fetch all app listings.  Please try again later.
 privateToolTip = This is a private app you created or a private app someone shared with you.
 sortLabel = Sort By:
+privateAppRatingNotSupported = Rating private apps is not supported

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppRatingCell.css
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppRatingCell.css
@@ -1,5 +1,11 @@
 .apps_icon {
 	float: left;
+	cursor: pointer;
+}
+
+.disabledRating {
+	float: left;
+	cursor: hand;
 }
 
 .disabled_unrate_button {

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppRatingCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppRatingCellDefaultAppearance.java
@@ -27,6 +27,8 @@ public class AppRatingCellDefaultAppearance implements AppRatingCell.AppRatingCe
         @ClassName("apps_icon")
         String appsIcon();
 
+        String disabledRating();
+
         @ClassName("disabled_unrate_button")
         String disabledUnrateButton();
     }
@@ -144,6 +146,11 @@ public class AppRatingCellDefaultAppearance implements AppRatingCell.AppRatingCe
             return;
         }
 
+        if (!app.isPublic()) {
+            eventTarget.setTitle(appMsgs.privateAppRatingNotSupported());
+            return;
+        }
+
         boolean setWhiteStar = false;
         if (eventTarget.getAttribute("name").startsWith("Rating")) {
             for (int i = 0; i < parent.getChildCount(); i++) {
@@ -181,6 +188,13 @@ public class AppRatingCellDefaultAppearance implements AppRatingCell.AppRatingCe
         int total = app.getRating().getTotal();
         // Build five rating stars
         for (int i = 0; i < ratings.size(); i++) {
+            if (!app.isPublic() || app.getAppType().equalsIgnoreCase(App.EXTERNAL_APP)) {
+                sb.append(templates.imgCell("Rating-" + i,
+                                            ratings.get(i),
+                                            resources.css().disabledRating(),
+                                            resources.whiteStar().getSafeUri()));
+                continue;
+            }
             if (i < rating) {
                 if (app.getRating().getUserRating() != 0) {
                     sb.append(templates.imgCell("Rating-" + i,

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppsTile.css
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppsTile.css
@@ -99,7 +99,6 @@
 
 .ratingMod {
     position: absolute;
-    cursor: pointer;
     left: centerMargin;
     bottom: 4px;
 }


### PR DESCRIPTION
Currently, it's possible to attempt to rate an app in Apps Under Development which results in the user getting an error that they cannot rate private apps.  It is not possible to rate external apps, but it does visually look like you could rate an external app (it has the little white glove cursor when hovering).

This PR makes it so that hovering over the private apps and external apps rating cells has the regular black pointer cursor to convey that they are not clickable.  This also adds a tooltip to the private app rating cell that lets the user know that rating private apps is not supported.