### PR TITLE
CORE-4012 Disable Copy Link button after link deleted

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/DataLinkView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/DataLinkView.java
@@ -1,7 +1,7 @@
 package org.iplantc.de.diskResource.client;
 
-import org.iplantc.de.client.models.dataLink.DataLink;
 import org.iplantc.de.client.models.diskResources.DiskResource;
+import org.iplantc.de.diskResource.client.events.selection.DeleteDataLinkSelected;
 
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -60,11 +60,10 @@ public interface DataLinkView extends IsWidget {
         String dataLinkWarningClass();
     }
 
-    public interface Presenter extends org.iplantc.de.commons.client.presenter.Presenter {
+    public interface Presenter extends org.iplantc.de.commons.client.presenter.Presenter,
+                                       DeleteDataLinkSelected.DeleteDataLinkSelectedHandler {
 
         void createDataLinks(List<DiskResource> selectedItems);
-
-        void deleteDataLink(DataLink dataLink);
 
         String getSelectedDataLinkDownloadUrl();
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/events/selection/DeleteDataLinkSelected.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/events/selection/DeleteDataLinkSelected.java
@@ -1,0 +1,39 @@
+package org.iplantc.de.diskResource.client.events.selection;
+
+import org.iplantc.de.client.models.dataLink.DataLink;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class DeleteDataLinkSelected
+        extends GwtEvent<DeleteDataLinkSelected.DeleteDataLinkSelectedHandler> {
+    public static interface DeleteDataLinkSelectedHandler extends EventHandler {
+        void onDeleteDataLinkSelected(DeleteDataLinkSelected event);
+    }
+
+    public interface HasDeleteDataLinkSelectedHandlers {
+        HandlerRegistration addDeleteDataLinkSelectedHandler(DeleteDataLinkSelectedHandler handler);
+    }
+    public static Type<DeleteDataLinkSelectedHandler> TYPE = new Type<DeleteDataLinkSelectedHandler>();
+    private DataLink link;
+
+    public DeleteDataLinkSelected(DataLink link) {
+        this.link = link;
+    }
+
+    public Type<DeleteDataLinkSelectedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(DeleteDataLinkSelectedHandler handler) {
+        handler.onDeleteDataLinkSelected(this);
+    }
+
+    public DataLink getLink() {
+        return link;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/dataLink/DataLinkPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/dataLink/DataLinkPresenterImpl.java
@@ -7,6 +7,7 @@ import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.util.WindowUtil;
+import org.iplantc.de.diskResource.client.events.selection.DeleteDataLinkSelected;
 import org.iplantc.de.diskResource.client.presenters.callbacks.CreateDataLinkCallback;
 import org.iplantc.de.diskResource.client.presenters.callbacks.DeleteDataLinksCallback;
 import org.iplantc.de.diskResource.client.presenters.callbacks.ListDataLinksCallback;
@@ -60,13 +61,11 @@ public class DataLinkPresenterImpl implements DataLinkView.Presenter {
                 view.getTree(),dlFactory));
     }
 
-
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
-    public void deleteDataLink(DataLink value) {
-        drService.deleteDataLinks(Lists.newArrayList(value.getId()),
-                new DeleteDataLinksCallback(view));
+    public void onDeleteDataLinkSelected(DeleteDataLinkSelected event) {
+        DataLink link = event.getLink();
+        drService.deleteDataLinks(Lists.newArrayList(link.getId()),
+                                  new DeleteDataLinksCallback(view));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/dataLink/DataLinkPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/dataLink/DataLinkPresenterImpl.java
@@ -7,12 +7,12 @@ import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.util.WindowUtil;
+import org.iplantc.de.diskResource.client.DataLinkView;
 import org.iplantc.de.diskResource.client.events.selection.DeleteDataLinkSelected;
+import org.iplantc.de.diskResource.client.gin.factory.DataLinkViewFactory;
 import org.iplantc.de.diskResource.client.presenters.callbacks.CreateDataLinkCallback;
 import org.iplantc.de.diskResource.client.presenters.callbacks.DeleteDataLinksCallback;
 import org.iplantc.de.diskResource.client.presenters.callbacks.ListDataLinksCallback;
-import org.iplantc.de.diskResource.client.DataLinkView;
-import org.iplantc.de.diskResource.client.gin.factory.DataLinkViewFactory;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -43,7 +43,7 @@ public class DataLinkPresenterImpl implements DataLinkView.Presenter {
         view = dataLinkViewFactory.create(this, resources);
 
         // Remove Folders
-        List<DiskResource> allowedResources = Lists.newArrayList();
+        List<DiskResource> allowedResources = createDiskResourcesList();
         for(DiskResource m : resources){
             if(!(m instanceof Folder)){
                 allowedResources.add(m);
@@ -54,7 +54,7 @@ public class DataLinkPresenterImpl implements DataLinkView.Presenter {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private void getExistingDataLinks(List<DiskResource> resources) {
+    void getExistingDataLinks(List<DiskResource> resources) {
         view.addRoots(resources);
         drService.listDataLinks(diskResourceUtil.asStringPathList(resources),
                                 new ListDataLinksCallback(
@@ -71,7 +71,7 @@ public class DataLinkPresenterImpl implements DataLinkView.Presenter {
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void createDataLinks(List<DiskResource> selectedItems) {
-        final List<String> drResourceIds = Lists.newArrayList();
+        final List<String> drResourceIds = createDiskResourceIdsList();
         for(DiskResource dr : selectedItems){
             if(!(dr instanceof DataLink)){
                 drResourceIds.add(dr.getPath());
@@ -103,5 +103,13 @@ public class DataLinkPresenterImpl implements DataLinkView.Presenter {
     @Override
     public void go(HasOneWidget container) {
         container.setWidget(view.asWidget());
+    }
+
+    List<DiskResource> createDiskResourcesList() {
+        return Lists.newArrayList();
+    }
+
+    List<String> createDiskResourceIdsList() {
+        return Lists.newArrayList();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/DataLinkViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/DataLinkViewImpl.java
@@ -128,6 +128,7 @@ public class DataLinkViewImpl implements DataLinkView,
 
     @Override
     public void onDeleteDataLinkSelected(DeleteDataLinkSelected event) {
+        copyDataLinkButton.setEnabled(false);
     }
 
     //<editor-fold desc="UI Handlers">

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/DataLinkViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/DataLinkViewImpl.java
@@ -4,6 +4,7 @@ import org.iplantc.de.client.models.dataLink.DataLink;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 import org.iplantc.de.diskResource.client.DataLinkView;
+import org.iplantc.de.diskResource.client.events.selection.DeleteDataLinkSelected;
 import org.iplantc.de.diskResource.client.views.dataLink.cells.DataLinkPanelCell;
 
 import com.google.gwt.core.client.GWT;
@@ -38,7 +39,8 @@ import java.util.List;
 /**
  * @author jstroot
  */
-public class DataLinkViewImpl implements DataLinkView {
+public class DataLinkViewImpl implements DataLinkView,
+                                         DeleteDataLinkSelected.DeleteDataLinkSelectedHandler {
 
     /**
      * A handler who controls this widgets button visibility based on tree check selection.
@@ -116,9 +118,16 @@ public class DataLinkViewImpl implements DataLinkView {
                                                                               copyDataLinkButton,
                                                                               advancedDataLinkButton,
                                                                               tree));
-        tree.setCell(new DataLinkPanelCell(this.presenter));
+        DataLinkPanelCell dataLinkPanelCell = new DataLinkPanelCell();
+        dataLinkPanelCell.addDeleteDataLinkSelectedHandler(this);
+        dataLinkPanelCell.addDeleteDataLinkSelectedHandler(presenter);
+        tree.setCell(dataLinkPanelCell);
         new QuickTip(widget);
 
+    }
+
+    @Override
+    public void onDeleteDataLinkSelected(DeleteDataLinkSelected event) {
     }
 
     //<editor-fold desc="UI Handlers">

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/cells/DataLinkPanelCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/cells/DataLinkPanelCell.java
@@ -4,6 +4,7 @@ import static com.google.gwt.dom.client.BrowserEvents.CLICK;
 
 import org.iplantc.de.client.models.dataLink.DataLink;
 import org.iplantc.de.client.models.diskResources.DiskResource;
+import org.iplantc.de.diskResource.client.events.selection.DeleteDataLinkSelected;
 
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.Cell;
@@ -20,7 +21,7 @@ import com.google.inject.Inject;
 /**
  * @author jstroot
  */
-public final class DataLinkPanelCell extends AbstractCell<DiskResource> {
+public final class DataLinkPanelCell extends AbstractCell<DiskResource> implements DeleteDataLinkSelected.HasDeleteDataLinkSelectedHandlers {
 
     public interface Appearance {
         void render(SafeHtmlBuilder sb, DiskResource value);
@@ -37,6 +38,11 @@ public final class DataLinkPanelCell extends AbstractCell<DiskResource> {
     public DataLinkPanelCell(final Appearance appearance) {
         super(CLICK);
         this.appearance = appearance;
+    }
+
+    @Override
+    public HandlerRegistration addDeleteDataLinkSelectedHandler(DeleteDataLinkSelected.DeleteDataLinkSelectedHandler handler) {
+        return ensureHandlers().addHandler(DeleteDataLinkSelected.TYPE, handler);
     }
 
     @Override
@@ -68,7 +74,7 @@ public final class DataLinkPanelCell extends AbstractCell<DiskResource> {
 
     private void doOnClick(Element eventTarget, DiskResource value) {
         if (eventTarget.getAttribute("name").equalsIgnoreCase("del")) {
-            presenter.deleteDataLink((DataLink) value);
+            ensureHandlers().fireEvent(new DeleteDataLinkSelected((DataLink) value));
         }
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/cells/DataLinkPanelCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/cells/DataLinkPanelCell.java
@@ -1,18 +1,21 @@
 package org.iplantc.de.diskResource.client.views.dataLink.cells;
 
+import static com.google.gwt.dom.client.BrowserEvents.CLICK;
+
 import org.iplantc.de.client.models.dataLink.DataLink;
 import org.iplantc.de.client.models.diskResources.DiskResource;
-import org.iplantc.de.diskResource.client.DataLinkView;
 
-import static com.google.gwt.dom.client.BrowserEvents.CLICK;
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.cell.client.ValueUpdater;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Event;
+import com.google.inject.Inject;
 
 /**
  * @author jstroot
@@ -23,17 +26,16 @@ public final class DataLinkPanelCell extends AbstractCell<DiskResource> {
         void render(SafeHtmlBuilder sb, DiskResource value);
     }
 
-    private final DataLinkView.Presenter presenter;
     private final Appearance appearance;
+    private HandlerManager handlerManager;
 
-    public DataLinkPanelCell(final DataLinkView.Presenter presenter) {
-        this(presenter,
-             GWT.<Appearance> create(Appearance.class));
+    public DataLinkPanelCell() {
+        this(GWT.<Appearance> create(Appearance.class));
     }
-    public DataLinkPanelCell(final DataLinkView.Presenter presenter,
-                             final Appearance appearance) {
+
+    @Inject
+    public DataLinkPanelCell(final Appearance appearance) {
         super(CLICK);
-        this.presenter = presenter;
         this.appearance = appearance;
     }
 
@@ -70,4 +72,15 @@ public final class DataLinkPanelCell extends AbstractCell<DiskResource> {
         }
     }
 
+    HandlerManager createHandlerManager() {
+        return new HandlerManager(this);
+    }
+
+    HandlerManager ensureHandlers() {
+        return handlerManager == null ? handlerManager = createHandlerManager() : handlerManager;
+    }
+
+    HandlerManager getHandlerManager() {
+        return handlerManager;
+    }
 }

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/dataLink/DataLinkPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/dataLink/DataLinkPresenterImplTest.java
@@ -1,0 +1,121 @@
+package org.iplantc.de.diskResource.client.presenters.dataLink;
+
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.client.models.dataLink.DataLink;
+import org.iplantc.de.client.models.dataLink.DataLinkFactory;
+import org.iplantc.de.client.models.diskResources.DiskResource;
+import org.iplantc.de.client.services.DiskResourceServiceFacade;
+import org.iplantc.de.client.util.DiskResourceUtil;
+import org.iplantc.de.diskResource.client.DataLinkView;
+import org.iplantc.de.diskResource.client.events.selection.DeleteDataLinkSelected;
+import org.iplantc.de.diskResource.client.gin.factory.DataLinkViewFactory;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author aramsey 
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class DataLinkPresenterImplTest {
+
+    @Mock DataLinkView viewMock;
+    @Mock DiskResourceServiceFacade drServiceMock;
+    @Mock DataLinkFactory dlFactoryMock;
+    @Mock DiskResourceUtil diskResourceUtilMock;
+    @Mock List<DiskResource> resourcesMock;
+    @Mock List<DiskResource> diskResourceListMock;
+    @Mock DataLinkViewFactory dataLinkViewFactoryMock;
+    @Mock Iterator<DiskResource> diskResourceIteratorMock;
+    @Mock DiskResource resourceMock;
+    @Mock List<String> stringListMock;
+    @Mock DataLink dataLinkMock;
+
+    @Captor ArgumentCaptor<AsyncCallback<String>> stringCallbackCaptor;
+    @Captor ArgumentCaptor<AsyncCallback<List<DataLink>>> dataLinkCallbackCaptor;
+
+
+    private DataLinkPresenterImpl uut;
+
+    @Before
+    public void setUp() {
+        when(dataLinkViewFactoryMock.create(isA(DataLinkPresenterImpl.class), eq(resourcesMock))).thenReturn(viewMock);
+        when(resourcesMock.size()).thenReturn(2);
+        when(resourcesMock.iterator()).thenReturn(diskResourceIteratorMock);
+        when(diskResourceIteratorMock.hasNext()).thenReturn(true, true, false);
+        when(diskResourceIteratorMock.next()).thenReturn(resourceMock, resourceMock);
+
+        uut = new DataLinkPresenterImpl(drServiceMock,
+                                        dataLinkViewFactoryMock,
+                                        dlFactoryMock,
+                                        diskResourceUtilMock,
+                                        resourcesMock){
+            @Override
+            List<DiskResource> createDiskResourcesList() {
+                return diskResourceListMock;
+            }
+
+            @Override
+            List<String> createDiskResourceIdsList() {
+                return stringListMock;
+            }
+        };
+
+        verifyConstructor();
+    }
+
+    private void verifyConstructor() {
+        verify(dataLinkViewFactoryMock).create(isA(DataLinkPresenterImpl.class), eq(resourcesMock));
+        verify(diskResourceListMock, times(2)).add(resourceMock);
+    }
+
+    @Test
+    public void testGetExistingDataLinks() {
+        when(diskResourceUtilMock.asStringPathList(resourcesMock)).thenReturn(stringListMock);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.getExistingDataLinks(resourcesMock);
+
+        verify(viewMock).addRoots(eq(resourcesMock));
+        verify(drServiceMock).listDataLinks(eq(stringListMock), stringCallbackCaptor.capture());
+    }
+
+    @Test
+    public void testOnDeleteDataLinkSelected() {
+        DeleteDataLinkSelected eventMock = mock(DeleteDataLinkSelected.class);
+        when(eventMock.getLink()).thenReturn(dataLinkMock);
+        when(dataLinkMock.getId()).thenReturn("id");
+
+        /** CALL METHOD UNDER TEST **/
+        uut.onDeleteDataLinkSelected(eventMock);
+        verify(drServiceMock).deleteDataLinks(anyListOf(String.class), stringCallbackCaptor.capture());
+    }
+
+    @Test
+    public void testCreateDataLinks() {
+        when(dataLinkMock.getPath()).thenReturn("string");
+
+        /** CALL METHOD UNDER TEST **/
+        uut.createDataLinks(resourcesMock);
+
+        verify(viewMock).mask();
+        verify(drServiceMock).createDataLinks(eq(stringListMock), dataLinkCallbackCaptor.capture());
+    }
+}


### PR DESCRIPTION
When a user goes to Create a Public Link to a file, in the Manage Data Links dialog that opens, the Copy Link button will remain enabled when no link is selected (in particular, after a link has been deleted).  Clicking on the Copy Link button then opens the Copy Link dialog with no URL.

This PR does some minor refactoring and then disables the Copy Link button after a link has been deleted.