### PR TITLE
CORE-8148 Add Refresh button to Apps Window

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.apps.client;
 
 import org.iplantc.de.apps.client.events.AppFavoritedEvent;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
+import org.iplantc.de.apps.client.events.SelectedHierarchyNotFound;
 import org.iplantc.de.apps.client.events.selection.AppCategorySelectionChangedEvent;
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.CopyAppSelected;
@@ -65,7 +66,8 @@ public interface AppCategoriesView extends IsWidget,
     interface Presenter extends AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
                                 CopyAppSelected.CopyAppSelectedHandler,
                                 CopyWorkflowSelected.CopyWorkflowSelectedHandler,
-                                AppCategorySelectionChangedEvent.HasAppCategorySelectionChangedEventHandlers {
+                                AppCategorySelectionChangedEvent.HasAppCategorySelectionChangedEventHandlers,
+                                SelectedHierarchyNotFound.SelectedHierarchyNotFoundHandler {
 
         AppCategory getSelectedAppCategory();
 

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
@@ -71,7 +71,7 @@ public interface AppCategoriesView extends IsWidget,
 
         AppCategoriesView getWorkspaceView();
 
-        void go(HasId selectedAppCategory, DETabPanel tabPanel);
+        void go(HasId selectedAppCategory, boolean selectDefaultCategory, DETabPanel tabPanel);
 
         void setViewDebugId(String baseID);
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
@@ -13,6 +13,7 @@ import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.events.selection.EditAppSelected;
 import org.iplantc.de.apps.client.events.selection.EditWorkflowSelected;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
+import org.iplantc.de.apps.client.events.selection.RefreshAppsSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.RequestToolSelected;
 import org.iplantc.de.apps.client.events.selection.RunAppSelected;
 import org.iplantc.de.apps.client.events.selection.ShareAppsSelected;
@@ -44,7 +45,8 @@ public interface AppsToolbarView extends IsWidget,
                                          RequestToolSelected.HasRequestToolSelectedHandlers,
                                          ShareAppsSelected.HasShareAppSelectedHandlers,
                                          OntologyHierarchySelectionChangedEvent.OntologyHierarchySelectionChangedEventHandler,
-                                         SwapViewButtonClickedEvent.HasSwapViewButtonClickedEventHandlers {
+                                         SwapViewButtonClickedEvent.HasSwapViewButtonClickedEventHandlers,
+                                         RefreshAppsSelectedEvent.HasRefreshAppsSelectedEventHandlers {
 
     interface AppsToolbarAppearance {
 
@@ -97,6 +99,10 @@ public interface AppsToolbarView extends IsWidget,
         String share();
 
         ImageResource shareAppIcon();
+
+        String refresh();
+
+        ImageResource refreshIcon();
     }
 
     interface Presenter extends BeforeLoadEvent.HasBeforeLoadHandlers<FilterPagingLoadConfig>,

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
@@ -109,9 +109,13 @@ public interface AppsToolbarView extends IsWidget,
                                 AppSearchResultLoadEvent.HasAppSearchResultLoadEventHandlers {
 
         AppsToolbarView getView();
+
+        void reloadSearchResults();
     }
 
     void hideAppMenu();
 
     void hideWorkflowMenu();
+
+    boolean hasSearchPhrase();
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
@@ -54,4 +54,6 @@ public interface AppsView extends IsWidget,
 
     void hideWorkflowMenu();
 
+    void clearTabPanel();
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
@@ -29,9 +29,11 @@ public interface OntologyHierarchiesView extends IsWidget,
                                 AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
                                 OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers {
 
-        void go(DETabPanel tabPanel);
+        void go(OntologyHierarchy selectedHierarchy, DETabPanel tabPanel);
 
         void setViewDebugId(String baseID);
+
+        OntologyHierarchy getSelectedHierarchy();
     }
 
     Tree<OntologyHierarchy, String> getTree();

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.apps.client;
 
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
+import org.iplantc.de.apps.client.events.SelectedHierarchyNotFound;
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
 import org.iplantc.de.client.models.IsMaskable;
@@ -27,7 +28,8 @@ public interface OntologyHierarchiesView extends IsWidget,
 
     interface Presenter extends AppInfoSelectedEvent.AppInfoSelectedEventHandler,
                                 AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
-                                OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers {
+                                OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers,
+                                SelectedHierarchyNotFound.HasSelectedHierarchyNotFoundHandlers {
 
         void go(OntologyHierarchy selectedHierarchy, DETabPanel tabPanel);
 
@@ -37,5 +39,9 @@ public interface OntologyHierarchiesView extends IsWidget,
     }
 
     Tree<OntologyHierarchy, String> getTree();
+
+    void setRoot(OntologyHierarchy hierarchy);
+
+    OntologyHierarchy getRoot();
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/events/SelectedHierarchyNotFound.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/events/SelectedHierarchyNotFound.java
@@ -1,0 +1,29 @@
+package org.iplantc.de.apps.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class SelectedHierarchyNotFound
+        extends GwtEvent<SelectedHierarchyNotFound.SelectedHierarchyNotFoundHandler> {
+    public static interface SelectedHierarchyNotFoundHandler extends EventHandler {
+        void onSelectedHierarchyNotFound(SelectedHierarchyNotFound event);
+    }
+
+    public interface HasSelectedHierarchyNotFoundHandlers {
+        HandlerRegistration addSelectedHierarchyNotFoundHandler(SelectedHierarchyNotFoundHandler handler);
+    }
+    public static Type<SelectedHierarchyNotFoundHandler> TYPE =
+            new Type<SelectedHierarchyNotFoundHandler>();
+
+    public Type<SelectedHierarchyNotFoundHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(SelectedHierarchyNotFoundHandler handler) {
+        handler.onSelectedHierarchyNotFound(this);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/RefreshAppsSelectedEvent.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/RefreshAppsSelectedEvent.java
@@ -1,0 +1,31 @@
+package org.iplantc.de.apps.client.events.selection;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class RefreshAppsSelectedEvent
+        extends GwtEvent<RefreshAppsSelectedEvent.RefreshAppsSelectedEventHandler> {
+
+    public static interface RefreshAppsSelectedEventHandler extends EventHandler {
+        void onRefreshAppsSelected(RefreshAppsSelectedEvent event);
+    }
+
+    public interface HasRefreshAppsSelectedEventHandlers {
+        HandlerRegistration addRefreshAppsSelectedEventHandler(RefreshAppsSelectedEventHandler handler);
+    }
+
+    public static Type<RefreshAppsSelectedEventHandler> TYPE =
+            new Type<RefreshAppsSelectedEventHandler>();
+
+    public Type<RefreshAppsSelectedEventHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(RefreshAppsSelectedEventHandler handler) {
+        handler.onRefreshAppsSelected(this);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
@@ -34,6 +34,7 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
     private final AppCategoriesView.Presenter categoriesPresenter;
     private final AppsListView.Presenter appsListPresenter;
     private final OntologyHierarchiesView.Presenter hierarchiesPresenter;
+    private final AppsToolbarView.Presenter toolbarPresenter;
     OntologyUtil ontologyUtil;
 
     @Inject
@@ -45,6 +46,7 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
         this.categoriesPresenter = categoriesPresenter;
         this.appsListPresenter = appsListPresenter;
         this.hierarchiesPresenter = hierarchiesPresenter;
+        this.toolbarPresenter = toolbarPresenter;
         this.view = viewFactory.create(categoriesPresenter,
                                        hierarchiesPresenter, appsListPresenter,
                                        toolbarPresenter);
@@ -124,12 +126,16 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
     public void onRefreshAppsSelected(RefreshAppsSelectedEvent event) {
         AppCategory selectedAppCategory = categoriesPresenter.getSelectedAppCategory();
         OntologyHierarchy selectedHierarchy = hierarchiesPresenter.getSelectedHierarchy();
-        boolean useDefaultSelection = selectedHierarchy == null;
+        boolean hasSearchPhrase = toolbarPresenter.getView().hasSearchPhrase();
+        boolean useDefaultSelection = !hasSearchPhrase && selectedHierarchy == null;
 
         view.clearTabPanel();
         DETabPanel categoryTabPanel = view.getCategoryTabPanel();
 
         categoriesPresenter.go(selectedAppCategory, useDefaultSelection, categoryTabPanel);
         hierarchiesPresenter.go(selectedHierarchy, categoryTabPanel);
+        if (hasSearchPhrase) {
+            toolbarPresenter.reloadSearchResults();
+        }
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
@@ -55,6 +55,7 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
 
         hierarchiesPresenter.addOntologyHierarchySelectionChangedEventHandler(appsListPresenter);
         hierarchiesPresenter.addOntologyHierarchySelectionChangedEventHandler(toolbarPresenter.getView());
+        hierarchiesPresenter.addSelectedHierarchyNotFoundHandler(categoriesPresenter);
 
         appsListPresenter.addAppSelectionChangedEventHandler(toolbarPresenter.getView());
         appsListPresenter.addAppInfoSelectedEventHandler(hierarchiesPresenter);

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/callbacks/ParentFilteredHierarchyCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/callbacks/ParentFilteredHierarchyCallback.java
@@ -17,7 +17,7 @@ public abstract class ParentFilteredHierarchyCallback {
 
     public ParentFilteredHierarchyCallback(List<FilteredHierarchyCallback> childCallbacks) {
         if (childCallbacks == null || childCallbacks.size() == 0) {
-            throw new RuntimeException("No callbacks passed to parent");
+            return;
         }
 
         this.childCallbacks = childCallbacks;
@@ -35,5 +35,5 @@ public abstract class ParentFilteredHierarchyCallback {
         }
     }
 
-    protected abstract void handleSuccess();
+    public abstract void handleSuccess();
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/callbacks/ParentFilteredHierarchyCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/callbacks/ParentFilteredHierarchyCallback.java
@@ -1,0 +1,39 @@
+package org.iplantc.de.apps.client.presenter.callbacks;
+
+import org.iplantc.de.apps.client.presenter.hierarchies.OntologyHierarchiesPresenterImpl.FilteredHierarchyCallback;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ *
+ * A class that will fire the handleSuccess method when all callbacks have reported back as
+ * finished
+ */
+public abstract class ParentFilteredHierarchyCallback {
+
+    int doneCount = 0;
+    List<FilteredHierarchyCallback> childCallbacks;
+
+    public ParentFilteredHierarchyCallback(List<FilteredHierarchyCallback> childCallbacks) {
+        if (childCallbacks == null || childCallbacks.size() == 0) {
+            throw new RuntimeException("No callbacks passed to parent");
+        }
+
+        this.childCallbacks = childCallbacks;
+
+        for(FilteredHierarchyCallback callback : childCallbacks) {
+            callback.setParent(this);
+        }
+    }
+
+    public synchronized void done() {
+        doneCount++;
+
+        if (doneCount == childCallbacks.size()) {
+            handleSuccess();
+        }
+    }
+
+    protected abstract void handleSuccess();
+}

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
@@ -261,7 +261,7 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
 
     void populateViewTabs(final OntologyHierarchy selectedHierarchy) {
         //Create all the callbacks I'll need
-        List<FilteredHierarchyCallback> childCallbacks = Lists.newArrayList();
+        List<FilteredHierarchyCallback> childCallbacks = createFilteredHierarchyList();
         for (OntologyHierarchiesView view: views) {
             FilteredHierarchyCallback callback =
                     new FilteredHierarchyCallback(view.getTree(), view.getRoot());
@@ -276,7 +276,7 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
         //Create a parent callback that will run handleSuccess when all the callbacks complete
         new ParentFilteredHierarchyCallback(childCallbacks) {
             @Override
-            protected void handleSuccess() {
+            public void handleSuccess() {
                 for (OntologyHierarchiesView view : views) {
                     selectDesiredHierarchy(view.getTree(), selectedHierarchy);
                 }
@@ -455,5 +455,9 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
         if (handlerManager != null) {
             handlerManager.fireEvent(event);
         }
+    }
+
+    List<FilteredHierarchyCallback> createFilteredHierarchyList() {
+        return Lists.newArrayList();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/toolBar/AppsToolbarPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/toolBar/AppsToolbarPresenterImpl.java
@@ -94,6 +94,11 @@ public class AppsToolbarPresenterImpl implements AppsToolbarView.Presenter,
     }
 
     @Override
+    public void reloadSearchResults() {
+        loader.load(loader.getLastLoadConfig());
+    }
+
+    @Override
     public void onCreateNewAppSelected(CreateNewAppSelected event) {
         eventBus.fireEvent(new CreateNewAppEvent());
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/AppsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/AppsViewImpl.java
@@ -51,6 +51,7 @@ public class AppsViewImpl extends Composite implements AppsView {
         this.toolBar = toolbarPresenter.getView();
 
         initWidget(uiBinder.createAndBindUi(this));
+
         categoryTabs.addSelectionHandler(new SelectionHandler<Widget>() {
             @Override
             public void onSelection(SelectionEvent<Widget> event) {
@@ -79,6 +80,15 @@ public class AppsViewImpl extends Composite implements AppsView {
     @Override
     public void hideWorkflowMenu() {
         toolBar.hideWorkflowMenu();
+    }
+
+    public void clearTabPanel() {
+        categoryTabs.disableEvents();
+        int tabCount = categoryTabs.getWidgetCount();
+        for (int i = 0 ; i < tabCount ; i++) {
+            categoryTabs.close(categoryTabs.getWidget(0));
+        }
+        categoryTabs.enableEvents();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/hierarchies/OntologyHierarchiesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/hierarchies/OntologyHierarchiesViewImpl.java
@@ -35,6 +35,7 @@ public class OntologyHierarchiesViewImpl extends ContentPanel implements Ontolog
     private TreeStore<OntologyHierarchy> treeStore;
     private OntologyHierarchiesAppearance appearance;
     private OntologyUtil ontologyUtil;
+    private OntologyHierarchy root;
 
     @Inject
     OntologyHierarchiesViewImpl(final OntologyHierarchiesAppearance appearance,
@@ -48,6 +49,16 @@ public class OntologyHierarchiesViewImpl extends ContentPanel implements Ontolog
     @Override
     public Tree<OntologyHierarchy, String> getTree() {
         return tree;
+    }
+
+    @Override
+    public void setRoot(OntologyHierarchy hierarchy) {
+        this.root = hierarchy;
+    }
+
+    @Override
+    public OntologyHierarchy getRoot() {
+        return root;
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbar.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbar.ui.xml
@@ -87,6 +87,11 @@
                     </button:menu>
               </button:TextButton>
           </toolbar:child>
+		<toolbar:child>
+			<button:TextButton ui:field="refreshButton"
+							   text="{appearance.refresh}"
+							   icon="{appearance.refreshIcon}"/>
+		</toolbar:child>
 		<toolbar:child layoutData="{boxData}">
 			<MyWidgets:AppSearchField ui:field="appSearch"
 				emptyText="{appearance.searchApps}" />

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
@@ -16,6 +16,7 @@ import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.events.selection.EditAppSelected;
 import org.iplantc.de.apps.client.events.selection.EditWorkflowSelected;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
+import org.iplantc.de.apps.client.events.selection.RefreshAppsSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.RequestToolSelected;
 import org.iplantc.de.apps.client.events.selection.RunAppSelected;
 import org.iplantc.de.apps.client.events.selection.ShareAppsSelected;
@@ -73,6 +74,7 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     Menu sharingMenu;
     @UiField
     TextButton shareMenuButton;
+    @UiField TextButton refreshButton;
     @UiField
     MenuItem appRun;
     @UiField
@@ -188,6 +190,10 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     @Override
     public HandlerRegistration addSwapViewButtonClickedEventHandler(SwapViewButtonClickedEvent.SwapViewButtonClickedEventHandler handler) {
         return addHandler(handler, SwapViewButtonClickedEvent.TYPE);
+    }
+
+    public HandlerRegistration addRefreshAppsSelectedEventHandler(RefreshAppsSelectedEvent.RefreshAppsSelectedEventHandler handler) {
+        return addHandler(handler, RefreshAppsSelectedEvent.TYPE);
     }
 
     // </editor-fold>
@@ -348,6 +354,8 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
         sharePublic.ensureDebugId(baseID + Ids.MENU_ITEM_SHARE_APP + Ids.MENU_ITEM_SHARE_APP_PUBLIC);
         shareCollab.ensureDebugId(baseID + Ids.MENU_ITEM_SHARE_APP + Ids.MENU_ITEM_SHARE_APP_COLLAB);
 
+        refreshButton.ensureDebugId(baseID + Ids.MENU_ITEM_REFRESH);
+
         wf_menu.ensureDebugId(baseID + Ids.MENU_ITEM_WF);
         wfRun.ensureDebugId(baseID + Ids.MENU_ITEM_WF + Ids.MENU_ITEM_USE_WF);
         createWorkflow.ensureDebugId(baseID + Ids.MENU_ITEM_WF + Ids.MENU_ITEM_CREATE_WF);
@@ -494,5 +502,10 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     @UiHandler("swapViewBtn")
     public void onSwapViewClick(SelectEvent e) {
         fireEvent(new SwapViewButtonClickedEvent());
+    }
+
+    @UiHandler("refreshButton")
+    void refreshButtonClicked(SelectEvent event) {
+        fireEvent(new RefreshAppsSelectedEvent());
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
@@ -212,6 +212,11 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
         boxData.setFlex(0);
     }
 
+    @Override
+    public boolean hasSearchPhrase() {
+        return appSearch.getCurrentValue() != null;
+    }
+
     // <editor-fold desc="Selection Handlers">
     @Override
     public void onAppCategorySelectionChanged(AppCategorySelectionChangedEvent event) {

--- a/de-lib/src/main/java/org/iplantc/de/apps/shared/AppsModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/shared/AppsModule.java
@@ -47,6 +47,7 @@ public interface AppsModule {
         String APP_CARD_CELL = ".card";
         String SWAP_VIEW_BTN = ".swapBtn";
         String APP_STATUS_CELL = ".status";
+        String MENU_ITEM_REFRESH = ".refresh";
     }
 }
 

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/DETabPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/DETabPanel.java
@@ -36,4 +36,9 @@ public class DETabPanel extends TabPanel {
         XElement item = findItem(getWidgetIndex(widget));
         item.setId(debugId);
     }
+
+    @Override
+    public void close(Widget item) {
+        super.close(item);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/toolbar/AppsToolbarViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/toolbar/AppsToolbarViewDefaultAppearance.java
@@ -121,6 +121,16 @@ public class AppsToolbarViewDefaultAppearance implements AppsToolbarView.AppsToo
     }
 
     @Override
+    public String refresh() {
+        return iplantDisplayStrings.refresh();
+    }
+
+    @Override
+    public ImageResource refreshIcon() {
+        return iplantResources.refresh();
+    }
+
+    @Override
     public String warning() {
         return iplantDisplayStrings.warning();
     }

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImplTest.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.apps.client.presenter;
 
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -76,8 +77,9 @@ public class AppsViewPresenterImplTest {
         verify(toolbarViewMock).addAppSearchResultLoadEventHandler(hierarchiesPresenter);
         verify(toolbarViewMock).addBeforeAppSearchEventHandler(listPresenterMock);
         verify(toolbarViewMock).addSwapViewButtonClickedEventHandler(listPresenterMock);
+        verify(toolbarViewMock).addRefreshAppsSelectedEventHandler(isA(AppsViewPresenterImpl.class));
 
-        verify(toolbarPresenterMock, times(12)).getView();
+        verify(toolbarPresenterMock, times(13)).getView();
 
 
         verifyNoMoreInteractions(viewFactoryMock,

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
@@ -128,7 +128,7 @@ public class AppCategoriesPresenterImplTest {
         when(appearanceMock.getAppCategoriesLoadingMask()).thenReturn("mask");
 
         /*** CALL METHOD UNDER TEST ***/
-        uut.go(null, tabPanelMock);
+        uut.go(null, false, tabPanelMock);
 
         verify(treeMock, times(2)).mask(anyString());
         verify(appServiceMock).getAppCategories(anyBoolean(), appCategoriesCaptor.capture());

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImplTest.java
@@ -1,5 +1,7 @@
 package org.iplantc.de.apps.client.presenter.hierarchies;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -26,6 +28,7 @@ import org.iplantc.de.apps.client.events.selection.AppRatingSelected;
 import org.iplantc.de.apps.client.events.selection.DetailsCategoryClicked;
 import org.iplantc.de.apps.client.events.selection.DetailsHierarchyClicked;
 import org.iplantc.de.apps.client.gin.factory.OntologyHierarchiesViewFactory;
+import org.iplantc.de.apps.client.presenter.callbacks.ParentFilteredHierarchyCallback;
 import org.iplantc.de.apps.client.views.details.dialogs.AppDetailsDialog;
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.apps.App;
@@ -104,13 +107,19 @@ public class OntologyHierarchiesPresenterImplTest {
     @Mock List<AppCategory> appCategoryListMock;
     @Mock List<OntologyHierarchy> unclassifiedHierarchiesMock;
     @Mock OntologyHierarchy unclassifiedMock;
+    @Mock List<OntologyHierarchiesView> viewsMock;
+    @Mock Iterator<OntologyHierarchiesView> viewIteratorMock;
+    @Mock Tree.TreeNode<OntologyHierarchy> treeNodeMock;
+    @Mock List<OntologyHierarchiesPresenterImpl.FilteredHierarchyCallback> childCallbacksMock;
+    @Mock ParentFilteredHierarchyCallback parentCallbackMock;
 
     @Captor ArgumentCaptor<AsyncCallback<List<OntologyHierarchy>>> hierarchyListCallback;
-    @Captor ArgumentCaptor<AsyncCallback<OntologyHierarchy>> hierarchyCallback;
+    @Captor ArgumentCaptor<OntologyHierarchiesPresenterImpl.FilteredHierarchyCallback> hierarchyCallback;
     @Captor ArgumentCaptor<AsyncCallback<AppDetailsDialog>> appDetailsDialogCallback;
     @Captor ArgumentCaptor<AsyncCallback<App>> appDetailsCallback;
     @Captor ArgumentCaptor<AsyncCallback<List<Avu>>> appAvuCallbackCaptor;
     @Captor ArgumentCaptor<AsyncCallback<Void>> voidCallbackCaptor;
+    @Captor ArgumentCaptor<ParentFilteredHierarchyCallback> parentCallbackCaptor;
 
 
     private OntologyHierarchiesPresenterImpl uut;
@@ -135,6 +144,7 @@ public class OntologyHierarchiesPresenterImplTest {
         when(appearanceMock.ontologyAttrMatchingFailure()).thenReturn("string");
         when(viewMock.asWidget()).thenReturn(randomWidgetMock);
         when(viewMock.getTree()).thenReturn(hierarchyTreeMock);
+        when(viewMock.getRoot()).thenReturn(hierarchyMock);
         when(hierarchyTreeMock.getSelectionModel()).thenReturn(treeSelectionModelMock);
         when(hierarchyTreeMock.getStore()).thenReturn(hierarchyTreeStoreMock);
         when(hierarchyTreeStoreMock.findModelWithKey(anyString())).thenReturn(hierarchyMock);
@@ -151,6 +161,12 @@ public class OntologyHierarchiesPresenterImplTest {
         when(unclassifiedHierarchiesMock.size()).thenReturn(2);
         when(unclassifiedHierarchiesMock.iterator()).thenReturn(hierarchyListIterator);
         when(ontologyUtilMock.addUnclassifiedChild(hierarchyMock)).thenReturn(unclassifiedMock);
+        when(hierarchyTreeMock.findNode(hierarchyMock)).thenReturn(treeNodeMock);
+        when(treeNodeMock.getModel()).thenReturn(hierarchyMock);
+        when(viewsMock.size()).thenReturn(2);
+        when(viewsMock.iterator()).thenReturn(viewIteratorMock);
+        when(viewIteratorMock.hasNext()).thenReturn(true, true, false);
+        when(viewIteratorMock.next()).thenReturn(viewMock, viewMock);
 
         uut = new OntologyHierarchiesPresenterImpl(factoryMock,
                                                    ontologyServiceMock,
@@ -165,6 +181,11 @@ public class OntologyHierarchiesPresenterImplTest {
             TreeStore<AppCategory> getCategoryTreeStore() {
                 return categoryTreeStoreMock;
             }
+
+            @Override
+            List<FilteredHierarchyCallback> createFilteredHierarchyList() {
+                return childCallbacksMock;
+            }
         };
         uut.ontologyUtil = ontologyUtilMock;
         uut.announcer = announcerMock;
@@ -175,6 +196,7 @@ public class OntologyHierarchiesPresenterImplTest {
         uut.searchRegexPattern = "test";
         uut.viewTabPanel = tabPanelMock;
         uut.unclassifiedHierarchies = unclassifiedHierarchiesMock;
+        uut.views = viewsMock;
     }
 
 
@@ -186,9 +208,11 @@ public class OntologyHierarchiesPresenterImplTest {
                                                    ontologyServiceMock,
                                                    eventBusMock,
                                                    appearanceMock) {
+
             @Override
-            void createViewTabs(List<OntologyHierarchy> results) {
+            void createViewTabs(OntologyHierarchy selectedHierarchy, List<OntologyHierarchy> results) {
             }
+
         };
         uut.ontologyUtil = ontologyUtilMock;
         uut.announcer = announcerMock;
@@ -198,7 +222,7 @@ public class OntologyHierarchiesPresenterImplTest {
         uut.iriToHierarchyMap = iriToHierarchyMapMock;
 
         /** CALL METHOD UNDER TEST **/
-        uut.go(tabPanelMock);
+        uut.go(hierarchyMock, tabPanelMock);
         verify(ontologyServiceMock).getRootHierarchies(hierarchyListCallback.capture());
 
         hierarchyListCallback.getValue().onSuccess(hierarchyListMock);
@@ -215,7 +239,7 @@ public class OntologyHierarchiesPresenterImplTest {
                                                    eventBusMock,
                                                    appearanceMock) {
             @Override
-            void createViewTabs(List<OntologyHierarchy> results) {
+            void createViewTabs(OntologyHierarchy selectedHierarchy, List<OntologyHierarchy> results) {
             }
         };
         uut.ontologyUtil = ontologyUtilMock;
@@ -226,7 +250,7 @@ public class OntologyHierarchiesPresenterImplTest {
         uut.iriToHierarchyMap = iriToHierarchyMapMock;
 
         /** CALL METHOD UNDER TEST **/
-        uut.go(tabPanelMock);
+        uut.go(hierarchyMock, tabPanelMock);
         verify(ontologyServiceMock).getRootHierarchies(hierarchyListCallback.capture());
 
         hierarchyListCallback.getValue().onSuccess(hierarchyListMock);
@@ -339,16 +363,47 @@ public class OntologyHierarchiesPresenterImplTest {
     @Test
     public void testCreateViewTabs() throws Exception {
         when(hierarchyListMock.iterator()).thenReturn(hierarchyListIterator);
+        OntologyHierarchy selectedHierarchy = mock(OntologyHierarchy.class);
 
         OntologyHierarchiesPresenterImpl spy = spy(uut);
 
         /** CALL METHOD UNDER TEST **/
-        spy.createViewTabs(hierarchyListMock);
+        spy.createViewTabs(selectedHierarchy, hierarchyListMock);
+        verify(viewMock).setRoot(hierarchyMock);
+        verify(viewsMock).add(viewMock);
         verify(viewMock).addOntologyHierarchySelectionChangedEventHandler(spy);
         verify(tabPanelMock).insert(eq(hierarchyTreeMock),
                                     anyInt(),
                                     isA(TabItemConfig.class),
                                     anyString());
+        verify(spy).populateViewTabs(selectedHierarchy);
+    }
+
+    @Test
+    public void testPopulateViewTabs() {
+        when(ontologyUtilMock.convertHierarchyToAvu(hierarchyMock)).thenReturn(avuMock);
+        OntologyHierarchy selectedHierarchy = mock(OntologyHierarchy.class);
+        OntologyHierarchiesPresenterImpl spy = spy(uut);
+
+        /** CALL METHOD UNDER TEST **/
+        spy.populateViewTabs(selectedHierarchy);
+        verify(childCallbacksMock, times(2)).add(isA(OntologyHierarchiesPresenterImpl.FilteredHierarchyCallback.class));
+        verify(hierarchyTreeMock, times(2)).mask(eq(appearanceMock.getAppCategoriesLoadingMask()));
+
+        verify(ontologyServiceMock, times(2)).getFilteredHierarchies(anyString(), eq(avuMock), hierarchyCallback.capture());
+
+        hierarchyCallback.getValue().setParent(parentCallbackMock);
+        hierarchyCallback.getValue().onSuccess(hierarchyMock);
+        verify(ontologyUtilMock).addUnclassifiedChild(eq(hierarchyMock));
+        verify(unclassifiedHierarchiesMock).add(eq(unclassifiedMock));
+        verify(ontologyUtilMock).getOrCreateHierarchyPathTag(hierarchyMock);
+        verify(spy).addHierarchies(eq(hierarchyTreeStoreMock), isNull(OntologyHierarchy.class), eq(hierarchyListMock));
+        verify(hierarchyTreeMock).unmask();
+        verify(parentCallbackMock).done();
+
+//        parentCallbackCaptor.capture();
+//        parentCallbackCaptor.getValue().handleSuccess();
+//        verify(spy, times(2)).selectDesiredHierarchy(hierarchyTreeMock, selectedHierarchy);
 
     }
 
@@ -450,20 +505,31 @@ public class OntologyHierarchiesPresenterImplTest {
     }
 
     @Test
-    public void testGetFilteredHierarchies() {
-        when(ontologyUtilMock.convertHierarchyToAvu(hierarchyMock)).thenReturn(avuMock);
+    public void testSelectDesiredHierarchy_hierarchyAlreadyFound() {
+        uut.desiredHierarchyFound = true;
+        OntologyHierarchy selectedHierarchyMock = mock(OntologyHierarchy.class);
 
         OntologyHierarchiesPresenterImpl spy = spy(uut);
 
         /*** CALL METHOD UNDER TEST ***/
-        spy.getFilteredHierarchies(hierarchyMock, hierarchyTreeMock);
-        verify(ontologyServiceMock).getFilteredHierarchies(anyString(), eq(avuMock), hierarchyCallback.capture());
+        spy.selectDesiredHierarchy(hierarchyTreeMock, selectedHierarchyMock);
+        verify(spy, times(0)).doSelectHierarchy(hierarchyTreeMock, selectedHierarchyMock);
+    }
 
-        hierarchyCallback.getValue().onSuccess(hierarchyMock);
-        verify(ontologyUtilMock).addUnclassifiedChild(eq(hierarchyMock));
-        verify(unclassifiedHierarchiesMock).add(eq(unclassifiedMock));
-        verify(ontologyUtilMock).getOrCreateHierarchyPathTag(hierarchyMock);
-        verify(spy).addHierarchies(eq(hierarchyTreeStoreMock), isNull(OntologyHierarchy.class), eq(hierarchyListMock));
-        verify(hierarchyTreeMock).unmask();
+    @Test
+    public void testDoSelectHierarchy_hierarchyNotFound() {
+        OntologyHierarchy selectedHierarchyMock = mock(OntologyHierarchy.class);
+        OntologyHierarchiesPresenterImpl spy = spy(uut);
+
+        /*** CALL METHOD UNDER TEST ***/
+        assertFalse(spy.doSelectHierarchy(hierarchyTreeMock, selectedHierarchyMock));
+    }
+
+    @Test
+    public void testDoSelectHierarchy_hierarchyFound() {
+        OntologyHierarchiesPresenterImpl spy = spy(uut);
+
+        /*** CALL METHOD UNDER TEST ***/
+        assertTrue(spy.doSelectHierarchy(hierarchyTreeMock, hierarchyMock));
     }
 }


### PR DESCRIPTION
Since all the other DE windows have Refresh buttons, the Apps window should probably have a Refresh button as well.

This enables the user to be able to refresh the categories, hierarchies, search results, and app listing at any time, and the user should be brought back to whatever category/hierarchy or search they had before hitting Refresh.

Given the nature of ontologies and how they can change at any time by the admins, there's also logic added to cover the scenario where the user has hit Refresh and the hierarchy they were viewing no longer exists. This can happen if the user has had the apps window open for a long time, the admin has published a new ontology that no longer has the hierarchy they were viewing, and then the user hits Refresh. In this case, the user will be brought back to the Apps Under Development category.
