### PR TITLE
CORE-8148 Add Refresh button to Apps Window

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.apps.client;
 
 import org.iplantc.de.apps.client.events.AppFavoritedEvent;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
+import org.iplantc.de.apps.client.events.SelectedHierarchyNotFound;
 import org.iplantc.de.apps.client.events.selection.AppCategorySelectionChangedEvent;
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.CopyAppSelected;
@@ -65,7 +66,8 @@ public interface AppCategoriesView extends IsWidget,
     interface Presenter extends AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
                                 CopyAppSelected.CopyAppSelectedHandler,
                                 CopyWorkflowSelected.CopyWorkflowSelectedHandler,
-                                AppCategorySelectionChangedEvent.HasAppCategorySelectionChangedEventHandlers {
+                                AppCategorySelectionChangedEvent.HasAppCategorySelectionChangedEventHandlers,
+                                SelectedHierarchyNotFound.SelectedHierarchyNotFoundHandler {
 
         AppCategory getSelectedAppCategory();
 

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
@@ -71,7 +71,7 @@ public interface AppCategoriesView extends IsWidget,
 
         AppCategoriesView getWorkspaceView();
 
-        void go(HasId selectedAppCategory, DETabPanel tabPanel);
+        void go(HasId selectedAppCategory, boolean selectDefaultCategory, DETabPanel tabPanel);
 
         void setViewDebugId(String baseID);
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
@@ -13,6 +13,7 @@ import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.events.selection.EditAppSelected;
 import org.iplantc.de.apps.client.events.selection.EditWorkflowSelected;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
+import org.iplantc.de.apps.client.events.selection.RefreshAppsSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.RequestToolSelected;
 import org.iplantc.de.apps.client.events.selection.RunAppSelected;
 import org.iplantc.de.apps.client.events.selection.ShareAppsSelected;
@@ -44,7 +45,8 @@ public interface AppsToolbarView extends IsWidget,
                                          RequestToolSelected.HasRequestToolSelectedHandlers,
                                          ShareAppsSelected.HasShareAppSelectedHandlers,
                                          OntologyHierarchySelectionChangedEvent.OntologyHierarchySelectionChangedEventHandler,
-                                         SwapViewButtonClickedEvent.HasSwapViewButtonClickedEventHandlers {
+                                         SwapViewButtonClickedEvent.HasSwapViewButtonClickedEventHandlers,
+                                         RefreshAppsSelectedEvent.HasRefreshAppsSelectedEventHandlers {
 
     interface AppsToolbarAppearance {
 
@@ -97,6 +99,10 @@ public interface AppsToolbarView extends IsWidget,
         String share();
 
         ImageResource shareAppIcon();
+
+        String refresh();
+
+        ImageResource refreshIcon();
     }
 
     interface Presenter extends BeforeLoadEvent.HasBeforeLoadHandlers<FilterPagingLoadConfig>,

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
@@ -54,4 +54,6 @@ public interface AppsView extends IsWidget,
 
     void hideWorkflowMenu();
 
+    void clearTabPanel();
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
@@ -29,9 +29,11 @@ public interface OntologyHierarchiesView extends IsWidget,
                                 AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
                                 OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers {
 
-        void go(DETabPanel tabPanel);
+        void go(OntologyHierarchy selectedHierarchy, DETabPanel tabPanel);
 
         void setViewDebugId(String baseID);
+
+        OntologyHierarchy getSelectedHierarchy();
     }
 
     Tree<OntologyHierarchy, String> getTree();

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.apps.client;
 
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
+import org.iplantc.de.apps.client.events.SelectedHierarchyNotFound;
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
 import org.iplantc.de.client.models.IsMaskable;
@@ -27,7 +28,8 @@ public interface OntologyHierarchiesView extends IsWidget,
 
     interface Presenter extends AppInfoSelectedEvent.AppInfoSelectedEventHandler,
                                 AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
-                                OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers {
+                                OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers,
+                                SelectedHierarchyNotFound.HasSelectedHierarchyNotFoundHandlers {
 
         void go(OntologyHierarchy selectedHierarchy, DETabPanel tabPanel);
 

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/events/SelectedHierarchyNotFound.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/events/SelectedHierarchyNotFound.java
@@ -1,0 +1,29 @@
+package org.iplantc.de.apps.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class SelectedHierarchyNotFound
+        extends GwtEvent<SelectedHierarchyNotFound.SelectedHierarchyNotFoundHandler> {
+    public static interface SelectedHierarchyNotFoundHandler extends EventHandler {
+        void onSelectedHierarchyNotFound(SelectedHierarchyNotFound event);
+    }
+
+    public interface HasSelectedHierarchyNotFoundHandlers {
+        HandlerRegistration addSelectedHierarchyNotFoundHandler(SelectedHierarchyNotFoundHandler handler);
+    }
+    public static Type<SelectedHierarchyNotFoundHandler> TYPE =
+            new Type<SelectedHierarchyNotFoundHandler>();
+
+    public Type<SelectedHierarchyNotFoundHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(SelectedHierarchyNotFoundHandler handler) {
+        handler.onSelectedHierarchyNotFound(this);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/RefreshAppsSelectedEvent.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/RefreshAppsSelectedEvent.java
@@ -1,0 +1,31 @@
+package org.iplantc.de.apps.client.events.selection;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class RefreshAppsSelectedEvent
+        extends GwtEvent<RefreshAppsSelectedEvent.RefreshAppsSelectedEventHandler> {
+
+    public static interface RefreshAppsSelectedEventHandler extends EventHandler {
+        void onRefreshAppsSelected(RefreshAppsSelectedEvent event);
+    }
+
+    public interface HasRefreshAppsSelectedEventHandlers {
+        HandlerRegistration addRefreshAppsSelectedEventHandler(RefreshAppsSelectedEventHandler handler);
+    }
+
+    public static Type<RefreshAppsSelectedEventHandler> TYPE =
+            new Type<RefreshAppsSelectedEventHandler>();
+
+    public Type<RefreshAppsSelectedEventHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(RefreshAppsSelectedEventHandler handler) {
+        handler.onRefreshAppsSelected(this);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
@@ -55,6 +55,7 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
 
         hierarchiesPresenter.addOntologyHierarchySelectionChangedEventHandler(appsListPresenter);
         hierarchiesPresenter.addOntologyHierarchySelectionChangedEventHandler(toolbarPresenter.getView());
+        hierarchiesPresenter.addSelectedHierarchyNotFoundHandler(categoriesPresenter);
 
         appsListPresenter.addAppSelectionChangedEventHandler(toolbarPresenter.getView());
         appsListPresenter.addAppInfoSelectedEventHandler(hierarchiesPresenter);

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/AppsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/AppsViewImpl.java
@@ -51,6 +51,7 @@ public class AppsViewImpl extends Composite implements AppsView {
         this.toolBar = toolbarPresenter.getView();
 
         initWidget(uiBinder.createAndBindUi(this));
+
         categoryTabs.addSelectionHandler(new SelectionHandler<Widget>() {
             @Override
             public void onSelection(SelectionEvent<Widget> event) {
@@ -79,6 +80,15 @@ public class AppsViewImpl extends Composite implements AppsView {
     @Override
     public void hideWorkflowMenu() {
         toolBar.hideWorkflowMenu();
+    }
+
+    public void clearTabPanel() {
+        categoryTabs.disableEvents();
+        int tabCount = categoryTabs.getWidgetCount();
+        for (int i = 0 ; i < tabCount ; i++) {
+            categoryTabs.close(categoryTabs.getWidget(0));
+        }
+        categoryTabs.enableEvents();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbar.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbar.ui.xml
@@ -87,6 +87,11 @@
                     </button:menu>
               </button:TextButton>
           </toolbar:child>
+		<toolbar:child>
+			<button:TextButton ui:field="refreshButton"
+							   text="{appearance.refresh}"
+							   icon="{appearance.refreshIcon}"/>
+		</toolbar:child>
 		<toolbar:child layoutData="{boxData}">
 			<MyWidgets:AppSearchField ui:field="appSearch"
 				emptyText="{appearance.searchApps}" />

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
@@ -16,6 +16,7 @@ import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.events.selection.EditAppSelected;
 import org.iplantc.de.apps.client.events.selection.EditWorkflowSelected;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
+import org.iplantc.de.apps.client.events.selection.RefreshAppsSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.RequestToolSelected;
 import org.iplantc.de.apps.client.events.selection.RunAppSelected;
 import org.iplantc.de.apps.client.events.selection.ShareAppsSelected;
@@ -73,6 +74,7 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     Menu sharingMenu;
     @UiField
     TextButton shareMenuButton;
+    @UiField TextButton refreshButton;
     @UiField
     MenuItem appRun;
     @UiField
@@ -188,6 +190,10 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     @Override
     public HandlerRegistration addSwapViewButtonClickedEventHandler(SwapViewButtonClickedEvent.SwapViewButtonClickedEventHandler handler) {
         return addHandler(handler, SwapViewButtonClickedEvent.TYPE);
+    }
+
+    public HandlerRegistration addRefreshAppsSelectedEventHandler(RefreshAppsSelectedEvent.RefreshAppsSelectedEventHandler handler) {
+        return addHandler(handler, RefreshAppsSelectedEvent.TYPE);
     }
 
     // </editor-fold>
@@ -348,6 +354,8 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
         sharePublic.ensureDebugId(baseID + Ids.MENU_ITEM_SHARE_APP + Ids.MENU_ITEM_SHARE_APP_PUBLIC);
         shareCollab.ensureDebugId(baseID + Ids.MENU_ITEM_SHARE_APP + Ids.MENU_ITEM_SHARE_APP_COLLAB);
 
+        refreshButton.ensureDebugId(baseID + Ids.MENU_ITEM_REFRESH);
+
         wf_menu.ensureDebugId(baseID + Ids.MENU_ITEM_WF);
         wfRun.ensureDebugId(baseID + Ids.MENU_ITEM_WF + Ids.MENU_ITEM_USE_WF);
         createWorkflow.ensureDebugId(baseID + Ids.MENU_ITEM_WF + Ids.MENU_ITEM_CREATE_WF);
@@ -494,5 +502,10 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     @UiHandler("swapViewBtn")
     public void onSwapViewClick(SelectEvent e) {
         fireEvent(new SwapViewButtonClickedEvent());
+    }
+
+    @UiHandler("refreshButton")
+    void refreshButtonClicked(SelectEvent event) {
+        fireEvent(new RefreshAppsSelectedEvent());
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/shared/AppsModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/shared/AppsModule.java
@@ -46,6 +46,7 @@ public interface AppsModule {
         String APP_TILES = ".tiles";
         String APP_CARD_CELL = ".card";
         String SWAP_VIEW_BTN = ".swapBtn";
+        String MENU_ITEM_REFRESH = ".refresh";
     }
 }
 

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/DETabPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/DETabPanel.java
@@ -36,4 +36,9 @@ public class DETabPanel extends TabPanel {
         XElement item = findItem(getWidgetIndex(widget));
         item.setId(debugId);
     }
+
+    @Override
+    public void close(Widget item) {
+        super.close(item);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/toolbar/AppsToolbarViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/toolbar/AppsToolbarViewDefaultAppearance.java
@@ -121,6 +121,16 @@ public class AppsToolbarViewDefaultAppearance implements AppsToolbarView.AppsToo
     }
 
     @Override
+    public String refresh() {
+        return iplantDisplayStrings.refresh();
+    }
+
+    @Override
+    public ImageResource refreshIcon() {
+        return iplantResources.refresh();
+    }
+
+    @Override
     public String warning() {
         return iplantDisplayStrings.warning();
     }

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImplTest.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.apps.client.presenter;
 
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -76,8 +77,9 @@ public class AppsViewPresenterImplTest {
         verify(toolbarViewMock).addAppSearchResultLoadEventHandler(hierarchiesPresenter);
         verify(toolbarViewMock).addBeforeAppSearchEventHandler(listPresenterMock);
         verify(toolbarViewMock).addSwapViewButtonClickedEventHandler(listPresenterMock);
+        verify(toolbarViewMock).addRefreshAppsSelectedEventHandler(isA(AppsViewPresenterImpl.class));
 
-        verify(toolbarPresenterMock, times(12)).getView();
+        verify(toolbarPresenterMock, times(13)).getView();
 
 
         verifyNoMoreInteractions(viewFactoryMock,

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
@@ -128,7 +128,7 @@ public class AppCategoriesPresenterImplTest {
         when(appearanceMock.getAppCategoriesLoadingMask()).thenReturn("mask");
 
         /*** CALL METHOD UNDER TEST ***/
-        uut.go(null, tabPanelMock);
+        uut.go(null, false, tabPanelMock);
 
         verify(treeMock, times(2)).mask(anyString());
         verify(appServiceMock).getAppCategories(anyBoolean(), appCategoriesCaptor.capture());


### PR DESCRIPTION
Since all the other DE windows have Refresh buttons, the Apps window should probably have a Refresh button as well.

This enables the user to be able to refresh the categories, hierarchies, and app listing at any time, and the user should be brought back to whatever category/hierarchy they had selected before hitting Refresh.

Given the nature of ontologies and how they can change at any time by the admins, there's also a lot of logic added to cover the scenario where the user has hit Refresh and the hierarchy they were viewing no longer exists.  This can happen if the user has had the apps window open for a long time, the admin has published a new ontology that no longer has the hierarchy they were viewing, and then the user hits Refresh.  In this case, the user will be brought back to the Apps Under Development category.