### PR TITLE
CORE-8362 quick-fix: ignore the referer's path when it's /, to avoid redirect loop

### DIFF
--- a/de-webapp/src/main/java/org/iplantc/de/server/controllers/DeController.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/controllers/DeController.java
@@ -39,11 +39,13 @@ public class DeController {
          * Sometimes a login attempt will redirect to "/".
          * If there is a "referer" header, redirect to its path. Otherwise, default to redirecting
          * to "/de/".
+	 *
+	 * Ignore a referer path of "/" since it produces a redirect loop.
          */
         if(!Strings.isNullOrEmpty(referer)){
                 url = new URL(referer);
-            if(!Strings.isNullOrEmpty(url.getPath())){
-                return "redirect:" + url.getPath();
+            if(!Strings.isNullOrEmpty(url.getFile()) && url.getPath() != "/"){
+                return "redirect:" + url.getFile();
             }
         }
         return "redirect:de/";


### PR DESCRIPTION
I'm also changing it to use `url.getFile()` because that includes the query string. But the main part is ignoring it when the path is `/`, so we don't produce a redirect loop.