### PR TITLE
CORE-8364 Add an error page for when the properties or bootstrap services fail

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/DEClientConstants.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/DEClientConstants.java
@@ -84,4 +84,6 @@ public interface DEClientConstants extends Constants {
      * The execution system name for HPC apps.
      */
     String hpcSystemId();
+
+    String errorUrl();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/DEClientConstants.properties
+++ b/de-lib/src/main/java/org/iplantc/de/client/DEClientConstants.properties
@@ -10,3 +10,4 @@ wssProtocol = wss://
 mdTemplateDownloadServlet = /de/secured/mdTemplateDownload
 deSystemId = de
 hpcSystemId = agave
+errorUrl = error

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -61,7 +61,6 @@ import org.iplantc.de.notifications.client.views.dialogs.RequestHistoryDialog;
 import org.iplantc.de.shared.DEProperties;
 import org.iplantc.de.shared.services.PropertyServiceAsync;
 import org.iplantc.de.systemMessages.client.events.NewSystemMessagesEvent;
-import org.iplantc.de.systemMessages.client.view.NewMessageView;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
@@ -162,7 +161,6 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
     private final EventBus eventBus;
     private final MessagePoller messagePoller;
     private final SaveSessionPeriodic ssp;
-    private final NewMessageView.Presenter systemMsgPresenter;
     private final DesktopView view;
     private final WindowManager windowManager;
     private NotificationWebSocketManager notificationWebSocketManager;
@@ -176,13 +174,11 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
                                 final DesktopPresenterEventHandler globalEventHandler,
                                 final DesktopPresenterWindowEventHandler windowEventHandler,
                                 final EventBus eventBus,
-                                final NewMessageView.Presenter systemMsgPresenter,
                                 final WindowManager windowManager,
                                 final DesktopWindowManager desktopWindowManager,
                                 final MessagePoller messagePoller) {
         this.view = view;
         this.eventBus = eventBus;
-        this.systemMsgPresenter = systemMsgPresenter;
         this.windowManager = windowManager;
         this.messagePoller = messagePoller;
         this.desktopWindowManager = desktopWindowManager;

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -333,6 +333,14 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
         }
     }
 
+    public void onBootstrapError(Integer statusCode) {
+        String redirectUrl = GWT.getHostPageBaseURL() + deClientConstants.errorUrl();
+        if (statusCode != null) {
+            redirectUrl += "-" + statusCode.toString();
+        }
+        Window.Location.assign(redirectUrl);
+    }
+
     private void cleanUp() {
         loggedOut = true;
         messagePoller.stop();

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/InitializationCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/InitializationCallbacks.java
@@ -12,6 +12,7 @@ import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.views.dialogs.AgaveAuthPrompt;
 import org.iplantc.de.desktop.client.DesktopView;
 import org.iplantc.de.shared.DEProperties;
+import org.iplantc.de.shared.exceptions.HttpException;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
@@ -27,6 +28,7 @@ import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent.DialogHideHandler;
 
 import java.util.HashMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -60,7 +62,12 @@ class InitializationCallbacks {
 
         @Override
         public void onFailure(Throwable caught) {
-            errorHandlerProvider.get().post(appearance.systemInitializationError(), caught);
+            LOG.log(Level.SEVERE, caught.getMessage());
+            Integer statusCode = null;
+            if (caught instanceof HttpException) {
+                statusCode = ((HttpException)caught).getStatusCode();
+            }
+            presenter.onBootstrapError(statusCode);
         }
 
         @Override
@@ -134,6 +141,7 @@ class InitializationCallbacks {
         private final UserSessionServiceFacade userSessionService;
         private final UserSettings userSettings;
         private final IplantAnnouncer announcer;
+        Logger LOG = Logger.getLogger(PropertyServiceCallback.class.getName());
 
         public PropertyServiceCallback(DEProperties deProperties,
                                        UserInfo userInfo,
@@ -157,7 +165,12 @@ class InitializationCallbacks {
 
         @Override
         public void onFailure(Throwable caught) {
-            errorHandlerProvider.get().post(appearance.systemInitializationError(), caught);
+            LOG.log(Level.SEVERE, caught.getMessage());
+            Integer statusCode = null;
+            if (caught instanceof HttpException) {
+                statusCode = ((HttpException)caught).getStatusCode();
+            }
+            presenter.onBootstrapError(statusCode);
         }
 
         @Override

--- a/de-lib/src/test/java/org/iplantc/de/desktop/client/presenter/DesktopNotifications_PresenterTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/desktop/client/presenter/DesktopNotifications_PresenterTest.java
@@ -74,7 +74,6 @@ public class DesktopNotifications_PresenterTest {
                                                                   globalEvntHndlrMock,
                                                                   windowEvntHndlrMock,
                                                                   eventBusMock,
-                                                                  sysMsgPresenterMock,
                                                                   windowMangerMock,
                                                                   desktopWindowManagerMock,
                                                                   msgPollerMock){
@@ -107,7 +106,6 @@ public class DesktopNotifications_PresenterTest {
                                                                   globalEvntHndlrMock,
                                                                   windowEvntHndlrMock,
                                                                   eventBusMock,
-                                                                  sysMsgPresenterMock,
                                                                   windowMangerMock,
                                                                   desktopWindowManagerMock,
                                                                   msgPollerMock);
@@ -135,7 +133,6 @@ public class DesktopNotifications_PresenterTest {
                                                                             globalEvntHndlrMock,
                                                                             windowEvntHndlrMock,
                                                                             eventBusMock,
-                                                                            sysMsgPresenterMock,
                                                                             windowMangerMock,
                                                                             desktopWindowManagerMock,
                                                                             msgPollerMock));

--- a/de-lib/src/test/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImplTest.java
@@ -1,10 +1,15 @@
 package org.iplantc.de.desktop.client.presenter;
 
-import org.iplantc.de.desktop.client.DesktopView;
-import org.iplantc.de.desktop.client.presenter.util.MessagePoller;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
+import org.iplantc.de.desktop.client.DesktopView;
+import org.iplantc.de.desktop.client.presenter.util.MessagePoller;
 import org.iplantc.de.systemMessages.client.view.NewMessageView;
 
 import com.google.gwt.dom.client.Element;
@@ -13,10 +18,6 @@ import com.google.gwtmockito.WithClassesToStub;
 
 import com.sencha.gxt.widget.core.client.WindowManager;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +43,6 @@ public class DesktopPresenterImplTest {
                                           globalEventHandlerMock,
                                           windowEventHandlerMock,
                                           eventBusMock,
-                                          sysMsgPresenterMock,
                                           windowManagerMock,
                                           desktopWindowManagerMock,
                                           messagePollerMock);

--- a/de-webapp/src/main/java/org/iplantc/de/conf/DeWebSecurityConfig.java
+++ b/de-webapp/src/main/java/org/iplantc/de/conf/DeWebSecurityConfig.java
@@ -1,12 +1,13 @@
 package org.iplantc.de.conf;
 
+import static org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN;
+
 import org.iplantc.de.server.CacheControlFilter;
 import org.iplantc.de.server.DeCasAuthenticationEntryPoint;
 import org.iplantc.de.server.DeLandingPage;
 import org.iplantc.de.server.MDCFilter;
 import org.iplantc.de.server.auth.CasLogoutSuccessHandler;
 
-import static org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN;
 import org.jasig.cas.client.session.SingleSignOutFilter;
 import org.jasig.cas.client.validation.Cas20ServiceTicketValidator;
 import org.slf4j.Logger;
@@ -142,7 +143,7 @@ public class DeWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
         http.antMatcher("/de/**")
             .authorizeRequests()
-            .antMatchers("/applets/**", "/**/logout", "/**/logged-out", "/*.css", "/*.png").permitAll()
+            .antMatchers("/applets/**", "/**/logout", "/**/logged-out", "/**/error", "/**/error-**", "/*.css", "/*.png").permitAll()
             .anyRequest().authenticated().and()
             .exceptionHandling().authenticationEntryPoint(deCasAuthenticationEntryPoint());
 

--- a/de-webapp/src/main/java/org/iplantc/de/server/controllers/BootstrapErrorController.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/controllers/BootstrapErrorController.java
@@ -14,8 +14,9 @@ public class BootstrapErrorController {
 
     @Value("${org.iplantc.discoveryenvironment.cas.app-name}") private String appName;
     @Value("${org.iplantc.discoveryenvironment.twitter-url}") private String twitterUrl;
+    @Value("${org.iplantc.discoveryenvironment.facebook-url}") private String facebookUrl;
     @Value("${org.iplantc.discoveryenvironment.newsletter-url}") private String newsletterUrl;
-    @Value("${org.iplantc.discoveryenvironment.status-url}") private String statusUrl;
+    @Value("${org.iplantc.discoveryenvironment.ask-url}") private String askUrl;
 
     @RequestMapping("/de/error-{statusCode:\\d+}")
     public ModelAndView deError(@PathVariable Integer statusCode) {
@@ -36,8 +37,9 @@ public class BootstrapErrorController {
         modelAndView.addObject("app_name", appName);
         modelAndView.addObject("login_url", appNamePathPart);
         modelAndView.addObject("twitter_url", twitterUrl);
+        modelAndView.addObject("facebook_url", facebookUrl);
         modelAndView.addObject("newsletter_url", newsletterUrl);
-        modelAndView.addObject("status_url", statusUrl);
+        modelAndView.addObject("ask_url", askUrl);
         modelAndView.addObject("status_code", statusCode);
 
         return modelAndView;

--- a/de-webapp/src/main/java/org/iplantc/de/server/controllers/BootstrapErrorController.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/controllers/BootstrapErrorController.java
@@ -1,0 +1,46 @@
+package org.iplantc.de.server.controllers;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * @author aramsey
+ */
+@Controller
+public class BootstrapErrorController {
+
+    @Value("${org.iplantc.discoveryenvironment.cas.app-name}") private String appName;
+    @Value("${org.iplantc.discoveryenvironment.twitter-url}") private String twitterUrl;
+    @Value("${org.iplantc.discoveryenvironment.newsletter-url}") private String newsletterUrl;
+    @Value("${org.iplantc.discoveryenvironment.status-url}") private String statusUrl;
+
+    @RequestMapping("/de/error-{statusCode:\\d+}")
+    public ModelAndView deError(@PathVariable Integer statusCode) {
+        if (statusCode >= 300 && statusCode < 600) {
+            return showError("/de", statusCode);
+        }
+        return showError("/de", null);
+    }
+
+    @RequestMapping("/de/error")
+    public ModelAndView deError() {
+        return showError("/de", null);
+    }
+
+
+    public ModelAndView showError(final String appNamePathPart, Integer statusCode){
+        ModelAndView modelAndView = new ModelAndView("bootstrapError");
+        modelAndView.addObject("app_name", appName);
+        modelAndView.addObject("login_url", appNamePathPart);
+        modelAndView.addObject("twitter_url", twitterUrl);
+        modelAndView.addObject("newsletter_url", newsletterUrl);
+        modelAndView.addObject("status_url", statusUrl);
+        modelAndView.addObject("status_code", statusCode);
+
+        return modelAndView;
+    }
+
+}

--- a/de-webapp/src/main/webapp/WEB-INF/jsp/bootstrapError.jsp
+++ b/de-webapp/src/main/webapp/WEB-INF/jsp/bootstrapError.jsp
@@ -40,6 +40,59 @@ h1 {
     color: #0971AB;
 }
 
+.darkBlueButton {
+    color: #FFF;
+    background-color: #185DA2;
+    cursor: pointer;
+    padding: 5px 5px;
+    border-radius: 5px;
+    border: 1px solid #424142;
+    background-image: linear-gradient(bottom, #185DA2 0%, #2989E6 100%);
+    background-image: -o-linear-gradient(bottom, #185DA2 0%, #2989E6 100%);
+    background-image: -moz-linear-gradient(bottom, #185DA2 0%, #2989E6 100%);
+    background-image: -webkit-linear-gradient(bottom, #185DA2 0%, #2989E6 100%);
+    background-image: -ms-linear-gradient(bottom, #185DA2 0%, #2989E6 100%);
+    font-family: Verdana;
+    font-size: 11px;
+    background-image: -webkit-gradient(
+            linear,
+            left bottom,
+            left top,
+            color-stop(0, #185DA2),
+            color-stop(1, #2989E6)
+    );
+    text-decoration: none;
+}
+.darkBlueButton:hover {
+    background-image: linear-gradient(bottom, #2989E6 0%, #185DA2 100%);
+    background-image: -o-linear-gradient(bottom, #2989E6 0%, #185DA2 100%);
+    background-image: -moz-linear-gradient(bottom, #2989E6 0%, #185DA2 100%);
+    background-image: -webkit-linear-gradient(bottom, #2989E6 0%, #185DA2 100%);
+    background-image: -ms-linear-gradient(bottom, #2989E6 0%, #185DA2 100%);
+    background-image: -webkit-gradient(
+            linear,
+            left bottom,
+            left top,
+            color-stop(0, #2989E6),
+            color-stop(1, #185DA2)
+    );
+}
+.darkBlueButton:active {
+    background-image: linear-gradient(bottom, #2989E6 0%, #246EBE 87%, #185DA2 100%);
+    background-image: -o-linear-gradient(bottom, #2989E6 0%, #246EBE 87%, #185DA2 100%);
+    background-image: -moz-linear-gradient(bottom, #2989E6 0%, #246EBE 87%, #185DA2 100%);
+    background-image: -webkit-linear-gradient(bottom, #2989E6 0%, #246EBE 87%, #185DA2 100%);
+    background-image: -ms-linear-gradient(bottom, #2989E6 0%, #246EBE 87%, #185DA2 100%);
+    background-image: -webkit-gradient(
+            linear,
+            left bottom,
+            left top,
+            color-stop(0, #2989E6),
+            color-stop(0.87, #246EBE),
+            color-stop(1, #185DA2)
+    );
+}
+
 a {
     color: #0971AB;
     text-decoration: none;
@@ -51,7 +104,7 @@ a:hover {
 .container {
     position: relative;
     top: 100px;
-    min-height: 220px;
+    min-height: 320px;
     margin-left: auto;
     margin-right: auto;
     padding: 10px;
@@ -74,32 +127,56 @@ a:hover {
 }
 </style>
 
+<script type="text/javascript">
+    <%--If the user refreshes their browser, redirect to /de --%>
+    if (sessionStorage.getItem("is_reloaded")) {
+        window.location.replace('${login_url}');
+        sessionStorage.removeItem("is_reloaded");
+    } else {
+        sessionStorage.setItem("is_reloaded", 1);
+    }
+
+</script>
+
 </head>
 <body>
 
 <img src="../cyverse_logo.png" height="107px" width="500px"/>
 
-    <div class="container">
+<div class="container">
 
-    <c:if test="${not empty status_code}">
-        <h1 class="redHeader">${status_code} Error</h1>
-    </c:if>
-    <h1 class="blueHeader">Oops... That wasn't supposed to happen</h1>
+    <h1 class="blueHeader" style="text-align: center">Oops... That wasn't supposed to happen</h1>
 
-    <p>
-    The CyVerse team tracks these errors automatically, but feel free to <a href="mailto:support@cyverse.org">contact support</a> if the error persists.
-        In the meantime, you can:
-        <li>Check out our <a href="${status_url}">status</a> page </li>
-        <li>Subscribe to our <a href="${newsletter_url}">newsletter</a></li>
-        <li>Follow us on <a href="${twitter_url}">Twitter</a></li>
+    <p style="text-align: center">
+        An unexpected error seems to have occurred. Try refreshing your page.
+    </p>
+    <p style="text-align: center">
+        <button class="darkBlueButton" onclick="sessionStorage.removeItem('is_reloaded');window.location.replace('${login_url}')">Refresh</button>
     </p>
 
-    <hr />
+    <p>
+        If the error persists and you want to learn more about what's going on
+        and when it may be resolved, you can:
+    <ul>
+        <li>Contact Support at <a href="mailto:support@cyverse.org">support@cyverse.org</a></li>
+        <li>Check <a href="${ask_url}">Ask CyVerse</a></li>
+    </ul>
+
+    </p>
+
+    <p>
+        You can also learn more about goings-on at CyVerse, as well as scheduled maintenance events, upcoming
+        workshops, and more by checking our <a href="${facebook_url}">CyVerse Facebook</a> page,
+        following us on <a href="${twitter_url}">CyVerse Twitter</a>, and making sure you're subscribed
+        to our newsletter, <a href="${newsletter_url}">The Node</a>.
+    </p>
+
+    <hr/>
 
     <div style="float: left"><a href="${login_url}">Go back to ${app_name}</a></div>
     <div style="float: right"><a href="http://www.cyverse.org">CyVerse Home Page</a></div>
 
-    </div>
+</div>
 
 </body>
 </html>

--- a/de-webapp/src/main/webapp/WEB-INF/jsp/bootstrapError.jsp
+++ b/de-webapp/src/main/webapp/WEB-INF/jsp/bootstrapError.jsp
@@ -1,0 +1,105 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+<head>
+
+<style>
+
+    @font-face {
+        font-family: TextaRegular;
+        src: url(../../Texta_Font/Texta-Regular.otf);
+    }
+
+    @font-face {
+        font-family: TextaBlack;
+        src: url(../../Texta_Font/Texta-Black.otf);
+    }
+
+body {
+    font-family: TextaRegular,Univers,Calibri,"Gill Sans","Gill Sans MT","Myriad Pro",Myriad,"DejaVu Sans Condensed","Liberation Sans","Nimbus Sans L",Tahoma,Geneva,"Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size: 0.9em;
+    background-color: #e2e2e2;
+    background-image: linear-gradient( 180deg, #FFF,#e2e2e2);
+    background-repeat: repeat-x;
+}
+h1 {
+    font-size: 1.5em;
+    line-height: .5em;
+    font-family: TextaBlack, Univers, Calibri, "Gill Sans", "Gill Sans MT", "Myriad Pro",
+    Myriad, "DejaVu Sans Condensed", "Liberation Sans", "Nimbus Sans L",
+    Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial,
+    sans-serif !important;
+}
+
+.redHeader {
+    color: darkred;
+    float: right;
+}
+
+.blueHeader {
+    color: #0971AB;
+}
+
+a {
+    color: #0971AB;
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: none;
+    border-bottom: 1px dotted #0971AB;
+}
+.container {
+    position: relative;
+    top: 100px;
+    min-height: 220px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 10px;
+    max-width: 520px;
+    border-radius: 5px;
+    border: 1px solid #BBB;
+    background-color: #FFF;
+    background-image: linear-gradient(bottom, #E2E2E2 0%, #FFF 100%);
+    background-image: -o-linear-gradient(bottom, #E2E2E2 0%, #FFF 100%);
+    background-image: -moz-linear-gradient(bottom, #E2E2E2 0%, #FFF 100%);
+    background-image: -webkit-linear-gradient(bottom, #E2E2E2 0%, #FFF 100%);
+    background-image: -ms-linear-gradient(bottom, #E2E2E2 0%, #FFF 100%);
+    background-image: -webkit-gradient(
+        linear,
+        left bottom,
+        left top,
+        color-stop(0, #E2E2E2),
+        color-stop(1, #FFF)
+    );;
+}
+</style>
+
+</head>
+<body>
+
+<img src="../cyverse_logo.png" height="107px" width="500px"/>
+
+    <div class="container">
+
+    <c:if test="${not empty status_code}">
+        <h1 class="redHeader">${status_code} Error</h1>
+    </c:if>
+    <h1 class="blueHeader">Oops... That wasn't supposed to happen</h1>
+
+    <p>
+    The CyVerse team tracks these errors automatically, but feel free to <a href="mailto:support@cyverse.org">contact support</a> if the error persists.
+        In the meantime, you can:
+        <li>Check out our <a href="${status_url}">status</a> page </li>
+        <li>Subscribe to our <a href="${newsletter_url}">newsletter</a></li>
+        <li>Follow us on <a href="${twitter_url}">Twitter</a></li>
+    </p>
+
+    <hr />
+
+    <div style="float: left"><a href="${login_url}">Go back to ${app_name}</a></div>
+    <div style="float: right"><a href="http://www.cyverse.org">CyVerse Home Page</a></div>
+
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
This PR is for getting the user out of a neverending loading spinner in the DE when the UI fails to retrieve the properties file or if one of the bootstrap services is down.  The user will be presented with an error page that gives them the option to email support and/or find other avenues for staying up-to-date on CyVerse status.

![image](https://cloud.githubusercontent.com/assets/8909156/19864931/79b4576e-9f57-11e6-8c67-4144b5e31447.png)

