### PR TITLE
CORE-8365 Use default values when /secured/preferences is down

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
@@ -6,6 +6,7 @@ import org.iplantc.de.client.models.diskResources.Folder;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
 import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 import com.google.web.bindery.autobean.shared.AutoBeanUtils;
@@ -269,6 +270,20 @@ public class UserSettings {
         StringQuoter.create(getLastPath()).assign(ret, LAST_PATH);
 
         return ret;
+    }
+
+    public void useDefaultValues(UserInfo instance) {
+        JSONObject defaults = new JSONObject();
+        JSONObject defaultHomeDir = new JSONObject();
+
+        JSONString id = new JSONString(instance.getHomePath());
+        JSONString path = new JSONString(instance.getHomePath());
+        defaultHomeDir.put("id", id);
+        defaultHomeDir.put("path", path);
+
+        defaults.put(DEFAULT_OUTPUT_FOLDER, defaultHomeDir);
+
+        setValues(defaults);
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
@@ -39,7 +39,7 @@ public class UserSettings {
     private boolean enableWaitTimeMessage;
     
     
-    public static final String EMAIL_ANALYSIS_NOTIFCATOIN = "enableAnalysisEmailNotification";
+    public static final String EMAIL_ANALYSIS_NOTIFICATION = "enableAnalysisEmailNotification";
     public static final String EMAIL_IMPORT_NOTIFICATION = "enableImportEmailNotification";
     public static final String DEFAULT_FILE_SELECTOR_PATH = "defaultFileSelectorPath";
     public static final String REMEMBER_LAST_PATH = "rememberLastPath";
@@ -88,8 +88,8 @@ public class UserSettings {
             return;
         }
 
-        if (split.get(EMAIL_ANALYSIS_NOTIFCATOIN) != null) {
-            setEnableAnalysisEmailNotification(split.get(EMAIL_ANALYSIS_NOTIFCATOIN).asBoolean());
+        if (split.get(EMAIL_ANALYSIS_NOTIFICATION) != null) {
+            setEnableAnalysisEmailNotification(split.get(EMAIL_ANALYSIS_NOTIFICATION).asBoolean());
         } else {
             setEnableAnalysisEmailNotification(true);
         }
@@ -252,7 +252,7 @@ public class UserSettings {
      */
     public Splittable asSplittable() {
         Splittable ret = StringQuoter.createSplittable();
-        StringQuoter.create(isEnableAnalysisEmailNotification()).assign(ret, EMAIL_ANALYSIS_NOTIFCATOIN);
+        StringQuoter.create(isEnableAnalysisEmailNotification()).assign(ret, EMAIL_ANALYSIS_NOTIFICATION);
         StringQuoter.create(isEnableImportEmailNotification()).assign(ret, EMAIL_IMPORT_NOTIFICATION);
         StringQuoter.create(isEnableWaitTimeMessage()).assign(ret, WAIT_TIME_MESSAGE);
         StringQuoter.create(getDefaultFileSelectorPath()).assign(ret, DEFAULT_FILE_SELECTOR_PATH);

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -183,6 +183,8 @@ public interface DesktopView extends IsWidget {
             String requestHistoryError();
             
             String checkSysMessageError();
+
+            String userPreferencesLoadError();
         }
 
         List<WindowState> getOrderedWindowStates();

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -407,6 +407,7 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
                                                                         userSessionService,
                                                                         errorHandlerProvider,
                                                                         appearance,
+                                                                        announcer,
                                                                         panel,
                                                                         this));
     }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopErrorMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopErrorMessages.java
@@ -29,4 +29,6 @@ public interface DesktopErrorMessages extends Messages {
     String systemInitializationError();
 
 	String checkSysMessageError();
+
+    String userPreferencesLoadError();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopErrorMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopErrorMessages.properties
@@ -6,4 +6,4 @@ systemInitializationError = Unable to retrieve the configuration settings from t
 permissionErrorTitle = Permission Error
 permissionErrorMessage = You do not have the permission to perform this operation on the selected item(s).
 checkSysMessageError = Unable to check for new system message!
-
+userPreferencesLoadError = We were unable to fetch your preferences.  A default set of preferences will be used instead.

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/presenter/DesktopPresenterDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/presenter/DesktopPresenterDefaultAppearance.java
@@ -127,4 +127,9 @@ public class DesktopPresenterDefaultAppearance implements DesktopView.Presenter.
 	public String checkSysMessageError() {
 		return desktopErrorMessages.checkSysMessageError();
 	}
+
+    @Override
+    public String userPreferencesLoadError() {
+        return desktopErrorMessages.userPreferencesLoadError();
+    }
 }


### PR DESCRIPTION
This PR enables the UI to be more resilient when /secured/preferences is down.  Previously, the UI would not load if this callback failed.  Now, a default set of preferences will be used, the user will be informed, and the UI will continue loading.
