### PR TITLE
CORE-8148 Refresh button w/ GwtQuery Promises

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/DiscoveryEnvironmentCommon.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/DiscoveryEnvironmentCommon.gwt.xml
@@ -10,6 +10,7 @@
 
     <!-- Other module inherits                                      -->
     <inherits name="com.sksamuel.gwt.GwtWebsockets" />
+    <inherits name="com.google.gwt.query.Query"/>
 
     <replace-with class="org.iplantc.de.shared.services.DefaultTimeSource">
         <when-type-is class="org.iplantc.de.shared.services.ProvidesTime"/>

--- a/de-lib/src/main/java/org/iplantc/de/apps/Apps.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/apps/Apps.gwt.xml
@@ -9,6 +9,7 @@
     <inherits name="org.iplantc.de.tools.requests.ToolRequests"/>
     <inherits name="com.sencha.gxt.theme.gray.Gray"/>
     <inherits name="org.iplantc.de.theme.base.Base"/>
+    <inherits name="com.google.gwt.query.Query"/>
 
     <source path="client" />
     <source path="shared" />

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.apps.client;
 
 import org.iplantc.de.apps.client.events.AppFavoritedEvent;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
+import org.iplantc.de.apps.client.events.SelectedHierarchyNotFound;
 import org.iplantc.de.apps.client.events.selection.AppCategorySelectionChangedEvent;
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.CopyAppSelected;
@@ -65,7 +66,8 @@ public interface AppCategoriesView extends IsWidget,
     interface Presenter extends AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
                                 CopyAppSelected.CopyAppSelectedHandler,
                                 CopyWorkflowSelected.CopyWorkflowSelectedHandler,
-                                AppCategorySelectionChangedEvent.HasAppCategorySelectionChangedEventHandlers {
+                                AppCategorySelectionChangedEvent.HasAppCategorySelectionChangedEventHandlers,
+                                SelectedHierarchyNotFound.SelectedHierarchyNotFoundHandler {
 
         AppCategory getSelectedAppCategory();
 

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
@@ -71,7 +71,7 @@ public interface AppCategoriesView extends IsWidget,
 
         AppCategoriesView getWorkspaceView();
 
-        void go(HasId selectedAppCategory, DETabPanel tabPanel);
+        void go(HasId selectedAppCategory, boolean selectDefaultCategory, DETabPanel tabPanel);
 
         void setViewDebugId(String baseID);
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
@@ -13,6 +13,7 @@ import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.events.selection.EditAppSelected;
 import org.iplantc.de.apps.client.events.selection.EditWorkflowSelected;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
+import org.iplantc.de.apps.client.events.selection.RefreshAppsSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.RequestToolSelected;
 import org.iplantc.de.apps.client.events.selection.RunAppSelected;
 import org.iplantc.de.apps.client.events.selection.ShareAppsSelected;
@@ -44,7 +45,8 @@ public interface AppsToolbarView extends IsWidget,
                                          RequestToolSelected.HasRequestToolSelectedHandlers,
                                          ShareAppsSelected.HasShareAppSelectedHandlers,
                                          OntologyHierarchySelectionChangedEvent.OntologyHierarchySelectionChangedEventHandler,
-                                         SwapViewButtonClickedEvent.HasSwapViewButtonClickedEventHandlers {
+                                         SwapViewButtonClickedEvent.HasSwapViewButtonClickedEventHandlers,
+                                         RefreshAppsSelectedEvent.HasRefreshAppsSelectedEventHandlers {
 
     interface AppsToolbarAppearance {
 
@@ -97,6 +99,10 @@ public interface AppsToolbarView extends IsWidget,
         String share();
 
         ImageResource shareAppIcon();
+
+        String refresh();
+
+        ImageResource refreshIcon();
     }
 
     interface Presenter extends BeforeLoadEvent.HasBeforeLoadHandlers<FilterPagingLoadConfig>,

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsToolbarView.java
@@ -109,9 +109,13 @@ public interface AppsToolbarView extends IsWidget,
                                 AppSearchResultLoadEvent.HasAppSearchResultLoadEventHandlers {
 
         AppsToolbarView getView();
+
+        void reloadSearchResults();
     }
 
     void hideAppMenu();
 
     void hideWorkflowMenu();
+
+    boolean hasSearchPhrase();
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
@@ -54,4 +54,6 @@ public interface AppsView extends IsWidget,
 
     void hideWorkflowMenu();
 
+    void clearTabPanel();
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
@@ -29,9 +29,11 @@ public interface OntologyHierarchiesView extends IsWidget,
                                 AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
                                 OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers {
 
-        void go(DETabPanel tabPanel);
+        void go(OntologyHierarchy selectedHierarchy, DETabPanel tabPanel);
 
         void setViewDebugId(String baseID);
+
+        OntologyHierarchy getSelectedHierarchy();
     }
 
     Tree<OntologyHierarchy, String> getTree();

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/OntologyHierarchiesView.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.apps.client;
 
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
+import org.iplantc.de.apps.client.events.SelectedHierarchyNotFound;
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
 import org.iplantc.de.client.models.IsMaskable;
@@ -27,7 +28,8 @@ public interface OntologyHierarchiesView extends IsWidget,
 
     interface Presenter extends AppInfoSelectedEvent.AppInfoSelectedEventHandler,
                                 AppSearchResultLoadEvent.AppSearchResultLoadEventHandler,
-                                OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers {
+                                OntologyHierarchySelectionChangedEvent.HasOntologyHierarchySelectionChangedEventHandlers,
+                                SelectedHierarchyNotFound.HasSelectedHierarchyNotFoundHandlers {
 
         void go(OntologyHierarchy selectedHierarchy, DETabPanel tabPanel);
 
@@ -37,5 +39,9 @@ public interface OntologyHierarchiesView extends IsWidget,
     }
 
     Tree<OntologyHierarchy, String> getTree();
+
+    void setRoot(OntologyHierarchy hierarchy);
+
+    OntologyHierarchy getRoot();
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/events/SelectedHierarchyNotFound.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/events/SelectedHierarchyNotFound.java
@@ -1,0 +1,29 @@
+package org.iplantc.de.apps.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class SelectedHierarchyNotFound
+        extends GwtEvent<SelectedHierarchyNotFound.SelectedHierarchyNotFoundHandler> {
+    public static interface SelectedHierarchyNotFoundHandler extends EventHandler {
+        void onSelectedHierarchyNotFound(SelectedHierarchyNotFound event);
+    }
+
+    public interface HasSelectedHierarchyNotFoundHandlers {
+        HandlerRegistration addSelectedHierarchyNotFoundHandler(SelectedHierarchyNotFoundHandler handler);
+    }
+    public static Type<SelectedHierarchyNotFoundHandler> TYPE =
+            new Type<SelectedHierarchyNotFoundHandler>();
+
+    public Type<SelectedHierarchyNotFoundHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(SelectedHierarchyNotFoundHandler handler) {
+        handler.onSelectedHierarchyNotFound(this);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/RefreshAppsSelectedEvent.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/events/selection/RefreshAppsSelectedEvent.java
@@ -1,0 +1,31 @@
+package org.iplantc.de.apps.client.events.selection;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class RefreshAppsSelectedEvent
+        extends GwtEvent<RefreshAppsSelectedEvent.RefreshAppsSelectedEventHandler> {
+
+    public static interface RefreshAppsSelectedEventHandler extends EventHandler {
+        void onRefreshAppsSelected(RefreshAppsSelectedEvent event);
+    }
+
+    public interface HasRefreshAppsSelectedEventHandlers {
+        HandlerRegistration addRefreshAppsSelectedEventHandler(RefreshAppsSelectedEventHandler handler);
+    }
+
+    public static Type<RefreshAppsSelectedEventHandler> TYPE =
+            new Type<RefreshAppsSelectedEventHandler>();
+
+    public Type<RefreshAppsSelectedEventHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(RefreshAppsSelectedEventHandler handler) {
+        handler.onRefreshAppsSelected(this);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
@@ -34,6 +34,7 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
     private final AppCategoriesView.Presenter categoriesPresenter;
     private final AppsListView.Presenter appsListPresenter;
     private final OntologyHierarchiesView.Presenter hierarchiesPresenter;
+    private final AppsToolbarView.Presenter toolbarPresenter;
     OntologyUtil ontologyUtil;
 
     @Inject
@@ -45,6 +46,7 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
         this.categoriesPresenter = categoriesPresenter;
         this.appsListPresenter = appsListPresenter;
         this.hierarchiesPresenter = hierarchiesPresenter;
+        this.toolbarPresenter = toolbarPresenter;
         this.view = viewFactory.create(categoriesPresenter,
                                        hierarchiesPresenter, appsListPresenter,
                                        toolbarPresenter);
@@ -124,12 +126,16 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
     public void onRefreshAppsSelected(RefreshAppsSelectedEvent event) {
         AppCategory selectedAppCategory = categoriesPresenter.getSelectedAppCategory();
         OntologyHierarchy selectedHierarchy = hierarchiesPresenter.getSelectedHierarchy();
-        boolean useDefaultSelection = selectedHierarchy == null;
+        boolean hasSearchPhrase = toolbarPresenter.getView().hasSearchPhrase();
+        boolean useDefaultSelection = !hasSearchPhrase && selectedHierarchy == null;
 
         view.clearTabPanel();
         DETabPanel categoryTabPanel = view.getCategoryTabPanel();
 
         categoriesPresenter.go(selectedAppCategory, useDefaultSelection, categoryTabPanel);
         hierarchiesPresenter.go(selectedHierarchy, categoryTabPanel);
+        if (hasSearchPhrase) {
+            toolbarPresenter.reloadSearchResults();
+        }
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
@@ -55,6 +55,7 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
 
         hierarchiesPresenter.addOntologyHierarchySelectionChangedEventHandler(appsListPresenter);
         hierarchiesPresenter.addOntologyHierarchySelectionChangedEventHandler(toolbarPresenter.getView());
+        hierarchiesPresenter.addSelectedHierarchyNotFoundHandler(categoriesPresenter);
 
         appsListPresenter.addAppSelectionChangedEventHandler(toolbarPresenter.getView());
         appsListPresenter.addAppInfoSelectedEventHandler(hierarchiesPresenter);

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
@@ -39,6 +39,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.query.client.Function;
 import com.google.gwt.query.client.GQuery;
+import com.google.gwt.query.client.Promise;
 import com.google.gwt.query.client.plugins.deferred.PromiseRPC;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
@@ -109,7 +110,7 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
         }
     }
 
-    class FilteredHierarchyCallback extends PromiseRPC<OntologyHierarchy> {
+    public class FilteredHierarchyCallback extends PromiseRPC<OntologyHierarchy> {
         private final Tree<OntologyHierarchy, String> tree;
         private final OntologyHierarchy root;
 
@@ -259,8 +260,7 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
 
     void populateViewTabs(final OntologyHierarchy selectedHierarchy) {
         //Create all the callbacks I'll need
-        List<FilteredHierarchyCallback> childCallbacks = Lists.newArrayList();
-
+        List<FilteredHierarchyCallback> childCallbacks = createFilteredHierarchyList();
         for (OntologyHierarchiesView view: views) {
 
             FilteredHierarchyCallback callback =
@@ -273,7 +273,7 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
                                                  callback);
         }
 
-        GQuery.when(childCallbacks.toArray()).done(new Function() {
+        whenCallbackPromises(childCallbacks).done(new Function() {
             public void f() {
                 for (OntologyHierarchiesView view : views) {
                     selectDesiredHierarchy(view.getTree(), selectedHierarchy);
@@ -453,5 +453,13 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
         if (handlerManager != null) {
             handlerManager.fireEvent(event);
         }
+    }
+
+    List<FilteredHierarchyCallback> createFilteredHierarchyList() {
+        return Lists.newArrayList();
+    }
+
+    Promise whenCallbackPromises(List<FilteredHierarchyCallback> childCallbacks) {
+        return GQuery.when(childCallbacks.toArray());
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
@@ -6,6 +6,7 @@ import org.iplantc.de.apps.client.OntologyHierarchiesView;
 import org.iplantc.de.apps.client.events.AppFavoritedEvent;
 import org.iplantc.de.apps.client.events.AppSearchResultLoadEvent;
 import org.iplantc.de.apps.client.events.AppUpdatedEvent;
+import org.iplantc.de.apps.client.events.SelectedHierarchyNotFound;
 import org.iplantc.de.apps.client.events.selection.AppFavoriteSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppInfoSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.AppRatingDeselected;
@@ -36,6 +37,9 @@ import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.inject.client.AsyncProvider;
+import com.google.gwt.query.client.Function;
+import com.google.gwt.query.client.GQuery;
+import com.google.gwt.query.client.plugins.deferred.PromiseRPC;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -105,27 +109,26 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
         }
     }
 
-    class FilteredHierarchyCallback implements AsyncCallback<OntologyHierarchy> {
+    class FilteredHierarchyCallback extends PromiseRPC<OntologyHierarchy> {
         private final Tree<OntologyHierarchy, String> tree;
         private final OntologyHierarchy root;
-        private final OntologyHierarchy selectedHierarchy;
 
         public FilteredHierarchyCallback(Tree<OntologyHierarchy, String> tree,
-                                         OntologyHierarchy root,
-                                         OntologyHierarchy selectedHierarchy) {
+                                         OntologyHierarchy root) {
             this.tree = tree;
             this.root = root;
-            this.selectedHierarchy = selectedHierarchy;
         }
 
         @Override
         public void onFailure(Throwable caught) {
             ErrorHandler.post(caught);
             tree.unmask();
+            super.onFailure(caught);
         }
 
         @Override
         public void onSuccess(OntologyHierarchy result) {
+
             if (result == null || result.getSubclasses() == null) {
                 result = root;
                 result.setSubclasses(Lists.<OntologyHierarchy>newArrayList());
@@ -136,8 +139,9 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
             // which will allow the children to know the full path from its parent to node
             ontologyUtil.getOrCreateHierarchyPathTag(result);
             addHierarchies(tree.getStore(), null, result.getSubclasses());
-            selectDesiredHierarchy(tree, selectedHierarchy);
+
             tree.unmask();
+            super.onSuccess(result);
         }
     }
 
@@ -155,7 +159,8 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
     private OntologyHierarchiesViewFactory viewFactory;
     String baseID;
     List<OntologyHierarchy> unclassifiedHierarchies = Lists.newArrayList();
-    List<Tree<OntologyHierarchy, String>> trees = Lists.newArrayList();
+    List<OntologyHierarchiesView> views;
+    boolean desiredHierarchyFound = false;
     Logger LOG = Logger.getLogger("OntologyHierarchiesPresenterImpl");
 
     @Inject
@@ -174,6 +179,8 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
 
     @Override
     public void go(final OntologyHierarchy selectedHierarchy, final DETabPanel tabPanel) {
+        desiredHierarchyFound = false;
+        views = Lists.newArrayList();
         viewTabPanel = tabPanel;
         serviceFacade.getRootHierarchies(new AsyncCallback<List<OntologyHierarchy>>() {
             @Override
@@ -204,9 +211,9 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
     @Override
     public OntologyHierarchy getSelectedHierarchy() {
         OntologyHierarchy hierarchy;
-        for (Tree<OntologyHierarchy, String> tree : trees) {
-            if (tree != null) {
-                hierarchy = tree.getSelectionModel().getSelectedItem();
+        for (OntologyHierarchiesView view : views) {
+            if (view.getTree() != null) {
+                hierarchy = view.getTree().getSelectionModel().getSelectedItem();
                 if (hierarchy != null) {
                     return hierarchy;
                 }
@@ -232,21 +239,50 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
         });
     }
 
-    void createViewTabs(OntologyHierarchy selectedHierarchy, List<OntologyHierarchy> results) {
+    void createViewTabs(final OntologyHierarchy selectedHierarchy, List<OntologyHierarchy> results) {
         for (OntologyHierarchy hierarchy : results) {
             TreeStore<OntologyHierarchy> treeStore = getHierarchyTreeStore();
             OntologyHierarchiesView view = viewFactory.create(treeStore);
             Tree<OntologyHierarchy, String> tree = view.getTree();
-            trees.add(tree);
+            view.setRoot(hierarchy);
+            views.add(view);
 
-            tree.mask(appearance.getAppCategoriesLoadingMask());
-            getFilteredHierarchies(hierarchy, selectedHierarchy, tree);
             String hierarchyDebugId = baseID + "." + hierarchy.getIri();
             view.asWidget().ensureDebugId(hierarchyDebugId);
             view.addOntologyHierarchySelectionChangedEventHandler(this);
             //As a preference, insert the hierarchy tabs before the HPC tab which is last
             viewTabPanel.insert(tree, viewTabPanel.getWidgetCount() - 1, new TabItemConfig(appearance.hierarchyLabelName(hierarchy)), hierarchyDebugId);
         }
+
+        populateViewTabs(selectedHierarchy);
+    }
+
+    void populateViewTabs(final OntologyHierarchy selectedHierarchy) {
+        //Create all the callbacks I'll need
+        List<FilteredHierarchyCallback> childCallbacks = Lists.newArrayList();
+
+        for (OntologyHierarchiesView view: views) {
+
+            FilteredHierarchyCallback callback =
+                    new FilteredHierarchyCallback(view.getTree(), view.getRoot());
+            childCallbacks.add(callback);
+
+            view.getTree().mask(appearance.getAppCategoriesLoadingMask());
+            serviceFacade.getFilteredHierarchies(view.getRoot().getIri(),
+                                                 ontologyUtil.convertHierarchyToAvu(view.getRoot()),
+                                                 callback);
+        }
+
+        GQuery.when(childCallbacks.toArray()).done(new Function() {
+            public void f() {
+                for (OntologyHierarchiesView view : views) {
+                    selectDesiredHierarchy(view.getTree(), selectedHierarchy);
+                }
+                if (selectedHierarchy != null && !desiredHierarchyFound) {
+                    fireEvent(new SelectedHierarchyNotFound());
+                }
+            }
+        });
     }
 
     @Override
@@ -270,20 +306,22 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
         return new AppCategoryTreeStoreProvider().get();
     }
 
-    void getFilteredHierarchies(final OntologyHierarchy root, final OntologyHierarchy selectedHierarchy, final Tree<OntologyHierarchy, String> tree) {
-        serviceFacade.getFilteredHierarchies(root.getIri(),
-                                             ontologyUtil.convertHierarchyToAvu(root),
-                                             new FilteredHierarchyCallback(tree,
-                                                                           root,
-                                                                           selectedHierarchy));
+    void selectDesiredHierarchy(Tree<OntologyHierarchy, String> tree, OntologyHierarchy selectedHierarchy) {
+        if (selectedHierarchy == null || desiredHierarchyFound) {
+            return;
+        }
+        desiredHierarchyFound = doSelectHierarchy(tree, selectedHierarchy);
     }
 
-    void selectDesiredHierarchy(Tree<OntologyHierarchy, String> tree, OntologyHierarchy selectedHierarchy) {
+    boolean doSelectHierarchy(Tree<OntologyHierarchy, String> tree,
+                              OntologyHierarchy selectedHierarchy) {
         Tree.TreeNode<OntologyHierarchy> node = tree.findNode(selectedHierarchy);
         if (node != null) {
             viewTabPanel.setActiveWidget(tree);
             tree.getSelectionModel().select(node.getModel(), true);
+            return true;
         }
+        return false;
     }
 
     void addHierarchies(TreeStore<OntologyHierarchy> treeStore, OntologyHierarchy parent, List<OntologyHierarchy> children) {
@@ -396,6 +434,11 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
     public HandlerRegistration addOntologyHierarchySelectionChangedEventHandler(
             OntologyHierarchySelectionChangedEvent.OntologyHierarchySelectionChangedEventHandler handler) {
         return ensureHandlers().addHandler(OntologyHierarchySelectionChangedEvent.TYPE, handler);
+    }
+
+    @Override
+    public HandlerRegistration addSelectedHierarchyNotFoundHandler(SelectedHierarchyNotFound.SelectedHierarchyNotFoundHandler handler) {
+        return ensureHandlers().addHandler(SelectedHierarchyNotFound.TYPE, handler);
     }
 
     HandlerManager createHandlerManager() {

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
@@ -102,10 +102,6 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
                      searchRegexPattern,
                      hierarchyTreeStore,
                      categoryTreeStore,
-                     OntologyHierarchiesPresenterImpl.this,
-                     OntologyHierarchiesPresenterImpl.this,
-                     OntologyHierarchiesPresenterImpl.this,
-                     OntologyHierarchiesPresenterImpl.this,
                      OntologyHierarchiesPresenterImpl.this);
         }
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/toolBar/AppsToolbarPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/toolBar/AppsToolbarPresenterImpl.java
@@ -94,6 +94,11 @@ public class AppsToolbarPresenterImpl implements AppsToolbarView.Presenter,
     }
 
     @Override
+    public void reloadSearchResults() {
+        loader.load(loader.getLastLoadConfig());
+    }
+
+    @Override
     public void onCreateNewAppSelected(CreateNewAppSelected event) {
         eventBus.fireEvent(new CreateNewAppEvent());
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/AppsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/AppsViewImpl.java
@@ -51,6 +51,7 @@ public class AppsViewImpl extends Composite implements AppsView {
         this.toolBar = toolbarPresenter.getView();
 
         initWidget(uiBinder.createAndBindUi(this));
+
         categoryTabs.addSelectionHandler(new SelectionHandler<Widget>() {
             @Override
             public void onSelection(SelectionEvent<Widget> event) {
@@ -79,6 +80,15 @@ public class AppsViewImpl extends Composite implements AppsView {
     @Override
     public void hideWorkflowMenu() {
         toolBar.hideWorkflowMenu();
+    }
+
+    public void clearTabPanel() {
+        categoryTabs.disableEvents();
+        int tabCount = categoryTabs.getWidgetCount();
+        for (int i = 0 ; i < tabCount ; i++) {
+            categoryTabs.close(categoryTabs.getWidget(0));
+        }
+        categoryTabs.enableEvents();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/dialogs/AppDetailsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/details/dialogs/AppDetailsDialog.java
@@ -13,6 +13,7 @@ import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 import org.iplantc.de.shared.AsyncProviderWrapper;
 
+import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
@@ -37,11 +38,7 @@ public class AppDetailsDialog extends IPlantDialog {
                      final String searchRegexPattern,
                      final TreeStore<OntologyHierarchy> hierarchyTreeStore,
                      final TreeStore<AppCategory> categoryTreeStore,
-                     final AppFavoriteSelectedEvent.AppFavoriteSelectedEventHandler favoriteSelectedHandler,
-                     final AppRatingSelected.AppRatingSelectedHandler ratingSelectedHandler,
-                     final AppRatingDeselected.AppRatingDeselectedHandler ratingDeselectedHandler,
-                     final DetailsHierarchyClicked.DetailsHierarchyClickedHandler hierarchySelectionHandler,
-                     final DetailsCategoryClicked.DetailsCategoryClickedHandler categoryClickedHandler) {
+                     final EventHandler eventHandler) {
 
         setHeadingText(app.getName());
         presenterProvider.get(new AsyncCallback<AppDetailsView.Presenter>() {
@@ -53,20 +50,12 @@ public class AppDetailsDialog extends IPlantDialog {
             @Override
             public void onSuccess(final AppDetailsView.Presenter result) {
                 result.go(AppDetailsDialog.this, app, searchRegexPattern, hierarchyTreeStore, categoryTreeStore);
-                if(favoriteSelectedHandler != null){
-                    result.addAppFavoriteSelectedEventHandlers(favoriteSelectedHandler);
-                }
-                if(ratingSelectedHandler != null){
-                    result.addAppRatingSelectedHandler(ratingSelectedHandler);
-                }
-                if(ratingDeselectedHandler != null){
-                    result.addAppRatingDeselectedHandler(ratingDeselectedHandler);
-                }
-                if (hierarchySelectionHandler != null) {
-                    result.addDetailsHierarchyClickedHandler(hierarchySelectionHandler);
-                }
-                if (categoryClickedHandler != null) {
-                    result.addDetailsCategoryClickedHandler(categoryClickedHandler);
+                if (eventHandler != null) {
+                    result.addAppFavoriteSelectedEventHandlers((AppFavoriteSelectedEvent.AppFavoriteSelectedEventHandler)eventHandler);
+                    result.addAppRatingSelectedHandler((AppRatingSelected.AppRatingSelectedHandler)eventHandler);
+                    result.addAppRatingDeselectedHandler((AppRatingDeselected.AppRatingDeselectedHandler)eventHandler);
+                    result.addDetailsHierarchyClickedHandler((DetailsHierarchyClicked.DetailsHierarchyClickedHandler)eventHandler);
+                    result.addDetailsCategoryClickedHandler((DetailsCategoryClicked.DetailsCategoryClickedHandler)eventHandler);
                 }
             }
         });

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/hierarchies/OntologyHierarchiesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/hierarchies/OntologyHierarchiesViewImpl.java
@@ -35,6 +35,7 @@ public class OntologyHierarchiesViewImpl extends ContentPanel implements Ontolog
     private TreeStore<OntologyHierarchy> treeStore;
     private OntologyHierarchiesAppearance appearance;
     private OntologyUtil ontologyUtil;
+    private OntologyHierarchy root;
 
     @Inject
     OntologyHierarchiesViewImpl(final OntologyHierarchiesAppearance appearance,
@@ -48,6 +49,16 @@ public class OntologyHierarchiesViewImpl extends ContentPanel implements Ontolog
     @Override
     public Tree<OntologyHierarchy, String> getTree() {
         return tree;
+    }
+
+    @Override
+    public void setRoot(OntologyHierarchy hierarchy) {
+        this.root = hierarchy;
+    }
+
+    @Override
+    public OntologyHierarchy getRoot() {
+        return root;
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbar.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbar.ui.xml
@@ -87,6 +87,11 @@
                     </button:menu>
               </button:TextButton>
           </toolbar:child>
+		<toolbar:child>
+			<button:TextButton ui:field="refreshButton"
+							   text="{appearance.refresh}"
+							   icon="{appearance.refreshIcon}"/>
+		</toolbar:child>
 		<toolbar:child layoutData="{boxData}">
 			<MyWidgets:AppSearchField ui:field="appSearch"
 				emptyText="{appearance.searchApps}" />

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
@@ -16,6 +16,7 @@ import org.iplantc.de.apps.client.events.selection.DeleteAppsSelected;
 import org.iplantc.de.apps.client.events.selection.EditAppSelected;
 import org.iplantc.de.apps.client.events.selection.EditWorkflowSelected;
 import org.iplantc.de.apps.client.events.selection.OntologyHierarchySelectionChangedEvent;
+import org.iplantc.de.apps.client.events.selection.RefreshAppsSelectedEvent;
 import org.iplantc.de.apps.client.events.selection.RequestToolSelected;
 import org.iplantc.de.apps.client.events.selection.RunAppSelected;
 import org.iplantc.de.apps.client.events.selection.ShareAppsSelected;
@@ -73,6 +74,7 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     Menu sharingMenu;
     @UiField
     TextButton shareMenuButton;
+    @UiField TextButton refreshButton;
     @UiField
     MenuItem appRun;
     @UiField
@@ -188,6 +190,10 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     @Override
     public HandlerRegistration addSwapViewButtonClickedEventHandler(SwapViewButtonClickedEvent.SwapViewButtonClickedEventHandler handler) {
         return addHandler(handler, SwapViewButtonClickedEvent.TYPE);
+    }
+
+    public HandlerRegistration addRefreshAppsSelectedEventHandler(RefreshAppsSelectedEvent.RefreshAppsSelectedEventHandler handler) {
+        return addHandler(handler, RefreshAppsSelectedEvent.TYPE);
     }
 
     // </editor-fold>
@@ -348,6 +354,8 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
         sharePublic.ensureDebugId(baseID + Ids.MENU_ITEM_SHARE_APP + Ids.MENU_ITEM_SHARE_APP_PUBLIC);
         shareCollab.ensureDebugId(baseID + Ids.MENU_ITEM_SHARE_APP + Ids.MENU_ITEM_SHARE_APP_COLLAB);
 
+        refreshButton.ensureDebugId(baseID + Ids.MENU_ITEM_REFRESH);
+
         wf_menu.ensureDebugId(baseID + Ids.MENU_ITEM_WF);
         wfRun.ensureDebugId(baseID + Ids.MENU_ITEM_WF + Ids.MENU_ITEM_USE_WF);
         createWorkflow.ensureDebugId(baseID + Ids.MENU_ITEM_WF + Ids.MENU_ITEM_CREATE_WF);
@@ -494,5 +502,10 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
     @UiHandler("swapViewBtn")
     public void onSwapViewClick(SelectEvent e) {
         fireEvent(new SwapViewButtonClickedEvent());
+    }
+
+    @UiHandler("refreshButton")
+    void refreshButtonClicked(SelectEvent event) {
+        fireEvent(new RefreshAppsSelectedEvent());
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/toolBar/AppsViewToolbarImpl.java
@@ -212,6 +212,11 @@ public class AppsViewToolbarImpl extends Composite implements AppsToolbarView {
         boxData.setFlex(0);
     }
 
+    @Override
+    public boolean hasSearchPhrase() {
+        return appSearch.getCurrentValue() != null;
+    }
+
     // <editor-fold desc="Selection Handlers">
     @Override
     public void onAppCategorySelectionChanged(AppCategorySelectionChangedEvent event) {

--- a/de-lib/src/main/java/org/iplantc/de/apps/shared/AppsModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/shared/AppsModule.java
@@ -47,6 +47,7 @@ public interface AppsModule {
         String APP_CARD_CELL = ".card";
         String SWAP_VIEW_BTN = ".swapBtn";
         String APP_STATUS_CELL = ".status";
+        String MENU_ITEM_REFRESH = ".refresh";
     }
 }
 

--- a/de-lib/src/main/java/org/iplantc/de/client/services/OntologyServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/OntologyServiceFacade.java
@@ -4,6 +4,7 @@ import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.avu.Avu;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 
+import com.google.gwt.query.client.plugins.deferred.PromiseRPC;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import java.util.List;
@@ -15,7 +16,7 @@ public interface OntologyServiceFacade {
 
     void getRootHierarchies(AsyncCallback<List<OntologyHierarchy>> callback);
 
-    void getFilteredHierarchies(String rootIri, Avu avu, AsyncCallback<OntologyHierarchy> callback);
+    void getFilteredHierarchies(String rootIri, Avu avu, PromiseRPC<OntologyHierarchy> callback);
 
     void getAppsInCategory(String iri, Avu avu, AsyncCallback<List<App>> callback);
 

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/PromiseConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/PromiseConverter.java
@@ -1,0 +1,29 @@
+package org.iplantc.de.client.services.converters;
+
+import com.google.gwt.query.client.plugins.deferred.PromiseRPC;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+/**
+ * @author aramsey
+ */
+public abstract class PromiseConverter<F, T> implements AsyncCallback<F> {
+
+    private final PromiseRPC<T> promiseRpc;
+
+    public PromiseConverter(PromiseRPC<T> promiseRPC) {
+        this.promiseRpc = promiseRPC;
+    }
+
+    @Override
+    public void onFailure(Throwable caught) {
+        promiseRpc.onFailure(caught);
+    }
+
+
+    @Override
+    public void onSuccess(F result) {
+        promiseRpc.onSuccess(convertFrom(result));
+    }
+
+    protected abstract T convertFrom(F object);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/OntologyServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/OntologyServiceFacadeImpl.java
@@ -12,12 +12,13 @@ import org.iplantc.de.client.services.AppServiceFacade;
 import org.iplantc.de.client.services.OntologyServiceFacade;
 import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
 import org.iplantc.de.client.services.converters.AvuListCallbackConverter;
-import org.iplantc.de.client.services.converters.OntologyHierarchyCallbackConverter;
 import org.iplantc.de.client.services.converters.OntologyHierarchyListCallbackConverter;
+import org.iplantc.de.client.services.converters.PromiseConverter;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.shared.services.ServiceCallWrapper;
 
 import com.google.gwt.http.client.URL;
+import com.google.gwt.query.client.plugins.deferred.PromiseRPC;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
@@ -45,11 +46,17 @@ public class OntologyServiceFacadeImpl implements OntologyServiceFacade {
     }
 
     @Override
-    public void getFilteredHierarchies(String rootIri, Avu avu, AsyncCallback<OntologyHierarchy> callback) {
+    public void getFilteredHierarchies(String rootIri, Avu avu, PromiseRPC<OntologyHierarchy> callback) {
         String address = APPS_HIERARCHIES + "/" + URL.encodeQueryString(rootIri) + "?attr=" + URL.encodeQueryString(avu.getAttribute());
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
-        deService.getServiceData(wrapper, new OntologyHierarchyCallbackConverter(callback, factory));
+        deService.getServiceData(wrapper, new PromiseConverter<String, OntologyHierarchy>(callback) {
+
+            @Override
+            protected OntologyHierarchy convertFrom(String object) {
+                return AutoBeanCodex.decode(svcFactory, OntologyHierarchy.class, object).as().getHierarchy();
+            }
+        });
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/DETabPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/DETabPanel.java
@@ -36,4 +36,9 @@ public class DETabPanel extends TabPanel {
         XElement item = findItem(getWidgetIndex(widget));
         item.setId(debugId);
     }
+
+    @Override
+    public void close(Widget item) {
+        super.close(item);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/toolbar/AppsToolbarViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/toolbar/AppsToolbarViewDefaultAppearance.java
@@ -121,6 +121,16 @@ public class AppsToolbarViewDefaultAppearance implements AppsToolbarView.AppsToo
     }
 
     @Override
+    public String refresh() {
+        return iplantDisplayStrings.refresh();
+    }
+
+    @Override
+    public ImageResource refreshIcon() {
+        return iplantResources.refresh();
+    }
+
+    @Override
     public String warning() {
         return iplantDisplayStrings.warning();
     }

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImplTest.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.apps.client.presenter;
 
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -76,8 +77,9 @@ public class AppsViewPresenterImplTest {
         verify(toolbarViewMock).addAppSearchResultLoadEventHandler(hierarchiesPresenter);
         verify(toolbarViewMock).addBeforeAppSearchEventHandler(listPresenterMock);
         verify(toolbarViewMock).addSwapViewButtonClickedEventHandler(listPresenterMock);
+        verify(toolbarViewMock).addRefreshAppsSelectedEventHandler(isA(AppsViewPresenterImpl.class));
 
-        verify(toolbarPresenterMock, times(12)).getView();
+        verify(toolbarPresenterMock, times(13)).getView();
 
 
         verifyNoMoreInteractions(viewFactoryMock,

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
@@ -128,7 +128,7 @@ public class AppCategoriesPresenterImplTest {
         when(appearanceMock.getAppCategoriesLoadingMask()).thenReturn("mask");
 
         /*** CALL METHOD UNDER TEST ***/
-        uut.go(null, tabPanelMock);
+        uut.go(null, false, tabPanelMock);
 
         verify(treeMock, times(2)).mask(anyString());
         verify(appServiceMock).getAppCategories(anyBoolean(), appCategoriesCaptor.capture());

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImplTest.java
@@ -1,5 +1,7 @@
 package org.iplantc.de.apps.client.presenter.hierarchies;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -43,6 +45,8 @@ import org.iplantc.de.commons.client.widgets.DETabPanel;
 
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.inject.client.AsyncProvider;
+import com.google.gwt.query.client.Function;
+import com.google.gwt.query.client.Promise;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -104,13 +108,19 @@ public class OntologyHierarchiesPresenterImplTest {
     @Mock List<AppCategory> appCategoryListMock;
     @Mock List<OntologyHierarchy> unclassifiedHierarchiesMock;
     @Mock OntologyHierarchy unclassifiedMock;
+    @Mock List<OntologyHierarchiesView> viewsMock;
+    @Mock Iterator<OntologyHierarchiesView> viewIteratorMock;
+    @Mock Tree.TreeNode<OntologyHierarchy> treeNodeMock;
+    @Mock List<OntologyHierarchiesPresenterImpl.FilteredHierarchyCallback> childCallbacksMock;
+    @Mock Promise promiseMock;
 
     @Captor ArgumentCaptor<AsyncCallback<List<OntologyHierarchy>>> hierarchyListCallback;
-    @Captor ArgumentCaptor<AsyncCallback<OntologyHierarchy>> hierarchyCallback;
+    @Captor ArgumentCaptor<OntologyHierarchiesPresenterImpl.FilteredHierarchyCallback> hierarchyCallback;
     @Captor ArgumentCaptor<AsyncCallback<AppDetailsDialog>> appDetailsDialogCallback;
     @Captor ArgumentCaptor<AsyncCallback<App>> appDetailsCallback;
     @Captor ArgumentCaptor<AsyncCallback<List<Avu>>> appAvuCallbackCaptor;
     @Captor ArgumentCaptor<AsyncCallback<Void>> voidCallbackCaptor;
+    @Captor ArgumentCaptor<Function> promiseArgumentCaptor;
 
 
     private OntologyHierarchiesPresenterImpl uut;
@@ -135,6 +145,7 @@ public class OntologyHierarchiesPresenterImplTest {
         when(appearanceMock.ontologyAttrMatchingFailure()).thenReturn("string");
         when(viewMock.asWidget()).thenReturn(randomWidgetMock);
         when(viewMock.getTree()).thenReturn(hierarchyTreeMock);
+        when(viewMock.getRoot()).thenReturn(hierarchyMock);
         when(hierarchyTreeMock.getSelectionModel()).thenReturn(treeSelectionModelMock);
         when(hierarchyTreeMock.getStore()).thenReturn(hierarchyTreeStoreMock);
         when(hierarchyTreeStoreMock.findModelWithKey(anyString())).thenReturn(hierarchyMock);
@@ -151,6 +162,12 @@ public class OntologyHierarchiesPresenterImplTest {
         when(unclassifiedHierarchiesMock.size()).thenReturn(2);
         when(unclassifiedHierarchiesMock.iterator()).thenReturn(hierarchyListIterator);
         when(ontologyUtilMock.addUnclassifiedChild(hierarchyMock)).thenReturn(unclassifiedMock);
+        when(hierarchyTreeMock.findNode(hierarchyMock)).thenReturn(treeNodeMock);
+        when(treeNodeMock.getModel()).thenReturn(hierarchyMock);
+        when(viewsMock.size()).thenReturn(2);
+        when(viewsMock.iterator()).thenReturn(viewIteratorMock);
+        when(viewIteratorMock.hasNext()).thenReturn(true, true, false);
+        when(viewIteratorMock.next()).thenReturn(viewMock, viewMock);
 
         uut = new OntologyHierarchiesPresenterImpl(factoryMock,
                                                    ontologyServiceMock,
@@ -165,6 +182,16 @@ public class OntologyHierarchiesPresenterImplTest {
             TreeStore<AppCategory> getCategoryTreeStore() {
                 return categoryTreeStoreMock;
             }
+
+            @Override
+            List<FilteredHierarchyCallback> createFilteredHierarchyList() {
+                return childCallbacksMock;
+            }
+
+            @Override
+            Promise whenCallbackPromises(List<FilteredHierarchyCallback> childCallbacks) {
+                return promiseMock;
+            }
         };
         uut.ontologyUtil = ontologyUtilMock;
         uut.announcer = announcerMock;
@@ -175,6 +202,7 @@ public class OntologyHierarchiesPresenterImplTest {
         uut.searchRegexPattern = "test";
         uut.viewTabPanel = tabPanelMock;
         uut.unclassifiedHierarchies = unclassifiedHierarchiesMock;
+        uut.views = viewsMock;
     }
 
 
@@ -186,9 +214,11 @@ public class OntologyHierarchiesPresenterImplTest {
                                                    ontologyServiceMock,
                                                    eventBusMock,
                                                    appearanceMock) {
+
             @Override
-            void createViewTabs(List<OntologyHierarchy> results) {
+            void createViewTabs(OntologyHierarchy selectedHierarchy, List<OntologyHierarchy> results) {
             }
+
         };
         uut.ontologyUtil = ontologyUtilMock;
         uut.announcer = announcerMock;
@@ -198,7 +228,7 @@ public class OntologyHierarchiesPresenterImplTest {
         uut.iriToHierarchyMap = iriToHierarchyMapMock;
 
         /** CALL METHOD UNDER TEST **/
-        uut.go(tabPanelMock);
+        uut.go(hierarchyMock, tabPanelMock);
         verify(ontologyServiceMock).getRootHierarchies(hierarchyListCallback.capture());
 
         hierarchyListCallback.getValue().onSuccess(hierarchyListMock);
@@ -215,7 +245,7 @@ public class OntologyHierarchiesPresenterImplTest {
                                                    eventBusMock,
                                                    appearanceMock) {
             @Override
-            void createViewTabs(List<OntologyHierarchy> results) {
+            void createViewTabs(OntologyHierarchy selectedHierarchy, List<OntologyHierarchy> results) {
             }
         };
         uut.ontologyUtil = ontologyUtilMock;
@@ -226,7 +256,7 @@ public class OntologyHierarchiesPresenterImplTest {
         uut.iriToHierarchyMap = iriToHierarchyMapMock;
 
         /** CALL METHOD UNDER TEST **/
-        uut.go(tabPanelMock);
+        uut.go(hierarchyMock, tabPanelMock);
         verify(ontologyServiceMock).getRootHierarchies(hierarchyListCallback.capture());
 
         hierarchyListCallback.getValue().onSuccess(hierarchyListMock);
@@ -339,16 +369,44 @@ public class OntologyHierarchiesPresenterImplTest {
     @Test
     public void testCreateViewTabs() throws Exception {
         when(hierarchyListMock.iterator()).thenReturn(hierarchyListIterator);
+        OntologyHierarchy selectedHierarchy = mock(OntologyHierarchy.class);
 
         OntologyHierarchiesPresenterImpl spy = spy(uut);
 
         /** CALL METHOD UNDER TEST **/
-        spy.createViewTabs(hierarchyListMock);
+        spy.createViewTabs(selectedHierarchy, hierarchyListMock);
+        verify(viewMock).setRoot(hierarchyMock);
+        verify(viewsMock).add(viewMock);
         verify(viewMock).addOntologyHierarchySelectionChangedEventHandler(spy);
         verify(tabPanelMock).insert(eq(hierarchyTreeMock),
                                     anyInt(),
                                     isA(TabItemConfig.class),
                                     anyString());
+        verify(spy).populateViewTabs(selectedHierarchy);
+    }
+
+    @Test
+    public void testPopulateViewTabs() {
+        when(ontologyUtilMock.convertHierarchyToAvu(hierarchyMock)).thenReturn(avuMock);
+        OntologyHierarchy selectedHierarchy = mock(OntologyHierarchy.class);
+        OntologyHierarchiesPresenterImpl spy = spy(uut);
+
+        /** CALL METHOD UNDER TEST **/
+        spy.populateViewTabs(selectedHierarchy);
+        verify(childCallbacksMock, times(2)).add(isA(OntologyHierarchiesPresenterImpl.FilteredHierarchyCallback.class));
+        verify(hierarchyTreeMock, times(2)).mask(eq(appearanceMock.getAppCategoriesLoadingMask()));
+
+        verify(ontologyServiceMock, times(2)).getFilteredHierarchies(anyString(), eq(avuMock), hierarchyCallback.capture());
+
+        verify(promiseMock).done(promiseArgumentCaptor.capture());
+        promiseArgumentCaptor.getValue();
+
+        hierarchyCallback.getValue().onSuccess(hierarchyMock);
+        verify(ontologyUtilMock).addUnclassifiedChild(eq(hierarchyMock));
+        verify(unclassifiedHierarchiesMock).add(eq(unclassifiedMock));
+        verify(ontologyUtilMock).getOrCreateHierarchyPathTag(hierarchyMock);
+        verify(spy).addHierarchies(eq(hierarchyTreeStoreMock), isNull(OntologyHierarchy.class), eq(hierarchyListMock));
+        verify(hierarchyTreeMock).unmask();
 
     }
 
@@ -450,20 +508,31 @@ public class OntologyHierarchiesPresenterImplTest {
     }
 
     @Test
-    public void testGetFilteredHierarchies() {
-        when(ontologyUtilMock.convertHierarchyToAvu(hierarchyMock)).thenReturn(avuMock);
+    public void testSelectDesiredHierarchy_hierarchyAlreadyFound() {
+        uut.desiredHierarchyFound = true;
+        OntologyHierarchy selectedHierarchyMock = mock(OntologyHierarchy.class);
 
         OntologyHierarchiesPresenterImpl spy = spy(uut);
 
         /*** CALL METHOD UNDER TEST ***/
-        spy.getFilteredHierarchies(hierarchyMock, hierarchyTreeMock);
-        verify(ontologyServiceMock).getFilteredHierarchies(anyString(), eq(avuMock), hierarchyCallback.capture());
+        spy.selectDesiredHierarchy(hierarchyTreeMock, selectedHierarchyMock);
+        verify(spy, times(0)).doSelectHierarchy(hierarchyTreeMock, selectedHierarchyMock);
+    }
 
-        hierarchyCallback.getValue().onSuccess(hierarchyMock);
-        verify(ontologyUtilMock).addUnclassifiedChild(eq(hierarchyMock));
-        verify(unclassifiedHierarchiesMock).add(eq(unclassifiedMock));
-        verify(ontologyUtilMock).getOrCreateHierarchyPathTag(hierarchyMock);
-        verify(spy).addHierarchies(eq(hierarchyTreeStoreMock), isNull(OntologyHierarchy.class), eq(hierarchyListMock));
-        verify(hierarchyTreeMock).unmask();
+    @Test
+    public void testDoSelectHierarchy_hierarchyNotFound() {
+        OntologyHierarchy selectedHierarchyMock = mock(OntologyHierarchy.class);
+        OntologyHierarchiesPresenterImpl spy = spy(uut);
+
+        /*** CALL METHOD UNDER TEST ***/
+        assertFalse(spy.doSelectHierarchy(hierarchyTreeMock, selectedHierarchyMock));
+    }
+
+    @Test
+    public void testDoSelectHierarchy_hierarchyFound() {
+        OntologyHierarchiesPresenterImpl spy = spy(uut);
+
+        /*** CALL METHOD UNDER TEST ***/
+        assertTrue(spy.doSelectHierarchy(hierarchyTreeMock, hierarchyMock));
     }
 }

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImplTest.java
@@ -43,6 +43,7 @@ import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.widgets.DETabPanel;
 
+import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.inject.client.AsyncProvider;
 import com.google.gwt.query.client.Function;
@@ -290,11 +291,7 @@ public class OntologyHierarchiesPresenterImplTest {
                                           anyString(),
                                           eq(hierarchyTreeStoreMock),
                                           eq(categoryTreeStoreMock),
-                                          Matchers.<AppFavoriteSelectedEvent.AppFavoriteSelectedEventHandler>any(),
-                                          Matchers.<AppRatingSelected.AppRatingSelectedHandler>any(),
-                                          Matchers.<AppRatingDeselected.AppRatingDeselectedHandler>any(),
-                                          Matchers.<DetailsHierarchyClicked.DetailsHierarchyClickedHandler>any(),
-                                          Matchers.<DetailsCategoryClicked.DetailsCategoryClickedHandler>any());
+                                          Matchers.<EventHandler>any());
 
         verifyNoMoreInteractions(ontologyServiceMock, appUserServiceMock, ontologyUtilMock);
 
@@ -325,11 +322,7 @@ public class OntologyHierarchiesPresenterImplTest {
                                           anyString(),
                                           eq(hierarchyTreeStoreMock),
                                           eq(categoryTreeStoreMock),
-                                          Matchers.<AppFavoriteSelectedEvent.AppFavoriteSelectedEventHandler>any(),
-                                          Matchers.<AppRatingSelected.AppRatingSelectedHandler>any(),
-                                          Matchers.<AppRatingDeselected.AppRatingDeselectedHandler>any(),
-                                          Matchers.<DetailsHierarchyClicked.DetailsHierarchyClickedHandler>any(),
-                                          Matchers.<DetailsCategoryClicked.DetailsCategoryClickedHandler>any());
+                                          Matchers.<EventHandler>any());
 
         verifyNoMoreInteractions(ontologyServiceMock, appUserServiceMock, ontologyUtilMock);
     }
@@ -356,11 +349,7 @@ public class OntologyHierarchiesPresenterImplTest {
                                           anyString(),
                                           eq(hierarchyTreeStoreMock),
                                           eq(categoryTreeStoreMock),
-                                          Matchers.<AppFavoriteSelectedEvent.AppFavoriteSelectedEventHandler>any(),
-                                          Matchers.<AppRatingSelected.AppRatingSelectedHandler>any(),
-                                          Matchers.<AppRatingDeselected.AppRatingDeselectedHandler>any(),
-                                          Matchers.<DetailsHierarchyClicked.DetailsHierarchyClickedHandler>any(),
-                                          Matchers.<DetailsCategoryClicked.DetailsCategoryClickedHandler>any());
+                                          Matchers.<EventHandler>any());
 
         verifyNoMoreInteractions(ontologyServiceMock, appUserServiceMock, ontologyUtilMock);
 

--- a/iplant/modules.gradle
+++ b/iplant/modules.gradle
@@ -62,6 +62,7 @@ project(':de-lib') {
         compile("org.springframework.security:spring-security-core:3.2.7.RELEASE")
         compile("org.springframework.security:spring-security-cas:3.2.7.RELEASE")
         compile('net.logstash.logback:logstash-logback-encoder:4.3')
+        compile("com.googlecode.gwtquery:gwtquery:1.4.2")
 
         testCompile "com.google.gwt.gwtmockito:gwtmockito:$gwtMockitoVer"
         testCompile "org.skyscreamer:jsonassert:1.3.0"


### PR DESCRIPTION
This is basically a dupe of PR#26, but instead of keeping track of the multiple callbacks for the filtered hierarchies with a "parent" callback, GwtQuery's Promises are taking care of that for me.

The code is pretty much identical, so I'm not entirely sure if it's worth adding another library, but I haven't investigated other areas where we could benefit from Promises.  I haven't fully flushed out how to test with Mockito and promises, but it seems a little bit trickier so far.

Not in this PR but as a note: there are some cleaner things you can do with DOM manipulation for setting hard-to-get static IDs as well.