### PR TITLE
CORE-6530 Remove file from favorites when de-favoriting in Favorites folder

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/NavigationView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/NavigationView.java
@@ -36,6 +36,9 @@ import java.util.List;
 public interface NavigationView extends IsWidget,
                                         HasFolderSelectionEventHandlers,
                                         HasDeleteSavedSearchClickedEventHandlers {
+
+    String FAVORITES_FOLDER_NAME = "Favorites";
+
     interface Appearance {
 
         String dataDragDropStatusText(int size);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -216,7 +216,7 @@ public class GridViewPresenterImpl implements
                           @Assisted final TYPE entityType) {
         this.appearance = appearance;
         this.navigationPresenter = navigationPresenter;
-        this.listStore = new ListStore<>(new DiskResourceModelKeyProvider());
+        this.listStore = getDiskResourceListStore();
         GridView.FolderContentsRpcProxy folderContentsRpcProxy = folderContentsProxyFactory.createWithEntityType(infoTypeFilters,
                                                                                                                  entityType);
 
@@ -239,7 +239,6 @@ public class GridViewPresenterImpl implements
         this.view.addDiskResourceSelectionChangedEventHandler(this);
     }
 
-    // <editor-fold desc="Handler Registrations">
     @Override
     public HandlerRegistration
             addStoreUpdateHandler(StoreUpdateEvent.StoreUpdateHandler<DiskResource> handler) {
@@ -357,7 +356,7 @@ public class GridViewPresenterImpl implements
 
             @Override
             public void onSuccess(CommentsDialog result) {
-                result.show(dr, PermissionValue.own.equals(dr.getPermission()), metadataService);
+                result.show(dr, hasOwnPermissions(dr), metadataService);
             }
         });
     }
@@ -385,7 +384,7 @@ public class GridViewPresenterImpl implements
         copyMetadata(selected);
     }
 
-    private void copyMetadata(final DiskResource selected) {
+    void copyMetadata(final DiskResource selected) {
         mCopyDialog.clearHandlers();
         mCopyDialog.addOkButtonSelectHandler(new SelectHandler() {
 
@@ -589,7 +588,7 @@ public class GridViewPresenterImpl implements
         listStore.update(updated);
     }
 
-    private void fetchDetails(final DiskResource resource) {
+    void fetchDetails(final DiskResource resource) {
         diskResourceService.getStat(diskResourceUtil.asStringPathTypeMap(Arrays.asList(resource),
                                                                          resource instanceof File ? TYPE.FILE
                                                                                                  : TYPE.FOLDER),
@@ -624,7 +623,7 @@ public class GridViewPresenterImpl implements
 
     }
 
-    private void setInfoType(final DiskResource dr, String newType) {
+    void setInfoType(final DiskResource dr, String newType) {
         diskResourceService.setFileType(dr.getPath(), newType, new AsyncCallback<String>() {
 
             @Override
@@ -640,7 +639,7 @@ public class GridViewPresenterImpl implements
         });
     }
 
-    private void updateFav(final DiskResource diskResource, boolean fav) {
+    void updateFav(final DiskResource diskResource, boolean fav) {
         if (getSelectedDiskResources().size() > 0) {
             Iterator<DiskResource> it = getSelectedDiskResources().iterator();
             if (it.hasNext()) {
@@ -656,7 +655,7 @@ public class GridViewPresenterImpl implements
         }
     }
 
-    private boolean isViewingFavoritesFolder() {
+    boolean isViewingFavoritesFolder() {
         return navigationPresenter.getSelectedFolder()
                                   .getName()
                                   .equalsIgnoreCase(NavigationView.FAVORITES_FOLDER_NAME);
@@ -742,6 +741,14 @@ public class GridViewPresenterImpl implements
                view.show();
            }
        });
+    }
+
+    ListStore<DiskResource> getDiskResourceListStore() {
+        return new ListStore<>(new DiskResourceModelKeyProvider());
+    }
+
+    boolean hasOwnPermissions(DiskResource dr) {
+        return PermissionValue.own.equals(dr.getPermission());
     }
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -11,9 +11,7 @@ import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
 import org.iplantc.de.client.models.diskResources.PermissionValue;
 import org.iplantc.de.client.models.diskResources.TYPE;
-import org.iplantc.de.client.models.errorHandling.ServiceErrorCode;
 import org.iplantc.de.client.models.errors.diskResources.DiskResourceErrorAutoBeanFactory;
-import org.iplantc.de.client.models.errors.diskResources.ErrorDiskResource;
 import org.iplantc.de.client.models.viewer.InfoType;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.services.FileSystemMetadataServiceFacade;
@@ -71,12 +69,9 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
-import com.google.web.bindery.autobean.shared.AutoBean;
-import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 import com.google.web.bindery.autobean.shared.Splittable;
 import com.google.web.bindery.autobean.shared.impl.StringQuoter;
 
@@ -85,11 +80,8 @@ import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.data.shared.event.StoreUpdateEvent;
 import com.sencha.gxt.data.shared.loader.PagingLoadResult;
 import com.sencha.gxt.data.shared.loader.PagingLoader;
-import com.sencha.gxt.widget.core.client.Dialog.PredefinedButton;
 import com.sencha.gxt.widget.core.client.box.AlertMessageBox;
-import com.sencha.gxt.widget.core.client.box.ConfirmMessageBox;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
-import com.sencha.gxt.widget.core.client.event.DialogHideEvent.DialogHideHandler;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent.SelectHandler;
 
@@ -656,9 +648,18 @@ public class GridViewPresenterImpl implements
                 if (next.getId().equals(diskResource.getId())) {
                     next.setFavorite(fav);
                     updateDiskResource(next);
+                    if (!fav && isViewingFavoritesFolder()) {
+                        listStore.remove(next);
+                    }
                 }
             }
         }
+    }
+
+    private boolean isViewingFavoritesFolder() {
+        return navigationPresenter.getSelectedFolder()
+                                  .getName()
+                                  .equalsIgnoreCase(NavigationView.FAVORITES_FOLDER_NAME);
     }
 
     private void doCopyMetadata(final DiskResource selected,

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImplTest.java
@@ -1,27 +1,59 @@
 package org.iplantc.de.diskResource.client.presenters.grid;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.diskResources.DiskResource;
+import org.iplantc.de.client.models.diskResources.DiskResourceAutoBeanFactory;
+import org.iplantc.de.client.models.diskResources.PermissionValue;
 import org.iplantc.de.client.models.diskResources.TYPE;
 import org.iplantc.de.client.models.viewer.InfoType;
+import org.iplantc.de.client.services.DiskResourceServiceFacade;
+import org.iplantc.de.client.services.FileSystemMetadataServiceFacade;
+import org.iplantc.de.client.util.DiskResourceUtil;
+import org.iplantc.de.commons.client.comments.view.dialogs.CommentsDialog;
+import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.diskResource.client.DiskResourceView;
 import org.iplantc.de.diskResource.client.GridView;
 import org.iplantc.de.diskResource.client.NavigationView;
+import org.iplantc.de.diskResource.client.events.RequestDiskResourceFavoriteEvent;
+import org.iplantc.de.diskResource.client.events.selection.EditInfoTypeSelected;
+import org.iplantc.de.diskResource.client.events.selection.ManageCommentsSelected;
 import org.iplantc.de.diskResource.client.gin.factory.FolderContentsRpcProxyFactory;
 import org.iplantc.de.diskResource.client.gin.factory.GridViewFactory;
+import org.iplantc.de.diskResource.client.views.dialogs.InfoTypeEditorDialog;
+import org.iplantc.de.diskResource.client.views.dialogs.MetadataCopyDialog;
+import org.iplantc.de.diskResource.client.views.dialogs.SaveAsDialog;
 import org.iplantc.de.diskResource.client.views.grid.DiskResourceColumnModel;
+import org.iplantc.de.diskResource.client.views.metadata.dialogs.ManageMetadataDialog;
+import org.iplantc.de.diskResource.client.views.sharing.dialogs.DataSharingDialog;
+import org.iplantc.de.diskResource.client.views.sharing.dialogs.ShareResourceLinkDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwtmockito.GxtMockitoTestRunner;
 
 import com.sencha.gxt.data.shared.ListStore;
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -39,6 +71,33 @@ public class GridViewPresenterImplTest {
     @Mock GridView.FolderContentsRpcProxy folderContentsProxyMock;
     @Mock DiskResourceColumnModel columnModelMock;
     @Mock GridView.Presenter.Appearance appearanceMock;
+    @Mock IplantAnnouncer announcerMock;
+    @Mock DiskResourceServiceFacade diskResourceServiceMock;
+    @Mock DiskResourceUtil diskResourceUtilMock;
+    @Mock EventBus eventBusMock;
+    @Mock FileSystemMetadataServiceFacade metadataServiceMock;
+    @Mock AsyncProviderWrapper<InfoTypeEditorDialog> infoTypeDialogProviderMock;
+    @Mock InfoTypeEditorDialog infoTypeEditorDialogMock;
+    @Mock AsyncProviderWrapper<CommentsDialog> commentDialogProviderMock;
+    @Mock CommentsDialog commentsDialogMock;
+    @Mock AsyncProviderWrapper<ManageMetadataDialog> metadataDialogProviderMock;
+    @Mock AsyncProviderWrapper<DataSharingDialog> dataSharingDialogProviderMock;
+    @Mock AsyncProviderWrapper<ShareResourceLinkDialog> shareLinkDialogProviderMock;
+    @Mock AsyncProviderWrapper<SaveAsDialog> saveAsDialogProviderMock;
+    @Mock DiskResourceAutoBeanFactory drFactoryMock;
+    @Mock MetadataCopyDialog mCopyDialog;
+    @Mock ListStore<DiskResource> listStoreMock;
+    @Mock HashMap<EventHandler, HandlerRegistration> registeredHandlersMock;
+    @Mock DiskResourceView.Presenter parentPresenterMock;
+    @Mock List<DiskResource> resourcesMock;
+    @Mock Iterator<DiskResource> resourceIteratorMock;
+    @Mock DiskResource resourceMock;
+    @Mock InfoType infoTypeMock;
+    @Mock PermissionValue permissionValueMock;
+
+    @Captor ArgumentCaptor<AsyncCallback<InfoTypeEditorDialog>> infoTypeEditorDialogCaptor;
+    @Captor ArgumentCaptor<AsyncCallback<String>> stringCaptor;
+    @Captor ArgumentCaptor<AsyncCallback<CommentsDialog>> commentsDialogCaptor;
 
     private GridViewPresenterImpl uut;
 
@@ -46,11 +105,171 @@ public class GridViewPresenterImplTest {
         when(folderContentsProxyFactoryMock.createWithEntityType(eq(infoTypeFiltersMock), eq(entityTypeMock))).thenReturn(folderContentsProxyMock);
         when(gridViewFactoryMock.create(any(GridView.Presenter.class), Matchers.<ListStore<DiskResource>>any(), eq(folderContentsProxyMock))).thenReturn(viewMock);
         when(viewMock.getColumnModel()).thenReturn(columnModelMock);
-        uut = new GridViewPresenterImpl(gridViewFactoryMock, folderContentsProxyFactoryMock, appearanceMock, navigationPresenterMock, infoTypeFiltersMock, entityTypeMock);
+        when(resourcesMock.size()).thenReturn(1);
+        when(resourcesMock.iterator()).thenReturn(resourceIteratorMock);
+        when(resourceIteratorMock.hasNext()).thenReturn(true, false);
+        when(resourceIteratorMock.next()).thenReturn(resourceMock);
+        when(resourceMock.getInfoType()).thenReturn(InfoType.RAW.toString());
+        when(resourceMock.getId()).thenReturn("id");
+        when(resourceMock.getPermission()).thenReturn(permissionValueMock);
+        when(infoTypeMock.toString()).thenReturn(InfoType.RAW.toString());
+        when(appearanceMock.markFavoriteError()).thenReturn("error");
+        when(appearanceMock.removeFavoriteError()).thenReturn("error");
+
+        uut = new GridViewPresenterImpl(gridViewFactoryMock,
+                                        folderContentsProxyFactoryMock,
+                                        appearanceMock,
+                                        navigationPresenterMock,
+                                        infoTypeFiltersMock,
+                                        entityTypeMock) {
+            @Override
+            public List<DiskResource> getSelectedDiskResources() {
+                return resourcesMock;
+            }
+
+            @Override
+            boolean isViewingFavoritesFolder() {
+                return true;
+            }
+
+            @Override
+            boolean hasOwnPermissions(DiskResource dr) {
+                return true;
+            }
+
+            @Override
+            ListStore<DiskResource> getDiskResourceListStore() {
+                return listStoreMock;
+            }
+        };
+        uut.announcer = announcerMock;
+        uut.infoTypeDialogProvider = infoTypeDialogProviderMock;
+        uut.metadataService = metadataServiceMock;
+        uut.commentDialogProvider = commentDialogProviderMock;
+        uut.diskResourceService = diskResourceServiceMock;
+
+        verifyConstructor();
     }
 
-    @Test public void placeHolderTest() {
+    private void verifyConstructor() {
+        verify(columnModelMock).addDiskResourceNameSelectedEventHandler(eq(uut));
+        verify(columnModelMock).addManageSharingSelectedEventHandler(eq(uut));
+        verify(columnModelMock).addManageMetadataSelectedEventHandler(eq(uut));
+        verify(columnModelMock).addCopyMetadataSelectedEventHandler(eq(uut));
+        verify(columnModelMock).addShareByDataLinkSelectedEventHandler(eq(uut));
+        verify(columnModelMock).addManageFavoritesEventHandler(eq(uut));
+        verify(columnModelMock).addManageCommentsSelectedEventHandler(eq(uut));
+        verify(columnModelMock).addDiskResourcePathSelectedEventHandler(eq(uut));
 
+        verify(viewMock).addDiskResourceSelectionChangedEventHandler(eq(uut));
     }
 
+    @Test
+    public void testOnEditInfoTypeSelected() {
+        EditInfoTypeSelected eventMock = mock(EditInfoTypeSelected.class);
+        when(eventMock.getSelectedDiskResources()).thenReturn(resourcesMock);
+        when(infoTypeEditorDialogMock.getSelectedValue()).thenReturn(infoTypeMock);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.onEditInfoTypeSelected(eventMock);
+        verify(infoTypeDialogProviderMock).get(infoTypeEditorDialogCaptor.capture());
+
+        infoTypeEditorDialogCaptor.getValue().onSuccess(infoTypeEditorDialogMock);
+        verify(infoTypeEditorDialogMock).addOkButtonSelectHandler(Matchers.<SelectEvent.SelectHandler>any());
+        infoTypeEditorDialogMock.show(isA(InfoType.class));
+    }
+
+    @Test
+    public void testOnFavoriteRequest_favorite() {
+        RequestDiskResourceFavoriteEvent eventMock = mock(RequestDiskResourceFavoriteEvent.class);
+        when(eventMock.getDiskResource()).thenReturn(resourceMock);
+        when(resourceMock.isFavorite()).thenReturn(false);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.onFavoriteRequest(eventMock);
+        verify(metadataServiceMock).addToFavorites(eq("id"), stringCaptor.capture());
+    }
+
+    @Test
+    public void testOnFavoriteRequest_defavorite() {
+        RequestDiskResourceFavoriteEvent eventMock = mock(RequestDiskResourceFavoriteEvent.class);
+        when(eventMock.getDiskResource()).thenReturn(resourceMock);
+        when(resourceMock.isFavorite()).thenReturn(true);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.onFavoriteRequest(eventMock);
+        verify(metadataServiceMock).removeFromFavorites(eq("id"), stringCaptor.capture());
+    }
+
+    @Test
+    public void testOnManageCommentsSelected() {
+        ManageCommentsSelected eventMock = mock(ManageCommentsSelected.class);
+        when(eventMock.getDiskResource()).thenReturn(resourceMock);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.onManageCommentsSelected(eventMock);
+        verify(commentDialogProviderMock).get(commentsDialogCaptor.capture());
+
+        commentsDialogCaptor.getValue().onSuccess(commentsDialogMock);
+        verify(commentsDialogMock).show(eq(resourceMock), eq(true), eq(metadataServiceMock));
+    }
+
+    @Test
+    public void testOnRequestManageMetadataSelected() {
+    }
+
+    @Test
+    public void testCopyMetadata() {
+    }
+
+    @Test
+    public void testOnRequestManageSharingSelected() {
+    }
+
+    @Test
+    public void testOnRequestShareByDataLinkSelected() {
+    }
+
+    @Test
+    public void testFetchDetails() {
+    }
+
+    @Test
+    public void testSetInfoType() {
+    }
+
+    @Test
+    public void testUpdateFav_removeFav() {
+        DiskResource diskResourceMock = mock(DiskResource.class);
+        when(diskResourceMock.getId()).thenReturn("id");
+
+        /** CALL METHOD UNDER TEST **/
+        uut.updateFav(diskResourceMock, false);
+
+        verify(resourceMock).setFavorite(eq(false));
+        verify(listStoreMock).remove(eq(resourceMock));
+    }
+
+    @Test
+    public void testUpdateFav_addFav() {
+        DiskResource diskResourceMock = mock(DiskResource.class);
+        when(diskResourceMock.getId()).thenReturn("id");
+        when(listStoreMock.findModelWithKey("id")).thenReturn(resourceMock);
+        when(diskResourceServiceMock.combineDiskResources(resourceMock, resourceMock)).thenReturn(resourceMock);
+
+
+        /** CALL METHOD UNDER TEST **/
+        uut.updateFav(diskResourceMock, true);
+
+        verify(resourceMock).setFavorite(eq(true));
+        verify(listStoreMock, times(0)).remove(eq(resourceMock));
+    }
+
+    @Test
+    public void testOnRequestSaveMetadataSelected() {
+    }
+
+    @Test
+    public void testOnDownloadTemplateSelected() {
+    }
 }


### PR DESCRIPTION
In the Data window, if you try to de-favorite a file/folder while viewing the Favorites folder, the view does not refresh and the file/folder remains in the Favorites folder (visually) until you refresh.

I also added some tests since we didn't have anything for GridViewPresenterImpl. 