### PR TITLE
Core 6529 drag-n-drop not clearing previous selection if you try to select a "red" file/folder

### DIFF
--- a/de-lib/src/main/java/com/sencha/gxt/widget/core/client/grid/LiveGridCheckBoxSelectionModel.java
+++ b/de-lib/src/main/java/com/sencha/gxt/widget/core/client/grid/LiveGridCheckBoxSelectionModel.java
@@ -111,9 +111,6 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
 
     @Override
     public boolean isSelected(final DiskResource item) {
-/*        if (item.isFilter()) {
-            return false;
-        }*/
         // It is selected if it is in the selection or select all is checked
         final ModelKeyProvider<? super DiskResource> keyProvider = store.getKeyProvider();
         final String itemKey = keyProvider.getKey(item);
@@ -171,9 +168,6 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
             doDeselect(new ArrayList<>(selected), true);
         }
         for (DiskResource m : models) {
-/*            if (m.isFilter()) {
-                continue;
-            }*/
             boolean isSelected = isSelected(m);
             if (!suppressEvent && !isSelected) {
                 BeforeSelectionEvent<DiskResource> evt = BeforeSelectionEvent.fire(this, m);
@@ -206,12 +200,9 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
 
     @Override
     protected void doSingleSelect(DiskResource model, boolean suppressEvent) {
-        if (locked)
+        if (locked) {
             return;
-
-/*        if (model.isFilter())
-            return;*/
-
+        }
         int index = -1;
         if (store instanceof ListStore) {
             ListStore<DiskResource> ls = (ListStore<DiskResource>) store;
@@ -270,32 +261,16 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
 
     @Override
     protected void onRowClick(RowClickEvent event) {
-        // Prevent selections of filtered items
-        DiskResource model = listStore.get(event.getRowIndex());
-/*        if ((model != null) && model.isFilter()) {
-            return;
-        }*/
-
         super.onRowClick(event);
     }
 
     @Override
     protected void onRowMouseDown(RowMouseDownEvent event) {
-        // Prevent selections of filtered items
-        DiskResource model = listStore.get(event.getRowIndex());
-/*        if ((model != null) && model.isFilter()) {
-            return;
-        }*/
-
         super.onRowMouseDown(event);
     }
 
     @Override
     protected void onSelectChange(DiskResource model, boolean select) {
-        // Prevent selections of filtered items
-/*        if (model.isFilter()) {
-            return;
-        }*/
         super.onSelectChange(model, select);
     }
 

--- a/de-lib/src/main/java/com/sencha/gxt/widget/core/client/grid/LiveGridCheckBoxSelectionModel.java
+++ b/de-lib/src/main/java/com/sencha/gxt/widget/core/client/grid/LiveGridCheckBoxSelectionModel.java
@@ -1,8 +1,9 @@
 package com.sencha.gxt.widget.core.client.grid;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.iplantc.de.client.models.diskResources.DiskResource;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -22,7 +23,6 @@ import com.sencha.gxt.widget.core.client.event.RowMouseDownEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import javax.annotation.Nullable;
 
 /**
@@ -111,9 +111,9 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
 
     @Override
     public boolean isSelected(final DiskResource item) {
-        if (item.isFilter()) {
+/*        if (item.isFilter()) {
             return false;
-        }
+        }*/
         // It is selected if it is in the selection or select all is checked
         final ModelKeyProvider<? super DiskResource> keyProvider = store.getKeyProvider();
         final String itemKey = keyProvider.getKey(item);
@@ -171,9 +171,9 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
             doDeselect(new ArrayList<>(selected), true);
         }
         for (DiskResource m : models) {
-            if (m.isFilter()) {
+/*            if (m.isFilter()) {
                 continue;
-            }
+            }*/
             boolean isSelected = isSelected(m);
             if (!suppressEvent && !isSelected) {
                 BeforeSelectionEvent<DiskResource> evt = BeforeSelectionEvent.fire(this, m);
@@ -209,8 +209,8 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
         if (locked)
             return;
 
-        if (model.isFilter())
-            return;
+/*        if (model.isFilter())
+            return;*/
 
         int index = -1;
         if (store instanceof ListStore) {
@@ -272,9 +272,9 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
     protected void onRowClick(RowClickEvent event) {
         // Prevent selections of filtered items
         DiskResource model = listStore.get(event.getRowIndex());
-        if ((model != null) && model.isFilter()) {
+/*        if ((model != null) && model.isFilter()) {
             return;
-        }
+        }*/
 
         super.onRowClick(event);
     }
@@ -283,9 +283,9 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
     protected void onRowMouseDown(RowMouseDownEvent event) {
         // Prevent selections of filtered items
         DiskResource model = listStore.get(event.getRowIndex());
-        if ((model != null) && model.isFilter()) {
+/*        if ((model != null) && model.isFilter()) {
             return;
-        }
+        }*/
 
         super.onRowMouseDown(event);
     }
@@ -293,9 +293,9 @@ public class LiveGridCheckBoxSelectionModel extends CheckBoxSelectionModel<DiskR
     @Override
     protected void onSelectChange(DiskResource model, boolean select) {
         // Prevent selections of filtered items
-        if (model.isFilter()) {
+/*        if (model.isFilter()) {
             return;
-        }
+        }*/
         super.onSelectChange(model, select);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
@@ -454,4 +454,14 @@ public class DiskResourceUtil {
         StringQuoter.create(infoType).assign(s, DiskResource.INFO_TYPE_KEY);
         return s;
     }
+
+    public boolean containsFilteredItems(List<? extends DiskResource> diskResources) {
+        for (DiskResource dr : diskResources) {
+            if (dr.isFilter()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
@@ -456,6 +456,9 @@ public class DiskResourceUtil {
     }
 
     public boolean containsFilteredItems(List<? extends DiskResource> diskResources) {
+        if(diskResources == null || diskResources.size() == 0) {
+            return false;
+        }
         for (DiskResource dr : diskResources) {
             if (dr.isFilter()) {
                 return true;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -272,15 +272,10 @@ public class GridViewPresenterImpl implements
     @Override
     public void onDiskResourceSelectionChanged(DiskResourceSelectionChangedEvent event) {
         final List<DiskResource> selection = event.getSelection();
-        if (selection.size() != 1) {
+        if (selection == null || selection.size() != 1 || selection.iterator().next().isFilter()) {
             // Only call get stat for single selections
             return;
         }
-
-        if(selection.size() > 0 && selection.iterator().next().isFilter()) {
-            return;
-        }
-
         fetchDetails(selection.iterator().next());
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -276,6 +276,11 @@ public class GridViewPresenterImpl implements
             // Only call get stat for single selections
             return;
         }
+
+        if(selection.size() > 0 && selection.iterator().next().isFilter()) {
+            return;
+        }
+
         fetchDetails(selection.iterator().next());
     }
 
@@ -447,7 +452,9 @@ public class GridViewPresenterImpl implements
                         if (selection != null && selection.size() == 1) {
                             Iterator<DiskResource> it = selection.iterator();
                             DiskResource next = it.next();
-                            fetchDetails(next);
+                            if(!next.isFilter()) {
+                                fetchDetails(next);
+                            }
                         }
                     }
                 });

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/details/DetailsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/details/DetailsViewImpl.java
@@ -179,7 +179,7 @@ public class DetailsViewImpl extends Composite implements DetailsView,
     @Override
     public void onDiskResourceSelectionChanged(DiskResourceSelectionChangedEvent event) {
         if (event.getSelection().isEmpty()
-                || event.getSelection().size() != 1) {
+                || event.getSelection().size() != 1 || event.getSelection().get(0).isFilter()) {
             bind(null);
             // Hide table
             table.addClassName(appearance.css().hidden());
@@ -221,7 +221,9 @@ public class DetailsViewImpl extends Composite implements DetailsView,
         }
 
         bind(singleSelection);
-        tagsPresenter.fetchTagsForResource(singleSelection);
+        if(!singleSelection.isFilter())  {
+            tagsPresenter.fetchTagsForResource(singleSelection);
+        }
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileFolderSelectDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileFolderSelectDialog.java
@@ -104,7 +104,7 @@ public class FileFolderSelectDialog extends IPlantDialog implements TakesValue<L
         final FieldLabel fl = new FieldLabel(selectedItemTextField, appearance.selectorFieldLabel());
         presenter = presenterFactory.filtered(true,
                                               true,
- singleSelect,// Single select
+                                              singleSelect,// Single select
                                               true,
                                               folderToSelect,
                                               infoTypeFilters,

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileSelectDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileSelectDialog.java
@@ -153,7 +153,7 @@ public class FileSelectDialog extends IPlantDialog implements TakesValue<List<Fi
     @Override
     public void setValue(List<File> value) {
         this.selectedFileIds = value;
-        if(value.isEmpty()){
+        if(value.isEmpty() || diskResourceUtil.containsFilteredItems(value)) {
             selectedFileField.clear();
             getOkButton().setEnabled(false);
             return;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FolderSelectDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FolderSelectDialog.java
@@ -5,6 +5,7 @@ import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.models.diskResources.TYPE;
 import org.iplantc.de.client.models.viewer.InfoType;
+import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 import org.iplantc.de.diskResource.client.DiskResourceView;
 import org.iplantc.de.diskResource.client.events.DiskResourceSelectionChangedEvent;
@@ -18,6 +19,7 @@ import com.google.inject.Inject;
 import com.sencha.gxt.widget.core.client.form.FieldLabel;
 import com.sencha.gxt.widget.core.client.form.TextField;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -105,6 +107,8 @@ public class FolderSelectDialog extends IPlantDialog implements TakesValue<Folde
     private DiskResourceView.Presenter presenter;
     private Folder selectedFolder;
     private final TextField selectedFolderTextField;
+    @Inject
+    DiskResourceUtil diskResourceUtil;
 
     @Inject
     FolderSelectDialog(final DiskResourcePresenterFactory presenterFactory,
@@ -163,7 +167,7 @@ public class FolderSelectDialog extends IPlantDialog implements TakesValue<Folde
     @Override
     public void setValue(Folder value) {
         this.selectedFolder = value;
-        if(value == null){
+        if(value == null || diskResourceUtil.containsFilteredItems(Arrays.asList(value))){
             selectedFolderTextField.clear();
             getOkButton().setEnabled(false);
             return;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/grid/GridViewDnDHandler.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/grid/GridViewDnDHandler.java
@@ -92,7 +92,7 @@ class GridViewDnDHandler implements DndDragStartHandler,
         List<? extends DiskResource> dragData = getDragSources(dragStartEl);
 
         if (dragData.isEmpty()
-                || containsFilteredItems(dragData)) {
+               || diskResourceUtil.containsFilteredItems(dragData)) {
             // Cancel drag
             event.setCancelled(true);
         } else {
@@ -156,15 +156,6 @@ class GridViewDnDHandler implements DndDragStartHandler,
         return true;
     }
 
-    private boolean containsFilteredItems(List<? extends DiskResource> dragData) {
-        for (DiskResource dr : dragData) {
-            if (dr.isFilter()) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     private void doMoveDiskResources(Folder targetFolder, List<DiskResource> resources) {
         presenter.doMoveDiskResources(targetFolder, resources);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/grid/GridViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/grid/GridViewImpl.java
@@ -171,8 +171,7 @@ public class GridViewImpl extends ContentPanel implements GridView,
     @Override
     public void onFolderSelected(FolderSelectionEvent event) {
         final Folder selectedItem = event.getSelectedFolder();
-        if (selectedItem == null
-                || selectedItem.isFilter()) {
+        if (selectedItem == null || selectedItem.isFilter()) {
             return;
         }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/grid/GridViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/grid/GridViewImpl.java
@@ -1,5 +1,7 @@
 package org.iplantc.de.diskResource.client.views.grid;
 
+import static com.sencha.gxt.core.client.Style.SelectionMode.SINGLE;
+
 import org.iplantc.de.client.models.HasPath;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.DiskResourceFavorite;
@@ -30,7 +32,6 @@ import com.google.gwt.uibinder.client.UiHandler;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
-import static com.sencha.gxt.core.client.Style.SelectionMode.SINGLE;
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.data.shared.loader.BeforeLoadEvent;
 import com.sencha.gxt.data.shared.loader.PagingLoadResult;
@@ -201,7 +202,6 @@ public class GridViewImpl extends ContentPanel implements GridView,
     @Override
     public void onSelectionChanged(SelectionChangedEvent<DiskResource> event) {
         updateSelectionCount(sm.getSelectedCount());
-
         fireEvent(new DiskResourceSelectionChangedEvent(event.getSelection()));
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar.ui.xml
@@ -50,9 +50,6 @@
                         <menu:MenuItem ui:field="newFolderMi"
                                        text="{appearance.newFolderMenuItem}"
                                        icon="{appearance.newFolderIcon}"/>
-                        <menu:MenuItem ui:field="duplicateMi"
-                                       text="{appearance.duplicateMenuItem}" enabled="false"
-                                       visible="false"/>
                         <menu:MenuItem ui:field="newFileMi" text="{appearance.newFileMenu}"
                                        icon="{appearance.newFileMenuIcon}">
                             <menu:submenu>

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbarImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbarImpl.java
@@ -270,6 +270,7 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
         boolean restoreMiEnabled;
 
         selectedDiskResources = event.getSelection();
+        final boolean containsFilteredItems = diskResourceUtil.containsFilteredItems(selectedDiskResources);
         final boolean isSelectionEmpty = selectedDiskResources.isEmpty();
         final boolean isSingleSelection = selectedDiskResources.size() == 1;
         final boolean isOwner = isOwnerList(selectedDiskResources);
@@ -280,45 +281,48 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
         final boolean isFolderSelect = !isSelectionEmpty
                                        && firstItem instanceof Folder;
 
-        duplicateMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash;
-        moveToTrashMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash;
+        duplicateMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash && !containsFilteredItems;
+        moveToTrashMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash && !containsFilteredItems;
 
-        renameMiEnabled = !isSelectionEmpty && isSingleSelection && isOwner && !isSelectionInTrash;
-        moveMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash;
-        deleteMiEnabled = !isSelectionEmpty && isOwner;
+        renameMiEnabled = !isSelectionEmpty && isSingleSelection && isOwner && !isSelectionInTrash && !containsFilteredItems;
+        moveMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash && !containsFilteredItems;
+        deleteMiEnabled = !isSelectionEmpty && isOwner && !containsFilteredItems;
         editFileMiEnabled = !isSelectionEmpty && isSingleSelection
-                && containsFile(selectedDiskResources) && isOwner && !isSelectionInTrash;
+                && containsFile(selectedDiskResources) && isOwner && !isSelectionInTrash && !containsFilteredItems;
         editCommentsMiEnabled = !isSelectionEmpty && isSingleSelection && !isSelectionInTrash
-                && isReadable;
+                && isReadable && !containsFilteredItems;
         editInfoTypeMiEnabled = !isSelectionEmpty && isSingleSelection && !isSelectionInTrash
-                && containsFile(selectedDiskResources) && isOwner;
-        metadataMiEnabled = !isSelectionEmpty && isSingleSelection && !isSelectionInTrash;
+                && containsFile(selectedDiskResources) && isOwner && !containsFilteredItems;
+        metadataMiEnabled = !isSelectionEmpty && isSingleSelection && !isSelectionInTrash && !containsFilteredItems;
 
-        simpleDownloadMiEnabled = !isSelectionEmpty && containsFile(selectedDiskResources);
-        bulkDownloadMiEnabled = !isSelectionEmpty;
+        simpleDownloadMiEnabled = !isSelectionEmpty && containsFile(selectedDiskResources) && !containsFilteredItems;
+        bulkDownloadMiEnabled = !isSelectionEmpty && !containsFilteredItems;
         sendToCogeMiEnabled = !isSelectionEmpty
                 && isSingleSelection
                 && containsFile(selectedDiskResources)
                 && !isSelectionInTrash
-                && diskResourceUtil.isGenomeVizInfoType(getInfoTypeFromSingletonCollection(selectedDiskResources));
+                && diskResourceUtil.isGenomeVizInfoType(getInfoTypeFromSingletonCollection(selectedDiskResources))
+                && !containsFilteredItems;
         sendToEnsemblMiEnabled = !isSelectionEmpty
                 && isSingleSelection
                 && containsFile(selectedDiskResources)
                 && !isSelectionInTrash
-                && diskResourceUtil.isEnsemblInfoType(getInfoTypeFromSingletonCollection(selectedDiskResources));
+                && diskResourceUtil.isEnsemblInfoType(getInfoTypeFromSingletonCollection(selectedDiskResources))
+                && !containsFilteredItems;
         sendToTreeViewerMiEnabled = !isSelectionEmpty
                 && isSingleSelection
                 && containsFile(selectedDiskResources)
                 && !isSelectionInTrash
-                && diskResourceUtil.isTreeInfoType(getInfoTypeFromSingletonCollection(selectedDiskResources));
+                && diskResourceUtil.isTreeInfoType(getInfoTypeFromSingletonCollection(selectedDiskResources))
+                && !containsFilteredItems;
 
-        shareWithCollaboratorsMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash;
+        shareWithCollaboratorsMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash && !containsFilteredItems;
         createPublicLinkMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash
-                && containsFile(selectedDiskResources);
+                && containsFile(selectedDiskResources) && !containsFilteredItems;
         shareFolderLocationMiEnabled = !isSelectionEmpty && isSingleSelection && !isSelectionInTrash
-                && containsOnlyFolders(selectedDiskResources);
+                && containsOnlyFolders(selectedDiskResources) && !containsFilteredItems;
 
-        restoreMiEnabled = !isSelectionEmpty && isSelectionInTrash && isOwner;
+        restoreMiEnabled = !isSelectionEmpty && isSelectionInTrash && isOwner && !containsFilteredItems;
 
         duplicateMi.setEnabled(duplicateMiEnabled);
         moveToTrashMi.setEnabled(moveToTrashMiEnabled);
@@ -363,24 +367,25 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
     @Override
     public void onFolderSelected(FolderSelectionEvent event) {
         boolean simpleUploadMiEnabled, bulkUploadMiEnabled, importFromUrlMiEnabled;
-
         boolean newFolderMiEnabled, newPlainTextFileMiEnabled, newTabularDataFileMiEnabled;
         boolean refreshButtonEnabled;
 
         selectedFolder = event.getSelectedFolder();
+        final boolean containsFilteredItems = diskResourceUtil.containsFilteredItems(selectedDiskResources);
         final boolean isFolderInTrash = isSelectionInTrash(Lists.<DiskResource> newArrayList(selectedFolder));
         final boolean isNull = selectedFolder == null;
-        final boolean canUploadTo = canUploadTo(selectedFolder);
+        final boolean canUploadTo = canUploadTo(selectedFolder) && !containsFilteredItems;
 
-        simpleUploadMiEnabled = !isFolderInTrash && (isNull || canUploadTo);
-        bulkUploadMiEnabled = !isFolderInTrash && (isNull || canUploadTo);
-        importFromUrlMiEnabled = !isFolderInTrash && (isNull || canUploadTo);
+
+        simpleUploadMiEnabled = !isFolderInTrash && (isNull || canUploadTo) && !containsFilteredItems;
+        bulkUploadMiEnabled = !isFolderInTrash && (isNull || canUploadTo) && !containsFilteredItems;
+        importFromUrlMiEnabled = !isFolderInTrash && (isNull || canUploadTo) && !containsFilteredItems;
 
         newFolderMiEnabled = isNull || canUploadTo;
         newPlainTextFileMiEnabled = isNull || canUploadTo;
         newTabularDataFileMiEnabled = isNull || canUploadTo;
 
-        refreshButtonEnabled = !isNull;
+        refreshButtonEnabled = !isNull && !containsFilteredItems;
 
         simpleUploadMi.setEnabled(simpleUploadMiEnabled);
         bulkUploadMi.setEnabled(bulkUploadMiEnabled);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbarImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbarImpl.java
@@ -89,7 +89,7 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
     @UiField
     MenuItem newPathListMi;
     @UiField
-    MenuItem newWindowMi, newWindowAtLocMi, newFolderMi, duplicateMi, newPlainTextFileMi,
+    MenuItem newWindowMi, newWindowAtLocMi, newFolderMi, newPlainTextFileMi,
             newTabularDataFileMi, moveToTrashMi, newRFileMi, newPerlFileMi, newPythonFileMi,
             newShellScriptFileMi, newMdFileMi;
     @UiField
@@ -257,7 +257,7 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
     @Override
     public void onDiskResourceSelectionChanged(DiskResourceSelectionChangedEvent event) {
 
-        boolean duplicateMiEnabled, addToSideBarMiEnabled, moveToTrashMiEnabled;
+        boolean addToSideBarMiEnabled, moveToTrashMiEnabled;
 
         boolean renameMiEnabled, moveMiEnabled, deleteMiEnabled, editFileMiEnabled, editCommentsMiEnabled
                 ,editInfoTypeMiEnabled, metadataMiEnabled;
@@ -281,7 +281,6 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
         final boolean isFolderSelect = !isSelectionEmpty
                                        && firstItem instanceof Folder;
 
-        duplicateMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash && !containsFilteredItems;
         moveToTrashMiEnabled = !isSelectionEmpty && isOwner && !isSelectionInTrash && !containsFilteredItems;
 
         renameMiEnabled = !isSelectionEmpty && isSingleSelection && isOwner && !isSelectionInTrash && !containsFilteredItems;
@@ -324,9 +323,7 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
 
         restoreMiEnabled = !isSelectionEmpty && isSelectionInTrash && isOwner && !containsFilteredItems;
 
-        duplicateMi.setEnabled(duplicateMiEnabled);
         moveToTrashMi.setEnabled(moveToTrashMiEnabled);
-
         renameMi.setEnabled(renameMiEnabled);
         moveMi.setEnabled(moveMiEnabled);
         deleteMi.setEnabled(deleteMiEnabled);
@@ -428,10 +425,6 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
     @UiHandler("deleteMi")
     void onDeleteClicked(SelectionEvent<Item> event) {
         fireEvent(new DeleteDiskResourcesSelected(selectedDiskResources));
-    }
-
-    @UiHandler("duplicateMi")
-    void onDuplicateClicked(SelectionEvent<Item> event) {/* Do Nothing */
     }
 
     @UiHandler("editCommentsMi")
@@ -726,7 +719,6 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
         newWindowMi.ensureDebugId(baseID + Ids.FILE_MENU + Ids.MENU_ITEM_NEW_WINDOW);
         newWindowAtLocMi.ensureDebugId(baseID + Ids.FILE_MENU + Ids.MENU_ITEM_NEW_WINDOW_AT_LOC);
         newFolderMi.ensureDebugId(baseID + Ids.FILE_MENU + Ids.MENU_ITEM_NEW_FOLDER);
-        duplicateMi.ensureDebugId(baseID + Ids.FILE_MENU + Ids.MENU_ITEM_DUPLICATE);
         newPlainTextFileMi.ensureDebugId(baseID + Ids.FILE_MENU + Ids.MENU_ITEM_NEW_PLAIN_TEXT);
         newTabularDataFileMi.ensureDebugId(baseID + Ids.FILE_MENU + Ids.MENU_ITEM_NEW_TABULAR_DATA);
         createNcbiSraMi.ensureDebugId(baseID + Ids.FILE_MENU + Ids.MENU_ITEM_NCBI_SRA);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FileSelectorField.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FileSelectorField.java
@@ -27,6 +27,7 @@ import com.sencha.gxt.dnd.core.client.StatusProxy;
 import com.sencha.gxt.widget.core.client.event.HideEvent;
 import com.sencha.gxt.widget.core.client.event.HideEvent.HideHandler;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -51,10 +52,11 @@ public class FileSelectorField extends AbstractDiskResourceSelector<File> {
 
         @Override
         public void onHide(HideEvent event) {
-            if ((takesValue.getValue() == null) || takesValue.getValue().isEmpty())
+            if ((takesValue.getValue() == null) || takesValue.getValue().isEmpty()
+                || diskResourceUtil.containsFilteredItems(takesValue.getValue())) {
                 return;
-
-            // This class is single select, so only grab first element
+            }
+           // This class is single select, so only grab first element
             File selectedResource = takesValue.getValue().get(0);
             setSelectedResource(selectedResource);
             // cache the last used path
@@ -109,7 +111,7 @@ public class FileSelectorField extends AbstractDiskResourceSelector<File> {
 
         DiskResource value = getValue();
         final List<DiskResource> selected = (value == null) ? null : Lists.<DiskResource>newArrayList();
-        if (value != null) {
+        if (value != null && !diskResourceUtil.containsFilteredItems(selected)) {
             selected.add(value);
         }
 
@@ -153,7 +155,8 @@ public class FileSelectorField extends AbstractDiskResourceSelector<File> {
     @Override
     protected boolean validateDropStatus(Set<DiskResource> dropData, StatusProxy status) {
         // Only allow 1 file to be dropped in this field.
-        if (dropData == null || dropData.size() != 1 || !(diskResourceUtil.containsFile(dropData))) {
+        if (dropData == null || dropData.size() != 1 || !(diskResourceUtil.containsFile(dropData))
+            || diskResourceUtil.containsFilteredItems(new ArrayList<>(dropData))) {
             status.setStatus(false);
             return false;
         }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FolderSelectorField.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FolderSelectorField.java
@@ -52,7 +52,7 @@ public class FolderSelectorField extends AbstractDiskResourceSelector<Folder> {
         public void onHide(HideEvent event) {
             Folder value = takesValue.getValue();
             if (value == null
-                || diskResourceUtil.containsFilteredItems(Arrays.asList(takesValue.getValue()))) {
+                || diskResourceUtil.containsFilteredItems(Arrays.asList(value))) {
                 return;
             }
             setSelectedResource(value);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FolderSelectorField.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/FolderSelectorField.java
@@ -26,6 +26,7 @@ import com.sencha.gxt.dnd.core.client.StatusProxy;
 import com.sencha.gxt.widget.core.client.event.HideEvent;
 import com.sencha.gxt.widget.core.client.event.HideEvent.HideHandler;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -50,9 +51,10 @@ public class FolderSelectorField extends AbstractDiskResourceSelector<Folder> {
         @Override
         public void onHide(HideEvent event) {
             Folder value = takesValue.getValue();
-            if (value == null)
+            if (value == null
+                || diskResourceUtil.containsFilteredItems(Arrays.asList(takesValue.getValue()))) {
                 return;
-
+            }
             setSelectedResource(value);
             // cache the last used path
             if (userSettings.isRememberLastPath()) {

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/share/DiskResourceModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/share/DiskResourceModule.java
@@ -26,7 +26,6 @@ public interface DiskResourceModule {
         String MENU_ITEM_NEW_WINDOW = ".newWindow";
         String MENU_ITEM_NEW_WINDOW_AT_LOC = ".newWindowLoc";
         String MENU_ITEM_NEW_FOLDER = ".newFolder";
-        String MENU_ITEM_DUPLICATE = ".duplicate";
         String MENU_ITEM_NEW_PLAIN_TEXT = ".newPlainText";
         String MENU_ITEM_NEW_TABULAR_DATA = ".newTabularData";
         String MENU_ITEM_NEW_R_DATA = ".newRData";

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/PathListViewer.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/PathListViewer.java
@@ -93,19 +93,20 @@ public class PathListViewer extends AbstractStructuredTextViewer implements Stor
                                                                      5000));
             }
 
+
         }
 
         @Override
         protected void onDragEnter(DndDragEnterEvent event) {
-            handleDropStatus(event.getDragSource().getData(),
+         /*   handleDropStatus(,
                              event,
-                             event.getStatusProxy());
+                             event.getStatusProxy());*/
         }
 
         @Override
         protected void onDragMove(DndDragMoveEvent event) {
             super.onDragMove(event);
-            handleDropStatus(event.getDragSource().getData(),
+            handleDropStatus(event.getData(),
                              event,
                              event.getStatusProxy());
         }
@@ -143,10 +144,11 @@ public class PathListViewer extends AbstractStructuredTextViewer implements Stor
             Iterable<DiskResource> iterable = (Iterable<DiskResource>) o;
             for(DiskResource dr : iterable){
                 InfoType infoType1 = InfoType.fromTypeString(dr.getInfoType());
-                if(InfoType.HT_ANALYSIS_PATH_LIST.equals(infoType1) || dr.isFilter()){
+                if(InfoType.HT_ANALYSIS_PATH_LIST.equals(infoType1)){
                     cancellableEvent.setCancelled(true);
                     statusProxy.update(appearance.preventPathListDrop());
                     statusProxy.setStatus(false);
+
                     return;
                 }
             }
@@ -155,10 +157,11 @@ public class PathListViewer extends AbstractStructuredTextViewer implements Stor
         }
 
         boolean hasCorrectData(Object data){
-
-            boolean isCollection = data instanceof Collection<?>;
+           boolean isCollection = data instanceof Collection<?>;
             boolean isEmpty = ((Collection<?>) data).isEmpty();
             boolean hasDiskResources = ((Collection<?>) data).iterator().next() instanceof DiskResource;
+            boolean filteredData = false;
+            Iterable<DiskResource> iterable = (Iterable<DiskResource>) data;
             return isCollection
                        && !isEmpty
                        && hasDiskResources;

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/PathListViewer.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/PathListViewer.java
@@ -1,5 +1,8 @@
 package org.iplantc.de.fileViewers.client.views;
 
+import static com.sencha.gxt.dnd.core.client.DND.Feedback.INSERT;
+import static com.sencha.gxt.dnd.core.client.DND.Operation.MOVE;
+
 import org.iplantc.de.client.events.FileSavedEvent;
 import org.iplantc.de.client.models.HasPath;
 import org.iplantc.de.client.models.diskResources.DiskResource;
@@ -11,7 +14,6 @@ import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.fileViewers.client.FileViewer;
 import org.iplantc.de.fileViewers.client.events.DeleteSelectedPathsSelectedEvent;
-import org.iplantc.de.resources.client.messages.I18N;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -21,12 +23,8 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
-import com.google.inject.Inject;
 import com.google.web.bindery.autobean.shared.Splittable;
 import com.google.web.bindery.autobean.shared.impl.StringQuoter;
-
-import static com.sencha.gxt.dnd.core.client.DND.Feedback.INSERT;
-import static com.sencha.gxt.dnd.core.client.DND.Operation.MOVE;
 
 import com.sencha.gxt.core.shared.event.CancellableEvent;
 import com.sencha.gxt.data.shared.event.StoreAddEvent;
@@ -145,7 +143,7 @@ public class PathListViewer extends AbstractStructuredTextViewer implements Stor
             Iterable<DiskResource> iterable = (Iterable<DiskResource>) o;
             for(DiskResource dr : iterable){
                 InfoType infoType1 = InfoType.fromTypeString(dr.getInfoType());
-                if(InfoType.HT_ANALYSIS_PATH_LIST.equals(infoType1)){
+                if(InfoType.HT_ANALYSIS_PATH_LIST.equals(infoType1) || dr.isFilter()){
                     cancellableEvent.setCancelled(true);
                     statusProxy.update(appearance.preventPathListDrop());
                     statusProxy.setStatus(false);

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/PathListViewer.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/PathListViewer.java
@@ -98,9 +98,10 @@ public class PathListViewer extends AbstractStructuredTextViewer implements Stor
 
         @Override
         protected void onDragEnter(DndDragEnterEvent event) {
-         /*   handleDropStatus(,
+           super.onDragEnter(event);
+           handleDropStatus(event.getDragSource().getData(),
                              event,
-                             event.getStatusProxy());*/
+                             event.getStatusProxy());
         }
 
         @Override
@@ -160,8 +161,6 @@ public class PathListViewer extends AbstractStructuredTextViewer implements Stor
            boolean isCollection = data instanceof Collection<?>;
             boolean isEmpty = ((Collection<?>) data).isEmpty();
             boolean hasDiskResources = ((Collection<?>) data).iterator().next() instanceof DiskResource;
-            boolean filteredData = false;
-            Iterable<DiskResource> iterable = (Iterable<DiskResource>) data;
             return isCollection
                        && !isEmpty
                        && hasDiskResources;

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onDiskResourceSelectionChangedTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onDiskResourceSelectionChangedTest.java
@@ -1,6 +1,15 @@
 package org.iplantc.de.diskResource.client.views.toolbar;
 
-import static org.iplantc.de.client.models.diskResources.PermissionValue.*;
+import static org.iplantc.de.client.models.diskResources.PermissionValue.own;
+import static org.iplantc.de.client.models.diskResources.PermissionValue.read;
+import static org.iplantc.de.client.models.diskResources.PermissionValue.write;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.File;
@@ -17,8 +26,6 @@ import com.google.gwtmockito.GxtMockitoTestRunner;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.menu.MenuItem;
 
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +41,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
     @Mock public MenuItem mockNewWindow,
             mockNewWindowAtLoc,
             mockNewFolder,
-            mockDuplicate,
             mockNewPlainTextFile,
             mockNewTabularFile,
             mockMoveToTrash;
@@ -139,7 +145,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -193,7 +198,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -251,7 +255,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -307,7 +310,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(true);
         verify(mockMoveToTrash).setEnabled(true);
 
         // Edit Menu Items
@@ -363,7 +365,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -419,7 +420,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -475,7 +475,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -532,7 +531,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -588,7 +586,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -645,7 +642,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(true);
         verify(mockMoveToTrash).setEnabled(true);
 
         // Edit Menu Items
@@ -700,7 +696,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -757,7 +752,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -814,7 +808,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -875,7 +868,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -934,7 +926,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -994,7 +985,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(true);
         verify(mockMoveToTrash).setEnabled(true);
 
         // Edit Menu Items
@@ -1062,7 +1052,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1121,7 +1110,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1180,7 +1168,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1246,7 +1233,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1305,7 +1291,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1364,7 +1349,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(true);
         verify(mockMoveToTrash).setEnabled(true);
 
         // Edit Menu Items
@@ -1389,6 +1373,165 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
 
         // Share Menu Items
         verify(mockShareWithCollabs).setEnabled(true);
+        verify(mockCreatePublicLink).setEnabled(false);
+        verify(mockShareFolderLocation).setEnabled(false);
+        verify(mockSendToCoge).setEnabled(false);
+        verify(mockSendToEnsembl).setEnabled(false);
+        verify(mockSendToTreeViewer).setEnabled(false);
+
+        // Trash Menu Items
+        verify(mockRestore).setEnabled(false);
+    }
+
+    @Test public void testOnDiskResourceSelectionChanged_redFolderSelected() {
+        this.isSelectionInTrash = false;
+        Folder redMockFolder1 = mock(Folder.class);
+        redMockFolder1.setFilter(true);
+        // Setup mock event
+        DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
+        final ArrayList<DiskResource> selection = Lists.newArrayList();
+        selection.add(redMockFolder1);
+        when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFilteredItems(selection)).thenReturn(true);
+          /*=================== Own ====================*/
+        this.isSelectionOwner = true;
+        this.containsOnlyFolders = true;
+        when(redMockFolder1.getPermission()).thenReturn(own);
+        uut.onDiskResourceSelectionChanged(mockEvent);
+        verifyOnDiskResourceSelectionChangedNeverUsedItems();
+
+        // File Menu Items
+        verify(mockMoveToTrash).setEnabled(false);
+
+        // Edit Menu Items
+        verify(mockRename).setEnabled(false);
+        verify(mockMove).setEnabled(false);
+        verify(mockDelete).setEnabled(false);
+        verify(mockEditFile).setEnabled(false);
+        verify(mockEditComments).setEnabled(false);
+        verify(mockEditInfoType).setEnabled(false);
+
+        //  verify(mockMetadata).setEnabled(false);
+        verify(mockSavemetadatami).setEnabled(false);
+        verify(mockCopymetadataMi).setEnabled(false);
+        verify(mockEditmetadataMi).setEnabled(false);
+        verify(mockBulkmetadataMi).setEnabled(false);
+        verify(mockSelectmetadataMi).setEnabled(false);
+        verify(mockDoiMi).setEnabled(false);
+
+        // Download Menu Items
+        verify(mockSimpleDownload).setEnabled(false);
+        verify(mockBulkDownload).setEnabled(false);
+
+        // Share Menu Items
+        verify(mockShareWithCollabs).setEnabled(false);
+        verify(mockCreatePublicLink).setEnabled(false);
+        verify(mockShareFolderLocation).setEnabled(false);
+        verify(mockSendToCoge).setEnabled(false);
+        verify(mockSendToEnsembl).setEnabled(false);
+        verify(mockSendToTreeViewer).setEnabled(false);
+
+        // Trash Menu Items
+        verify(mockRestore).setEnabled(false);
+    }
+
+    @Test public void testOnDiskResourceSelectionChanged_redFileSelected() {
+        this.isSelectionInTrash = false;
+        File redMockFile1 = mock(File.class);
+        redMockFile1.setFilter(true);
+        // Setup mock event
+        DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
+        final ArrayList<DiskResource> selection = Lists.newArrayList();
+        selection.add(redMockFile1);
+        when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFilteredItems(selection)).thenReturn(true);
+          /*=================== Own ====================*/
+        this.isSelectionOwner = true;
+        this.containsOnlyFolders = false;
+        when(redMockFile1.getPermission()).thenReturn(own);
+        uut.onDiskResourceSelectionChanged(mockEvent);
+        verifyOnDiskResourceSelectionChangedNeverUsedItems();
+
+        // File Menu Items
+        verify(mockMoveToTrash).setEnabled(false);
+
+        // Edit Menu Items
+        verify(mockRename).setEnabled(false);
+        verify(mockMove).setEnabled(false);
+        verify(mockDelete).setEnabled(false);
+        verify(mockEditFile).setEnabled(false);
+        verify(mockEditComments).setEnabled(false);
+        verify(mockEditInfoType).setEnabled(false);
+
+        //  verify(mockMetadata).setEnabled(false);
+        verify(mockSavemetadatami).setEnabled(false);
+        verify(mockCopymetadataMi).setEnabled(false);
+        verify(mockEditmetadataMi).setEnabled(false);
+        verify(mockBulkmetadataMi).setEnabled(false);
+        verify(mockSelectmetadataMi).setEnabled(false);
+        verify(mockDoiMi).setEnabled(false);
+
+        // Download Menu Items
+        verify(mockSimpleDownload).setEnabled(false);
+        verify(mockBulkDownload).setEnabled(false);
+
+        // Share Menu Items
+        verify(mockShareWithCollabs).setEnabled(false);
+        verify(mockCreatePublicLink).setEnabled(false);
+        verify(mockShareFolderLocation).setEnabled(false);
+        verify(mockSendToCoge).setEnabled(false);
+        verify(mockSendToEnsembl).setEnabled(false);
+        verify(mockSendToTreeViewer).setEnabled(false);
+
+        // Trash Menu Items
+        verify(mockRestore).setEnabled(false);
+    }
+
+    @Test public void testOnDiskResourceSelectionChanged_redFileMixedSelected() {
+        this.isSelectionInTrash = false;
+        File redMockFile1 = mock(File.class);
+        redMockFile1.setFilter(true);
+        File mockFile2 = mock(File.class);
+        mockFile2.setFilter(false);
+        // Setup mock event
+        DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
+        final ArrayList<DiskResource> selection = Lists.newArrayList();
+        selection.add(redMockFile1);
+        selection.add(mockFile2);
+        when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFilteredItems(selection)).thenReturn(true);
+          /*=================== Own ====================*/
+        this.isSelectionOwner = true;
+        this.containsOnlyFolders = false;
+        when(redMockFile1.getPermission()).thenReturn(own);
+        uut.onDiskResourceSelectionChanged(mockEvent);
+        verifyOnDiskResourceSelectionChangedNeverUsedItems();
+
+        // File Menu Items
+        verify(mockMoveToTrash).setEnabled(false);
+
+        // Edit Menu Items
+        verify(mockRename).setEnabled(false);
+        verify(mockMove).setEnabled(false);
+        verify(mockDelete).setEnabled(false);
+        verify(mockEditFile).setEnabled(false);
+        verify(mockEditComments).setEnabled(false);
+        verify(mockEditInfoType).setEnabled(false);
+
+        //  verify(mockMetadata).setEnabled(false);
+        verify(mockSavemetadatami).setEnabled(false);
+        verify(mockCopymetadataMi).setEnabled(false);
+        verify(mockEditmetadataMi).setEnabled(false);
+        verify(mockBulkmetadataMi).setEnabled(false);
+        verify(mockSelectmetadataMi).setEnabled(false);
+        verify(mockDoiMi).setEnabled(false);
+
+        // Download Menu Items
+        verify(mockSimpleDownload).setEnabled(false);
+        verify(mockBulkDownload).setEnabled(false);
+
+        // Share Menu Items
+        verify(mockShareWithCollabs).setEnabled(false);
         verify(mockCreatePublicLink).setEnabled(false);
         verify(mockShareFolderLocation).setEnabled(false);
         verify(mockSendToCoge).setEnabled(false);
@@ -1429,7 +1572,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1488,7 +1630,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1547,7 +1688,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1614,7 +1754,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1670,7 +1809,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
 
         // File Menu Items
-        verify(mockDuplicate).setEnabled(false);
         verify(mockMoveToTrash).setEnabled(false);
 
         // Edit Menu Items
@@ -1746,7 +1884,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         uut.newWindowMi = mockNewWindow;
         uut.newWindowAtLocMi = mockNewWindowAtLoc;
         uut.newFolderMi = mockNewFolder;
-        uut.duplicateMi = mockDuplicate;
         uut.newPlainTextFileMi = mockNewPlainTextFile;
         uut.newTabularDataFileMi = mockNewTabularFile;
         uut.moveToTrashMi = mockMoveToTrash;

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onFolderSelectedTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onFolderSelectedTest.java
@@ -406,7 +406,6 @@ public class DiskResourceViewToolbar_onFolderSelectedTest {
         uut.newWindowMi = mockNewWindow;
         uut.newWindowAtLocMi = mockNewWindowAtLoc;
         uut.newFolderMi = mockNewFolder;
-        uut.duplicateMi = mockDuplicate;
         uut.newFileMi = mockNewFileMi;
         uut.moveToTrashMi = mockMoveToTrash;
 

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onFolderSelectedTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onFolderSelectedTest.java
@@ -1,10 +1,19 @@
 package org.iplantc.de.diskResource.client.views.toolbar;
 
-import static org.iplantc.de.client.models.diskResources.PermissionValue.*;
+import static org.iplantc.de.client.models.diskResources.PermissionValue.own;
+import static org.iplantc.de.client.models.diskResources.PermissionValue.read;
+import static org.iplantc.de.client.models.diskResources.PermissionValue.write;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.models.search.DiskResourceQueryTemplate;
+import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.diskResource.client.ToolbarView;
 import org.iplantc.de.diskResource.client.events.FolderSelectionEvent;
 import org.iplantc.de.diskResource.client.views.search.DiskResourceSearchField;
@@ -14,8 +23,6 @@ import com.google.gwtmockito.GxtMockitoTestRunner;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.menu.MenuItem;
 
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,6 +80,8 @@ public class DiskResourceViewToolbar_onFolderSelectedTest {
     private DiskResourceViewToolbarImpl uut;
     @Mock ToolbarView.Appearance mockAppearance;
     @Mock ToolbarView.Presenter mockPresenter;
+    @Mock
+    DiskResourceUtil mockDiskResourceUtil;
 
     @Before public void setup() {
         uut = new DiskResourceViewToolbarImpl(searchFieldMock, mock(UserInfo.class), mockAppearance, mockPresenter){
@@ -105,6 +114,7 @@ public class DiskResourceViewToolbar_onFolderSelectedTest {
                                && !(folder instanceof DiskResourceQueryTemplate);
             }
         };
+        uut.diskResourceUtil = mockDiskResourceUtil;
         mockMenuItems(uut);
     }
 


### PR DESCRIPTION
Additionally
- Modify how "red" file / folder behave in center panel.
- Remove unused menu item.
- Add tests for "red" file / folder selection.
