### PR TITLE
CORE-8400 Disable saved sessions when /secured/sessions fails and add "Try Again" btn to preferences

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
@@ -27,6 +27,7 @@ public class UserSettings {
     private String defaultFileSelectorPath;
     private boolean rememberLastPath;
     private boolean saveSession;
+    private boolean sessionConnectionFailed;
     private Folder defaultOutputFolder;
     private String dataShortCut;
     private String appShortCut;
@@ -240,6 +241,10 @@ public class UserSettings {
         return (defaultFileSelectorPath == null) ? "" : defaultFileSelectorPath;
     }
 
+    public boolean sessionConnectionFailed() {
+        return sessionConnectionFailed;
+    }
+
     /**
      * Get Splittable representation
      * 
@@ -287,6 +292,10 @@ public class UserSettings {
      */
     public void setSaveSession(boolean saveSession) {
         this.saveSession = saveSession;
+    }
+
+    public void setSessionConnectionFailed(boolean failedConnection) {
+        this.sessionConnectionFailed = failedConnection;
     }
 
     public boolean isSaveSession() {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/Desktop.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/Desktop.gwt.xml
@@ -33,6 +33,7 @@
     <inherits name="org.iplantc.de.notifications.Notifications"/>
     <inherits name="org.iplantc.de.systemMessages.SystemMessages"/>
     <inherits name="org.iplantc.de.collaborators.Collaborators" />
+    <inherits name="org.iplantc.de.preferences.Preferences"/>
 
     <source path="client"/>
     <source path="shared"/>

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -209,6 +209,7 @@ public interface DesktopView extends IsWidget {
 
         void stickWindowToTop(Window window);
 
+        void setPeriodicSessionFailFlags();
     }
 
     interface UserSettingsMenuPresenter {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -209,6 +209,10 @@ public interface DesktopView extends IsWidget {
 
         void stickWindowToTop(Window window);
 
+        void doPeriodicSessionSave();
+
+        void restoreWindows(List<WindowState> windowStates);
+
         void setPeriodicSessionFailFlags();
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -791,7 +791,9 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
 		};
     }-*/;
 
-    public void setPeriodicSessionSave(boolean saveEnabled) {
-        userSettings.setSaveSession(saveEnabled);
+    @Override
+    public void setPeriodicSessionFailFlags() {
+        userSettings.setSaveSession(false);
+        userSettings.setSessionConnectionFailed(true);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -631,7 +631,8 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
         desktopWindowManager.stickWindowToTop(window);
     }
 
-    void doPeriodicSessionSave() {
+    @Override
+    public void doPeriodicSessionSave() {
         if (userSettings.isSaveSession()) {
             ssp.run();
             messagePoller.addTask(ssp);
@@ -654,7 +655,8 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
    
    }
 
-    void restoreWindows(List<WindowState> windowStates) {
+   @Override
+   public void restoreWindows(List<WindowState> windowStates) {
         if (windowStates != null && windowStates.size() > 0) {
             for (WindowState ws : windowStates) {
                 desktopWindowManager.show(ws);

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -791,4 +791,7 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
 		};
     }-*/;
 
+    public void setPeriodicSessionSave(boolean saveEnabled) {
+        userSettings.setSaveSession(saveEnabled);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
@@ -45,7 +45,7 @@ class RuntimeCallbacks {
         public void onFailure(Throwable caught) {
             final SafeHtml message = SafeHtmlUtils.fromTrustedString(appearance.loadSessionFailed());
             announcer.schedule(new ErrorAnnouncementConfig(message, true, 5000));
-            presenter.doPeriodicSessionSave();
+            presenter.setPeriodicSessionSave(false);
             progressMessageBox.hide();
         }
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
@@ -45,7 +45,7 @@ class RuntimeCallbacks {
         public void onFailure(Throwable caught) {
             final SafeHtml message = SafeHtmlUtils.fromTrustedString(appearance.loadSessionFailed());
             announcer.schedule(new ErrorAnnouncementConfig(message, true, 5000));
-            presenter.setPeriodicSessionSave(false);
+            presenter.setPeriodicSessionFailFlags();
             progressMessageBox.hide();
         }
 
@@ -159,7 +159,8 @@ class RuntimeCallbacks {
                 userSessionService.saveUserSession(presenter.getOrderedWindowStates(), new AsyncCallback<Void>() {
                     @Override
                     public void onFailure(Throwable caught) {
-                      announcer.schedule(new ErrorAnnouncementConfig(appearance.saveSessionFailed()));
+                        announcer.schedule(new ErrorAnnouncementConfig(appearance.saveSessionFailed()));
+                        presenter.setPeriodicSessionFailFlags();
                     }
 
                     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
@@ -155,9 +155,6 @@ class RuntimeCallbacks {
         @Override
         public void onSuccess(Void result) {
             userSettings.setValues(newValue.asSplittable());
-            if(!updateSilently){
-                announcer.schedule(new SuccessAnnouncementConfig(appearance.saveSettings(), true, 3000));
-            }
             if(userSettings.isSaveSession()) {
                 userSessionService.saveUserSession(presenter.getOrderedWindowStates(), new AsyncCallback<Void>() {
                     @Override
@@ -167,9 +164,17 @@ class RuntimeCallbacks {
 
                     @Override
                     public void onSuccess(Void result) {
-                      //Do nothing. Session saved as per user request.
+                        showSaveSettingSuccess();
                     }
                 });
+            } else {
+                showSaveSettingSuccess();
+            }
+        }
+
+        void showSaveSettingSuccess() {
+            if (!updateSilently) {
+                announcer.schedule(new SuccessAnnouncementConfig(appearance.saveSettings(), true, 3000));
             }
         }
     }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
@@ -35,7 +35,6 @@ import com.sencha.gxt.widget.core.client.Dialog.PredefinedButton;
 import com.sencha.gxt.widget.core.client.WindowManager;
 import com.sencha.gxt.widget.core.client.box.AlertMessageBox;
 import com.sencha.gxt.widget.core.client.button.IconButton;
-import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
 import com.sencha.gxt.widget.core.client.event.RegisterEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent.SelectHandler;
@@ -320,19 +319,8 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
 
     @UiHandler("preferencesBtn")
     void onPreferencesClick(ClickEvent event){
-        final PreferencesDialog preferencesDialog = preferencesDialogProvider.get();
-        final UserSettings userSettingsCopy = new UserSettings(userSettings.asSplittable());
-        preferencesDialog.initAndShow(userSettingsCopy);
-        userSettingsCopy.setSessionConnectionFailed(userSettings.sessionConnectionFailed());
-        preferencesDialog.addDialogHideHandler(new DialogHideEvent.DialogHideHandler() {
-            @Override
-            public void onDialogHide(DialogHideEvent event) {
-                if(PredefinedButton.OK.equals(event.getHideButton())){
-                    presenter.saveUserSettings(preferencesDialog.getValue(), false);
-                    preferencesDialog.hide();
-                }
-            }
-        });
+        PreferencesDialog dialog = preferencesDialogProvider.get();
+        dialog.show(presenter, userSettings);
     }
 
     @UiHandler("collaboratorsBtn")

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
@@ -323,6 +323,7 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
         final PreferencesDialog preferencesDialog = preferencesDialogProvider.get();
         final UserSettings userSettingsCopy = new UserSettings(userSettings.asSplittable());
         preferencesDialog.initAndShow(userSettingsCopy);
+        userSettingsCopy.setSessionConnectionFailed(userSettings.sessionConnectionFailed());
         preferencesDialog.addDialogHideHandler(new DialogHideEvent.DialogHideHandler() {
             @Override
             public void onDialogHide(DialogHideEvent event) {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesDialog.java
@@ -4,6 +4,7 @@ import org.iplantc.de.client.models.UserSettings;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 import org.iplantc.de.desktop.client.DesktopView;
 import org.iplantc.de.preferences.client.PreferencesView;
+import org.iplantc.de.preferences.shared.Preferences;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -59,6 +60,8 @@ public class PreferencesDialog extends IPlantDialog implements DialogHideEvent.D
     public void show(DesktopView.Presenter desktopPresenter, UserSettings settings) {
         presenter.go(desktopPresenter, settings);
         super.show();
+
+        ensureDebugId(Preferences.Ids.PREFERENCES_DLG);
     }
 
     @Override
@@ -100,5 +103,15 @@ public class PreferencesDialog extends IPlantDialog implements DialogHideEvent.D
             presenter.saveUserSettings();
             hide();
         }
+    }
+
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        presenter.setViewDebugId(baseID);
+        getButton(PredefinedButton.OK).ensureDebugId(baseID + Preferences.Ids.DONE);
+        getButton(PredefinedButton.CANCEL).ensureDebugId(baseID + Preferences.Ids.CANCEL);
+        defaultsBtn.ensureDebugId(baseID + Preferences.Ids.DEFAULTS_BTN);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesDialog.java
@@ -1,320 +1,87 @@
 package org.iplantc.de.desktop.client.views.widgets;
 
-import org.iplantc.de.apps.widgets.client.view.editors.validation.AnalysisOutputValidator;
-import org.iplantc.de.client.KeyBoardShortcutConstants;
 import org.iplantc.de.client.models.UserSettings;
-import org.iplantc.de.client.models.diskResources.Folder;
-import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
-import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
-import org.iplantc.de.desktop.shared.DeModule;
-import org.iplantc.de.diskResource.client.gin.factory.DiskResourceSelectorFieldFactory;
-import org.iplantc.de.diskResource.client.views.widgets.FolderSelectorField;
+import org.iplantc.de.desktop.client.DesktopView;
+import org.iplantc.de.preferences.client.PreferencesView;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.editor.client.Editor;
-import com.google.gwt.editor.client.SimpleBeanEditorDriver;
-import com.google.gwt.event.dom.client.KeyPressEvent;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.uibinder.client.UiBinder;
-import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.uibinder.client.UiHandler;
-import com.google.gwt.uibinder.client.UiTemplate;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
 import com.sencha.gxt.core.client.XTemplates;
+import com.sencha.gxt.widget.core.client.Dialog;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.container.AbstractHtmlLayoutContainer.HtmlData;
 import com.sencha.gxt.widget.core.client.container.HtmlLayoutContainer;
-import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
+import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
-import com.sencha.gxt.widget.core.client.form.CheckBox;
-import com.sencha.gxt.widget.core.client.form.TextField;
-import com.sencha.gxt.widget.core.client.form.validator.MaxLengthValidator;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author sriram, jstroot
  */
-public class PreferencesDialog extends IPlantDialog implements Editor<UserSettings> {
 
-    public interface PreferencesViewAppearance {
-
-        String defaultOutputFolderHelp();
-
-        String done();
-
-        String duplicateShortCutKey(String key);
-
-        String notifyEmailHelp();
-
-        String preferences();
-
-        String notifyAnalysisEmail();
-
-        String notifyImportEmail();
-
-        String completeRequiredFieldsError();
-
-        String rememberFileSectorPath();
-
-        String rememberFileSectorPathHelp();
-
-        String restoreDefaults();
-
-        String saveSession();
-
-        String defaultOutputFolder();
-
-        String keyboardShortCut();
-
-        String openAppsWindow();
-
-        String kbShortcutMetaKey();
-
-        String oneCharMax();
-
-        String openDataWindow();
-
-        String openAnalysesWindow();
-
-        String openNotificationsWindow();
-
-        String closeActiveWindow();
-
-        String saveSessionHelp();
-
-        String notifyEmail();
-
-        String waitTime();
-
-        String retrySessionConnection();
-
-        String sessionConnectionFailed();
-    }
+public class PreferencesDialog extends IPlantDialog implements DialogHideEvent.DialogHideHandler {
 
     public interface HtmlLayoutContainerTemplate extends XTemplates {
         @XTemplate(source = "PreferencesHelpTemplate.html")
         SafeHtml getTemplate();
     }
 
-    @UiTemplate("PreferencesView.ui.xml")
-    interface MyUiBinder extends UiBinder<VerticalLayoutContainer, PreferencesDialog> { }
-
-    interface EditorDriver extends SimpleBeanEditorDriver<UserSettings, PreferencesDialog>{}
-
-    @UiField @Ignore VerticalLayoutContainer container;
-    @UiField @Ignore VerticalLayoutContainer kbContainer;
-    @UiField @Ignore VerticalLayoutContainer prefContainer;
-
-    @UiField TextField analysesShortCut;
-    @UiField TextField appsShortCut;
-    @UiField CheckBox rememberLastPath;
-    @UiField CheckBox enableAnalysisEmailNotification;
-    @UiField CheckBox enableImportEmailNotification;
-    @UiField CheckBox enableWaitTimeMessage;
-    @UiField CheckBox saveSession;
-    @UiField @Ignore TextButton retrySession;
-    @UiField TextField closeShortCut;
-    @UiField TextField dataShortCut;
-    @UiField(provided = true) FolderSelectorField defaultOutputFolder;
-    @UiField TextField notifyShortCut;
-    @UiField(provided = true) PreferencesViewAppearance appearance;
-
-    private final KeyBoardShortcutConstants KB_CONSTANTS;
-    private final TextButton defaultsBtn;
-    private final Map<TextField, String> kbMap;
-
-    private final EditorDriver editorDriver = GWT.create(EditorDriver.class);
-    private static MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
-
-    private UserSettings flushedValue;
-    private UserSettings usValue;
-
-    @Inject UserSettings us;
+    private final PreferencesView.PreferencesViewAppearance appearance;
+    private PreferencesView.Presenter presenter;
+    private TextButton defaultsBtn;
 
     @Inject
-    PreferencesDialog(final DiskResourceSelectorFieldFactory folderSelectorFieldFactory,
-                      final PreferencesViewAppearance appearance,
-                      final KeyBoardShortcutConstants kbConstants) {
+    PreferencesDialog(final PreferencesView.PreferencesViewAppearance appearance,
+                      final PreferencesView.Presenter presenter) {
         super(true);
+        this.presenter = presenter;
         this.appearance = appearance;
-        this.defaultOutputFolder = folderSelectorFieldFactory.defaultFolderSelector();
-        this.defaultOutputFolder.hideResetButton();
-        this.KB_CONSTANTS = kbConstants;
         setHeadingText(appearance.preferences());
-        VerticalLayoutContainer vlc = uiBinder.createAndBindUi(this);
-        kbMap = new HashMap<>();
-        appsShortCut.addValidator(new MaxLengthValidator(1));
-        dataShortCut.addValidator(new MaxLengthValidator(1));
-        analysesShortCut.addValidator(new MaxLengthValidator(1));
-        notifyShortCut.addValidator(new MaxLengthValidator(1));
-        closeShortCut.addValidator(new MaxLengthValidator(1));
-        defaultOutputFolder.addValidator(new AnalysisOutputValidator());
-        defaultOutputFolder.addValueChangeHandler(new ValueChangeHandler<Folder>() {
-
-            @Override
-            public void onValueChange(ValueChangeEvent<Folder> event) {
-                defaultOutputFolder.validate(false);
-            }
-        });
-        populateKbMap();
         getButton(PredefinedButton.OK).setText(appearance.done());
+        getButton(PredefinedButton.CANCEL);
         defaultsBtn = new TextButton(appearance.restoreDefaults());
         defaultsBtn.addSelectHandler(new SelectEvent.SelectHandler() {
             @Override
             public void onSelect(SelectEvent event) {
-                setDefaultValues();
+                presenter.setDefaultValues();
             }
         });
+        addDialogHideHandler(this);
         getButtonBar().insert(defaultsBtn, 0);
         addHelp(constructHelpView());
-        add(vlc);
-        editorDriver.initialize(this);
+        add(presenter.getView());
     }
 
-    @Ignore
-    @Override
-    public TextButton getOkButton() {
-        return getButton(PredefinedButton.OK);
-    }
-
-    @Ignore
-    public UserSettings getValue() {
-        return flushedValue;
-    }
-
-    public void initAndShow(final UserSettings userSettings) {
-        this.usValue = userSettings;
-        editorDriver.edit(userSettings);
-        if (userSettings.sessionConnectionFailed()) {
-            retrySession.setVisible(true);
-            saveSession.setBoxLabel(appearance.sessionConnectionFailed());
-        }
-        show();
-        ensureDebugId(DeModule.PreferenceIds.PREFERENCES_DLG);
-    }
-
-    public boolean isValid() {
-        boolean valid = defaultOutputFolder.validate(false) && appsShortCut.isValid() && dataShortCut.isValid()
-                            && analysesShortCut.isValid() && notifyShortCut.isValid() && closeShortCut.isValid();
-
-        if (valid) {
-            populateKbMap();
-            resetKbFieldErrors();
-            for (TextField ks : kbMap.keySet()) {
-                for (TextField sc : kbMap.keySet()) {
-                    if (ks != sc) {
-                        if (kbMap.get(ks).equals(kbMap.get(sc))) {
-                            ks.markInvalid(appearance.duplicateShortCutKey(kbMap.get(ks)));
-                            sc.markInvalid(appearance.duplicateShortCutKey(kbMap.get(ks)));
-                            valid = false;
-                        }
-                    }
-                }
-            }
-        }
-        return valid;
+    public void show(DesktopView.Presenter desktopPresenter, UserSettings settings) {
+        presenter.go(desktopPresenter, settings);
+        super.show();
     }
 
     @Override
     protected void onButtonPressed(TextButton button) {
         if (button == getButton(PredefinedButton.OK)) {
-            UserSettings value = editorDriver.flush();
-            if (!editorDriver.hasErrors() && isValid()) {
-                this.flushedValue = value;
+            presenter.getView().flush();
+            if (presenter.getView().isValid()) {
                 super.onButtonPressed(button);
-            } else {
-                IplantAnnouncer.getInstance()
-                               .schedule(new ErrorAnnouncementConfig(appearance.completeRequiredFieldsError()));
+                hide();
             }
-
-
         } else if (button == defaultsBtn) {
-            setDefaultValues();
-            if (isValid()) {
-                super.onButtonPressed(button);
-            }
+            presenter.setDefaultValues();
+            super.onButtonPressed(button);
         } else if (button == getButton(PredefinedButton.CANCEL)) {
             super.onButtonPressed(button);
         }
-
     }
 
-    void setDefaultValues() {
-        enableAnalysisEmailNotification.setValue(true);
-        enableImportEmailNotification.setValue(true);
-        enableWaitTimeMessage.setValue(true);
-        rememberLastPath.setValue(true);
-        saveSession.setValue(true);
-        appsShortCut.setValue(KB_CONSTANTS.appsKeyShortCut());
-        dataShortCut.setValue(KB_CONSTANTS.dataKeyShortCut());
-        analysesShortCut.setValue(KB_CONSTANTS.analysisKeyShortCut());
-        notifyShortCut.setValue(KB_CONSTANTS.notifyKeyShortCut());
-        closeShortCut.setValue(KB_CONSTANTS.closeKeyShortCut());
-        defaultOutputFolder.setValue(us.getSystemDefaultOutputFolder());
-    }
 
-    @Override
-    protected void onEnsureDebugId(String baseID) {
-        super.onEnsureDebugId(baseID);
-        getButton(PredefinedButton.OK).ensureDebugId(baseID + DeModule.PreferenceIds.DONE);
-        getButton(PredefinedButton.CANCEL).ensureDebugId(baseID + DeModule.PreferenceIds.CANCEL);
-        defaultsBtn.ensureDebugId(baseID + DeModule.PreferenceIds.DEFAULTS_BTN);
-
-        enableAnalysisEmailNotification.ensureDebugId(baseID + DeModule.PreferenceIds.EMAIL_ANALYSIS_NOTIFICATION);
-        enableImportEmailNotification.ensureDebugId(baseID + DeModule.PreferenceIds.EMAIL_IMPORT_NOTIFICATION);
-        rememberLastPath.ensureDebugId(baseID + DeModule.PreferenceIds.REMEMBER_LAST_PATH);
-        saveSession.ensureDebugId(baseID + DeModule.PreferenceIds.SAVE_SESSION);
-        defaultOutputFolder.ensureDebugId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER);
-        defaultOutputFolder.setInputFieldId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER + DeModule.PreferenceIds.DEFAULT_OUTPUT_FIELD);
-        defaultOutputFolder.setBrowseButtonId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER + DeModule.PreferenceIds.BROWSE_OUTPUT_FOLDER);
-
-        appsShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.APPS_SC);
-        dataShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.DATA_SC);
-        analysesShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.ANALYSES_SC);
-        notifyShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.NOTIFICATION_SC);
-        closeShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.CLOSE_SC);
-
-    }
-
-    @UiHandler({"appsShortCut", "dataShortCut", "analysesShortCut", "notifyShortCut", "closeShortCut"})
-    void onKeyPress(KeyPressEvent event) {
-        TextField fld = (TextField) event.getSource();
-        int code = event.getNativeEvent().getCharCode();
-        if ((code > 96 && code <= 122)) {
-            fld.clear();
-            fld.setValue((event.getCharCode() + "").toUpperCase());
-            fld.setText((event.getCharCode() + "").toUpperCase());
-            fld.setCursorPos(1);
-            fld.focus();
-        } else if ((code > 47 && code <= 57) || (code > 64 && code <= 90)) {
-            fld.clear();
-            fld.setValue(event.getCharCode() + "");
-            fld.setText(event.getCharCode() + "");
-            fld.setCursorPos(1);
-            fld.focus();
-        }
-        if (code != 0) {
-            event.preventDefault();
-        }
-
-    }
-
-    @UiHandler("retrySession")
-    void onRetrySessionClicked(SelectEvent event) {
-        saveSession.setBoxLabel(appearance.saveSession());
-        retrySession.setVisible(false);
-    }
 
     private Widget constructHelpView() {
-        HtmlLayoutContainerTemplate templates = GWT.create(HtmlLayoutContainerTemplate.class);
+        HtmlLayoutContainerTemplate
+                templates = GWT.create(HtmlLayoutContainerTemplate.class);
         HtmlLayoutContainer c = new HtmlLayoutContainer(templates.getTemplate());
         c.add(new HTML(appearance.notifyEmail()), new HtmlData(".emailHeader"));
         c.add(new HTML(appearance.notifyEmailHelp()), new HtmlData(".emailHelp"));
@@ -327,18 +94,11 @@ public class PreferencesDialog extends IPlantDialog implements Editor<UserSettin
         return c.asWidget();
     }
 
-    private void populateKbMap() {
-        kbMap.put(appsShortCut, appsShortCut.getValue());
-        kbMap.put(dataShortCut, dataShortCut.getValue());
-        kbMap.put(analysesShortCut, analysesShortCut.getValue());
-        kbMap.put(notifyShortCut, notifyShortCut.getValue());
-        kbMap.put(closeShortCut, closeShortCut.getValue());
-    }
-
-    private void resetKbFieldErrors() {
-        for (TextField ks : kbMap.keySet()) {
-            ks.clearInvalid();
+    @Override
+    public void onDialogHide(DialogHideEvent event) {
+        if (Dialog.PredefinedButton.OK.equals(event.getHideButton())) {
+            presenter.saveUserSettings();
+            hide();
         }
     }
-
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesDialog.java
@@ -165,18 +165,7 @@ public class PreferencesDialog extends IPlantDialog implements Editor<UserSettin
         defaultsBtn.addSelectHandler(new SelectEvent.SelectHandler() {
             @Override
             public void onSelect(SelectEvent event) {
-                enableAnalysisEmailNotification.setValue(true);
-                enableImportEmailNotification.setValue(true);
-                enableWaitTimeMessage.setValue(true);
-                rememberLastPath.setValue(true);
-                saveSession.setValue(true);
-                appsShortCut.setValue(KB_CONSTANTS.appsKeyShortCut());
-                dataShortCut.setValue(KB_CONSTANTS.dataKeyShortCut());
-                analysesShortCut.setValue(KB_CONSTANTS.analysisKeyShortCut());
-                notifyShortCut.setValue(KB_CONSTANTS.notifyKeyShortCut());
-                closeShortCut.setValue(KB_CONSTANTS.closeKeyShortCut());
-                final Folder systemDefaultOutputFolder = usValue.getSystemDefaultOutputFolder();
-                defaultOutputFolder.setValue(systemDefaultOutputFolder);
+                setDefaultValues();
             }
         });
         getButtonBar().insert(defaultsBtn, 0);
@@ -239,17 +228,7 @@ public class PreferencesDialog extends IPlantDialog implements Editor<UserSettin
 
 
         } else if (button == defaultsBtn) {
-            enableAnalysisEmailNotification.setValue(true);
-            enableImportEmailNotification.setValue(true);
-            enableWaitTimeMessage.setValue(true);
-            rememberLastPath.setValue(true);
-            saveSession.setValue(true);
-            appsShortCut.setValue(KB_CONSTANTS.appsKeyShortCut());
-            dataShortCut.setValue(KB_CONSTANTS.dataKeyShortCut());
-            analysesShortCut.setValue(KB_CONSTANTS.analysisKeyShortCut());
-            notifyShortCut.setValue(KB_CONSTANTS.notifyKeyShortCut());
-            closeShortCut.setValue(KB_CONSTANTS.closeKeyShortCut());
-            defaultOutputFolder.setValue(us.getSystemDefaultOutputFolder());
+            setDefaultValues();
             if (isValid()) {
                 super.onButtonPressed(button);
             }
@@ -257,6 +236,20 @@ public class PreferencesDialog extends IPlantDialog implements Editor<UserSettin
             super.onButtonPressed(button);
         }
 
+    }
+
+    void setDefaultValues() {
+        enableAnalysisEmailNotification.setValue(true);
+        enableImportEmailNotification.setValue(true);
+        enableWaitTimeMessage.setValue(true);
+        rememberLastPath.setValue(true);
+        saveSession.setValue(true);
+        appsShortCut.setValue(KB_CONSTANTS.appsKeyShortCut());
+        dataShortCut.setValue(KB_CONSTANTS.dataKeyShortCut());
+        analysesShortCut.setValue(KB_CONSTANTS.analysisKeyShortCut());
+        notifyShortCut.setValue(KB_CONSTANTS.notifyKeyShortCut());
+        closeShortCut.setValue(KB_CONSTANTS.closeKeyShortCut());
+        defaultOutputFolder.setValue(us.getSystemDefaultOutputFolder());
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesDialog.java
@@ -93,6 +93,10 @@ public class PreferencesDialog extends IPlantDialog implements Editor<UserSettin
         String notifyEmail();
 
         String waitTime();
+
+        String retrySessionConnection();
+
+        String sessionConnectionFailed();
     }
 
     public interface HtmlLayoutContainerTemplate extends XTemplates {
@@ -116,6 +120,7 @@ public class PreferencesDialog extends IPlantDialog implements Editor<UserSettin
     @UiField CheckBox enableImportEmailNotification;
     @UiField CheckBox enableWaitTimeMessage;
     @UiField CheckBox saveSession;
+    @UiField @Ignore TextButton retrySession;
     @UiField TextField closeShortCut;
     @UiField TextField dataShortCut;
     @UiField(provided = true) FolderSelectorField defaultOutputFolder;
@@ -188,6 +193,10 @@ public class PreferencesDialog extends IPlantDialog implements Editor<UserSettin
     public void initAndShow(final UserSettings userSettings) {
         this.usValue = userSettings;
         editorDriver.edit(userSettings);
+        if (userSettings.sessionConnectionFailed()) {
+            retrySession.setVisible(true);
+            saveSession.setBoxLabel(appearance.sessionConnectionFailed());
+        }
         show();
         ensureDebugId(DeModule.PreferenceIds.PREFERENCES_DLG);
     }
@@ -296,6 +305,12 @@ public class PreferencesDialog extends IPlantDialog implements Editor<UserSettin
             event.preventDefault();
         }
 
+    }
+
+    @UiHandler("retrySession")
+    void onRetrySessionClicked(SelectEvent event) {
+        saveSession.setBoxLabel(appearance.saveSession());
+        retrySession.setVisible(false);
     }
 
     private Widget constructHelpView() {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/PreferencesView.ui.xml
@@ -3,6 +3,7 @@
              xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
              xmlns:g="urn:import:com.google.gwt.user.client.ui"
              xmlns:selector="urn:import:org.iplantc.de.diskResource.client.views.widgets"
+             xmlns:button="urn:import:com.sencha.gxt.widget.core.client.button"
              xmlns:form="urn:import:com.sencha.gxt.widget.core.client.form">
 
     <ui:with field="appearance" type="org.iplantc.de.desktop.client.views.widgets.PreferencesDialog.PreferencesViewAppearance" />
@@ -59,9 +60,14 @@
                                    boxLabel="{appearance.rememberFileSectorPath}"/>
                 </container:child>
                 <container:child layoutData="{preferenceLayoutData}">
-                    <form:CheckBox ui:field="saveSession"
+                    <g:HorizontalPanel>
+                        <form:CheckBox ui:field="saveSession"
                                    debugId="cboSaveSession"
                                    boxLabel="{appearance.saveSession}"/>
+                        <button:TextButton ui:field="retrySession"
+                                        text="{appearance.retrySessionConnection}"
+                                        visible="false"/>
+                    </g:HorizontalPanel>
                 </container:child>
                 <container:child layoutData="{preferenceLayoutData}">
                     <form:CheckBox ui:field="enableWaitTimeMessage"

--- a/de-lib/src/main/java/org/iplantc/de/desktop/shared/DeModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/shared/DeModule.java
@@ -43,25 +43,6 @@ public interface DeModule {
         String SUPPORT_BTN = ".support";
     }
 
-    interface PreferenceIds {
-        String PREFERENCES_DLG = "preferencesDlg";
-        String DONE = ".done";
-        String CANCEL = ".cancel";
-        String DEFAULTS_BTN = ".defaults";
-        String APPS_SC = ".appsShortcut";
-        String DATA_SC = ".dataShortcut";
-        String ANALYSES_SC = ".analysesShortcut";
-        String NOTIFICATION_SC = ".notificationsShortcut";
-        String CLOSE_SC = ".closeActiveShortcut";
-        String EMAIL_ANALYSIS_NOTIFICATION = ".emailAnalysisNotification";
-        String EMAIL_IMPORT_NOTIFICATION = ".emailImportNotification";
-        String REMEMBER_LAST_PATH = ".rememberLastPath";
-        String SAVE_SESSION = ".saveSession";
-        String DEFAULT_OUTPUT_FOLDER = ".defaultOutputFolder";
-        String BROWSE_OUTPUT_FOLDER = ".browseButton";
-        String DEFAULT_OUTPUT_FIELD = ".inputField";
-    }
-
     interface WindowIds {
 
         /**

--- a/de-lib/src/main/java/org/iplantc/de/preferences/Preferences.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/Preferences.gwt.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.0//EN"
+        "http://google-web-toolkit.googlecode.com/svn/releases/2.0/distro-source/core/src/gwt-module.dtd">
+<module>
+
+    <inherits name='com.google.gwt.user.User'/>
+    <inherits name="org.iplantc.de.DiscoveryEnvironmentCommon"/>
+    <inherits name="org.iplantc.de.commons.ui-commons" />
+    <inherits name="org.iplantc.de.apps.widgets.Widgets"/>
+
+    <source path="client"/>
+    <source path="shared"/>
+
+</module>

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/PreferencesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/PreferencesView.java
@@ -1,0 +1,97 @@
+package org.iplantc.de.preferences.client;
+
+import org.iplantc.de.client.models.UserSettings;
+import org.iplantc.de.desktop.client.DesktopView;
+import org.iplantc.de.preferences.client.events.PrefDlgRetryUserSessionClicked;
+
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.user.client.ui.IsWidget;
+
+/**
+ * @author aramsey
+ */
+public interface PreferencesView extends IsWidget,
+                                         PrefDlgRetryUserSessionClicked.HasPrefDlgRetryUserSessionClickedHandlers {
+
+    interface PreferencesViewAppearance {
+
+        String defaultOutputFolderHelp();
+
+        String done();
+
+        String duplicateShortCutKey(String key);
+
+        String notifyEmailHelp();
+
+        String preferences();
+
+        String notifyAnalysisEmail();
+
+        String notifyImportEmail();
+
+        String completeRequiredFieldsError();
+
+        String rememberFileSectorPath();
+
+        String rememberFileSectorPathHelp();
+
+        String restoreDefaults();
+
+        String saveSession();
+
+        String defaultOutputFolder();
+
+        String keyboardShortCut();
+
+        String openAppsWindow();
+
+        String kbShortcutMetaKey();
+
+        String oneCharMax();
+
+        String openDataWindow();
+
+        String openAnalysesWindow();
+
+        String openNotificationsWindow();
+
+        String closeActiveWindow();
+
+        String saveSessionHelp();
+
+        String notifyEmail();
+
+        String retrySessionConnection();
+
+        SafeHtml sessionConnectionFailed();
+    }
+
+    void userSessionSuccess();
+
+    void userSessionFail();
+
+    void initAndShow(UserSettings userSettings);
+
+    UserSettings getValue();
+
+    void setDefaultValues();
+
+    void hide();
+
+    boolean isValid();
+
+    void flush();
+
+    void saveUserSettings();
+
+    interface Presenter {
+
+        void go(DesktopView.Presenter presenter, UserSettings userSettings);
+
+        void setDefaultValues();
+
+        void saveUserSettings();
+
+        PreferencesView getView();
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/PreferencesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/PreferencesView.java
@@ -61,6 +61,8 @@ public interface PreferencesView extends IsWidget,
 
         String notifyEmail();
 
+        String waitTime();
+
         String retrySessionConnection();
 
         SafeHtml sessionConnectionFailed();

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/PreferencesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/PreferencesView.java
@@ -93,5 +93,7 @@ public interface PreferencesView extends IsWidget,
         void saveUserSettings();
 
         PreferencesView getView();
+
+        void setViewDebugId(String baseId);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/events/PrefDlgRetryUserSessionClicked.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/events/PrefDlgRetryUserSessionClicked.java
@@ -1,0 +1,31 @@
+package org.iplantc.de.preferences.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class PrefDlgRetryUserSessionClicked
+        extends GwtEvent<PrefDlgRetryUserSessionClicked.PrefDlgRetryUserSessionClickedHandler> {
+
+    public interface PrefDlgRetryUserSessionClickedHandler extends EventHandler {
+        void onPrefDlgRetryUserSessionClicked(PrefDlgRetryUserSessionClicked event);
+    }
+
+    public interface HasPrefDlgRetryUserSessionClickedHandlers {
+        HandlerRegistration addPrefDlgRetryUserSessionClickedHandlers(PrefDlgRetryUserSessionClickedHandler handler);
+    }
+
+    public static Type<PrefDlgRetryUserSessionClickedHandler> TYPE =
+            new Type<PrefDlgRetryUserSessionClickedHandler>();
+
+    public Type<PrefDlgRetryUserSessionClickedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(PrefDlgRetryUserSessionClickedHandler handler) {
+        handler.onPrefDlgRetryUserSessionClicked(this);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/gin/PreferencesGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/gin/PreferencesGinModule.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.preferences.client.gin;
+
+import org.iplantc.de.preferences.client.PreferencesView;
+import org.iplantc.de.preferences.client.presenter.PreferencesPresenterImpl;
+import org.iplantc.de.preferences.client.view.PreferencesViewImpl;
+
+import com.google.gwt.inject.client.AbstractGinModule;
+
+/**
+ * @author aramsey
+ */
+public class PreferencesGinModule extends AbstractGinModule {
+    @Override
+    protected void configure() {
+        bind(PreferencesView.class).to(PreferencesViewImpl.class);
+        bind(PreferencesView.Presenter.class).to(PreferencesPresenterImpl.class);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/presenter/PreferencesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/presenter/PreferencesPresenterImpl.java
@@ -1,0 +1,73 @@
+package org.iplantc.de.preferences.client.presenter;
+
+import org.iplantc.de.client.models.UserSettings;
+import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.services.UserSessionServiceFacade;
+import org.iplantc.de.desktop.client.DesktopView;
+import org.iplantc.de.preferences.client.events.PrefDlgRetryUserSessionClicked;
+import org.iplantc.de.preferences.client.PreferencesView;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public class PreferencesPresenterImpl implements PreferencesView.Presenter,
+                                                 PrefDlgRetryUserSessionClicked.PrefDlgRetryUserSessionClickedHandler {
+
+
+    private final PreferencesView view;
+    private final UserSessionServiceFacade serviceFacade;
+    DesktopView.Presenter desktopPresenter;
+
+    @Inject
+    public PreferencesPresenterImpl(PreferencesView view,
+                                    UserSessionServiceFacade serviceFacade) {
+        this.view = view;
+        this.serviceFacade = serviceFacade;
+
+        this.view.addPrefDlgRetryUserSessionClickedHandlers(this);
+    }
+
+    @Override
+    public void go(DesktopView.Presenter presenter, UserSettings userSettings) {
+        this.desktopPresenter = presenter;
+        view.initAndShow(userSettings);
+    }
+
+    @Override
+    public void setDefaultValues() {
+        view.setDefaultValues();
+    }
+
+    @Override
+    public void onPrefDlgRetryUserSessionClicked(PrefDlgRetryUserSessionClicked event) {
+        serviceFacade.getUserSession(new AsyncCallback<List<WindowState>>() {
+
+            @Override
+            public void onFailure(Throwable caught) {
+                view.userSessionFail();
+            }
+
+            @Override
+            public void onSuccess(List<WindowState> result) {
+                view.userSessionSuccess();
+                desktopPresenter.restoreWindows(result);
+                desktopPresenter.doPeriodicSessionSave();
+            }
+        });
+    }
+
+    @Override
+    public void saveUserSettings() {
+        desktopPresenter.saveUserSettings(view.getValue(), false);
+    }
+
+    @Override
+    public PreferencesView getView() {
+        return view;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/presenter/PreferencesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/presenter/PreferencesPresenterImpl.java
@@ -70,4 +70,9 @@ public class PreferencesPresenterImpl implements PreferencesView.Presenter,
     public PreferencesView getView() {
         return view;
     }
+
+    @Override
+    public void setViewDebugId(String baseId) {
+        view.asWidget().ensureDebugId(baseId);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
@@ -41,7 +41,7 @@
         <form:FieldSet headingText="{appearance.preferences}"
                        collapsible="true">
             <container:VerticalLayoutContainer ui:field="prefContainer"
-                                               height="150">
+                                               height="170">
                 <container:child layoutData="{preferenceLayoutData}">
                     <form:CheckBox ui:field="enableAnalysisEmailNotification"
                                    debugId="idCboAnalysisNotifyEmail"

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
@@ -6,7 +6,7 @@
              xmlns:button="urn:import:com.sencha.gxt.widget.core.client.button"
              xmlns:form="urn:import:com.sencha.gxt.widget.core.client.form">
 
-    <ui:with field="appearance" type="org.iplantc.de.desktop.client.views.widgets.PreferencesDialog.PreferencesViewAppearance" />
+    <ui:with field="appearance" type="org.iplantc.de.preferences.client.PreferencesView.PreferencesViewAppearance" />
 
     <ui:style>
         .user_pref {
@@ -64,6 +64,8 @@
                         <form:CheckBox ui:field="saveSession"
                                    debugId="cboSaveSession"
                                    boxLabel="{appearance.saveSession}"/>
+                        <g:HTML ui:field="savedSessionFailed"
+                                        visible="false"/>
                         <button:TextButton ui:field="retrySession"
                                         text="{appearance.retrySessionConnection}"
                                         visible="false"/>

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
@@ -58,6 +58,7 @@ public class PreferencesViewImpl extends Composite implements PreferencesView,
     @UiField CheckBox rememberLastPath;
     @UiField CheckBox enableAnalysisEmailNotification;
     @UiField CheckBox enableImportEmailNotification;
+    @UiField CheckBox enableWaitTimeMessage;
     @UiField CheckBox saveSession;
     @UiField @Ignore HTML savedSessionFailed;
     @UiField @Ignore TextButton retrySession;
@@ -170,6 +171,7 @@ public class PreferencesViewImpl extends Composite implements PreferencesView,
     public void setDefaultValues() {
         enableAnalysisEmailNotification.setValue(true);
         enableImportEmailNotification.setValue(true);
+        enableWaitTimeMessage.setValue(true);
         rememberLastPath.setValue(true);
         saveSession.setValue(true);
         appsShortCut.setValue(KB_CONSTANTS.appsKeyShortCut());

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
@@ -1,0 +1,259 @@
+package org.iplantc.de.preferences.client.view;
+
+import org.iplantc.de.apps.widgets.client.view.editors.validation.AnalysisOutputValidator;
+import org.iplantc.de.client.KeyBoardShortcutConstants;
+import org.iplantc.de.client.models.UserSettings;
+import org.iplantc.de.client.models.diskResources.Folder;
+import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
+import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.desktop.shared.DeModule;
+import org.iplantc.de.diskResource.client.gin.factory.DiskResourceSelectorFieldFactory;
+import org.iplantc.de.diskResource.client.views.widgets.FolderSelectorField;
+import org.iplantc.de.preferences.client.PreferencesView;
+import org.iplantc.de.preferences.client.events.PrefDlgRetryUserSessionClicked;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.editor.client.Editor;
+import com.google.gwt.editor.client.SimpleBeanEditorDriver;
+import com.google.gwt.event.dom.client.KeyPressEvent;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.uibinder.client.UiTemplate;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.inject.Inject;
+
+import com.sencha.gxt.widget.core.client.Composite;
+import com.sencha.gxt.widget.core.client.button.TextButton;
+import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
+import com.sencha.gxt.widget.core.client.form.CheckBox;
+import com.sencha.gxt.widget.core.client.form.TextField;
+import com.sencha.gxt.widget.core.client.form.validator.MaxLengthValidator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author sriram, jstroot
+ */
+public class PreferencesViewImpl extends Composite implements PreferencesView,
+                                                              Editor<UserSettings> {
+
+
+    @UiTemplate("PreferencesView.ui.xml")
+    interface MyUiBinder extends UiBinder<VerticalLayoutContainer, PreferencesViewImpl> { }
+
+    interface EditorDriver extends SimpleBeanEditorDriver<UserSettings, PreferencesViewImpl>{}
+
+    @UiField @Ignore VerticalLayoutContainer container;
+    @UiField @Ignore VerticalLayoutContainer kbContainer;
+    @UiField @Ignore VerticalLayoutContainer prefContainer;
+
+    @UiField TextField analysesShortCut;
+    @UiField TextField appsShortCut;
+    @UiField CheckBox rememberLastPath;
+    @UiField CheckBox enableAnalysisEmailNotification;
+    @UiField CheckBox enableImportEmailNotification;
+    @UiField CheckBox saveSession;
+    @UiField @Ignore HTML savedSessionFailed;
+    @UiField @Ignore TextButton retrySession;
+    @UiField TextField closeShortCut;
+    @UiField TextField dataShortCut;
+    @UiField(provided = true) FolderSelectorField defaultOutputFolder;
+    @UiField TextField notifyShortCut;
+    @UiField(provided = true) PreferencesViewAppearance appearance;
+
+    private final KeyBoardShortcutConstants KB_CONSTANTS;
+    private final Map<TextField, String> kbMap;
+
+    private final EditorDriver editorDriver = GWT.create(EditorDriver.class);
+    private static MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
+
+    private UserSettings flushedValue;
+    private UserSettings usValue;
+
+    @Inject UserSettings us;
+
+    @Inject
+    PreferencesViewImpl(final DiskResourceSelectorFieldFactory folderSelectorFieldFactory,
+                        final PreferencesViewAppearance appearance,
+                        final KeyBoardShortcutConstants kbConstants) {
+        this.appearance = appearance;
+        this.defaultOutputFolder = folderSelectorFieldFactory.defaultFolderSelector();
+        this.defaultOutputFolder.hideResetButton();
+        this.KB_CONSTANTS = kbConstants;
+        initWidget(uiBinder.createAndBindUi(this));
+
+        kbMap = new HashMap<>();
+        appsShortCut.addValidator(new MaxLengthValidator(1));
+        dataShortCut.addValidator(new MaxLengthValidator(1));
+        analysesShortCut.addValidator(new MaxLengthValidator(1));
+        notifyShortCut.addValidator(new MaxLengthValidator(1));
+        closeShortCut.addValidator(new MaxLengthValidator(1));
+        defaultOutputFolder.addValidator(new AnalysisOutputValidator());
+        defaultOutputFolder.addValueChangeHandler(new ValueChangeHandler<Folder>() {
+
+            @Override
+            public void onValueChange(ValueChangeEvent<Folder> event) {
+                defaultOutputFolder.validate(false);
+            }
+        });
+        populateKbMap();
+        savedSessionFailed.setHTML(appearance.sessionConnectionFailed());
+
+        editorDriver.initialize(this);
+    }
+
+    @Override
+    public HandlerRegistration addPrefDlgRetryUserSessionClickedHandlers(PrefDlgRetryUserSessionClicked.PrefDlgRetryUserSessionClickedHandler handler) {
+        return addHandler(handler, PrefDlgRetryUserSessionClicked.TYPE);
+    }
+    @Ignore
+    public UserSettings getValue() {
+        return flushedValue;
+    }
+
+    @Override
+    public void initAndShow(final UserSettings userSettings) {
+        this.usValue = userSettings;
+        editorDriver.edit(userSettings);
+        if (userSettings.sessionConnectionFailed()) {
+            userSessionFail();
+        }
+        show();
+        ensureDebugId(DeModule.PreferenceIds.PREFERENCES_DLG);
+    }
+
+    public boolean isValid() {
+        boolean valid = defaultOutputFolder.validate(false) && appsShortCut.isValid() && dataShortCut.isValid()
+                            && analysesShortCut.isValid() && notifyShortCut.isValid() && closeShortCut.isValid();
+
+        if (valid) {
+            populateKbMap();
+            resetKbFieldErrors();
+            for (TextField ks : kbMap.keySet()) {
+                for (TextField sc : kbMap.keySet()) {
+                    if (ks != sc) {
+                        if (kbMap.get(ks).equals(kbMap.get(sc))) {
+                            ks.markInvalid(appearance.duplicateShortCutKey(kbMap.get(ks)));
+                            sc.markInvalid(appearance.duplicateShortCutKey(kbMap.get(ks)));
+                            valid = false;
+                        }
+                    }
+                }
+            }
+        }
+        return valid;
+    }
+
+    @Override
+    public void flush() {
+        UserSettings value = editorDriver.flush();
+        if (!editorDriver.hasErrors() && isValid()) {
+            this.flushedValue = value;
+        } else {
+            IplantAnnouncer.getInstance()
+                           .schedule(new ErrorAnnouncementConfig(appearance.completeRequiredFieldsError()));
+        }
+    }
+
+    @Override
+    public void saveUserSettings() {
+
+    }
+
+    @Override
+    public void setDefaultValues() {
+        enableAnalysisEmailNotification.setValue(true);
+        enableImportEmailNotification.setValue(true);
+        rememberLastPath.setValue(true);
+        saveSession.setValue(true);
+        appsShortCut.setValue(KB_CONSTANTS.appsKeyShortCut());
+        dataShortCut.setValue(KB_CONSTANTS.dataKeyShortCut());
+        analysesShortCut.setValue(KB_CONSTANTS.analysisKeyShortCut());
+        notifyShortCut.setValue(KB_CONSTANTS.notifyKeyShortCut());
+        closeShortCut.setValue(KB_CONSTANTS.closeKeyShortCut());
+        defaultOutputFolder.setValue(us.getSystemDefaultOutputFolder());
+    }
+
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        enableAnalysisEmailNotification.ensureDebugId(baseID + DeModule.PreferenceIds.EMAIL_ANALYSIS_NOTIFICATION);
+        enableImportEmailNotification.ensureDebugId(baseID + DeModule.PreferenceIds.EMAIL_IMPORT_NOTIFICATION);
+        rememberLastPath.ensureDebugId(baseID + DeModule.PreferenceIds.REMEMBER_LAST_PATH);
+        saveSession.ensureDebugId(baseID + DeModule.PreferenceIds.SAVE_SESSION);
+        defaultOutputFolder.ensureDebugId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER);
+        defaultOutputFolder.setInputFieldId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER + DeModule.PreferenceIds.DEFAULT_OUTPUT_FIELD);
+        defaultOutputFolder.setBrowseButtonId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER + DeModule.PreferenceIds.BROWSE_OUTPUT_FOLDER);
+
+        appsShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.APPS_SC);
+        dataShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.DATA_SC);
+        analysesShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.ANALYSES_SC);
+        notifyShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.NOTIFICATION_SC);
+        closeShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.CLOSE_SC);
+
+    }
+
+    @UiHandler({"appsShortCut", "dataShortCut", "analysesShortCut", "notifyShortCut", "closeShortCut"})
+    void onKeyPress(KeyPressEvent event) {
+        TextField fld = (TextField) event.getSource();
+        int code = event.getNativeEvent().getCharCode();
+        if ((code > 96 && code <= 122)) {
+            fld.clear();
+            fld.setValue((event.getCharCode() + "").toUpperCase());
+            fld.setText((event.getCharCode() + "").toUpperCase());
+            fld.setCursorPos(1);
+            fld.focus();
+        } else if ((code > 47 && code <= 57) || (code > 64 && code <= 90)) {
+            fld.clear();
+            fld.setValue(event.getCharCode() + "");
+            fld.setText(event.getCharCode() + "");
+            fld.setCursorPos(1);
+            fld.focus();
+        }
+        if (code != 0) {
+            event.preventDefault();
+        }
+
+    }
+
+    @UiHandler("retrySession")
+    void onRetrySessionClicked(SelectEvent event) {
+        savedSessionFailed.setVisible(false);
+        fireEvent(new PrefDlgRetryUserSessionClicked());
+    }
+
+    private void populateKbMap() {
+        kbMap.put(appsShortCut, appsShortCut.getValue());
+        kbMap.put(dataShortCut, dataShortCut.getValue());
+        kbMap.put(analysesShortCut, analysesShortCut.getValue());
+        kbMap.put(notifyShortCut, notifyShortCut.getValue());
+        kbMap.put(closeShortCut, closeShortCut.getValue());
+    }
+
+    private void resetKbFieldErrors() {
+        for (TextField ks : kbMap.keySet()) {
+            ks.clearInvalid();
+        }
+    }
+
+    @Override
+    public void userSessionSuccess() {
+        saveSession.setVisible(true);
+        savedSessionFailed.setVisible(false);
+        retrySession.setVisible(false);
+    }
+
+    @Override
+    public void userSessionFail() {
+        saveSession.setVisible(false);
+        savedSessionFailed.setVisible(true);
+        retrySession.setVisible(true);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
@@ -6,11 +6,11 @@ import org.iplantc.de.client.models.UserSettings;
 import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
-import org.iplantc.de.desktop.shared.DeModule;
 import org.iplantc.de.diskResource.client.gin.factory.DiskResourceSelectorFieldFactory;
 import org.iplantc.de.diskResource.client.views.widgets.FolderSelectorField;
 import org.iplantc.de.preferences.client.PreferencesView;
 import org.iplantc.de.preferences.client.events.PrefDlgRetryUserSessionClicked;
+import org.iplantc.de.preferences.shared.Preferences;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
@@ -125,7 +125,7 @@ public class PreferencesViewImpl extends Composite implements PreferencesView,
             userSessionFail();
         }
         show();
-        ensureDebugId(DeModule.PreferenceIds.PREFERENCES_DLG);
+        ensureDebugId(Preferences.Ids.PREFERENCES_DLG);
     }
 
     public boolean isValid() {
@@ -184,19 +184,19 @@ public class PreferencesViewImpl extends Composite implements PreferencesView,
     protected void onEnsureDebugId(String baseID) {
         super.onEnsureDebugId(baseID);
 
-        enableAnalysisEmailNotification.ensureDebugId(baseID + DeModule.PreferenceIds.EMAIL_ANALYSIS_NOTIFICATION);
-        enableImportEmailNotification.ensureDebugId(baseID + DeModule.PreferenceIds.EMAIL_IMPORT_NOTIFICATION);
-        rememberLastPath.ensureDebugId(baseID + DeModule.PreferenceIds.REMEMBER_LAST_PATH);
-        saveSession.ensureDebugId(baseID + DeModule.PreferenceIds.SAVE_SESSION);
-        defaultOutputFolder.ensureDebugId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER);
-        defaultOutputFolder.setInputFieldId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER + DeModule.PreferenceIds.DEFAULT_OUTPUT_FIELD);
-        defaultOutputFolder.setBrowseButtonId(baseID + DeModule.PreferenceIds.DEFAULT_OUTPUT_FOLDER + DeModule.PreferenceIds.BROWSE_OUTPUT_FOLDER);
+        enableAnalysisEmailNotification.ensureDebugId(baseID + Preferences.Ids.EMAIL_ANALYSIS_NOTIFICATION);
+        enableImportEmailNotification.ensureDebugId(baseID + Preferences.Ids.EMAIL_IMPORT_NOTIFICATION);
+        rememberLastPath.ensureDebugId(baseID + Preferences.Ids.REMEMBER_LAST_PATH);
+        saveSession.ensureDebugId(baseID + Preferences.Ids.SAVE_SESSION);
+        defaultOutputFolder.ensureDebugId(baseID + Preferences.Ids.DEFAULT_OUTPUT_FOLDER);
+        defaultOutputFolder.setInputFieldId(baseID + Preferences.Ids.DEFAULT_OUTPUT_FOLDER + Preferences.Ids.DEFAULT_OUTPUT_FIELD);
+        defaultOutputFolder.setBrowseButtonId(baseID + Preferences.Ids.DEFAULT_OUTPUT_FOLDER + Preferences.Ids.BROWSE_OUTPUT_FOLDER);
 
-        appsShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.APPS_SC);
-        dataShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.DATA_SC);
-        analysesShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.ANALYSES_SC);
-        notifyShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.NOTIFICATION_SC);
-        closeShortCut.ensureDebugId(baseID + DeModule.PreferenceIds.CLOSE_SC);
+        appsShortCut.ensureDebugId(baseID + Preferences.Ids.APPS_SC);
+        dataShortCut.ensureDebugId(baseID + Preferences.Ids.DATA_SC);
+        analysesShortCut.ensureDebugId(baseID + Preferences.Ids.ANALYSES_SC);
+        notifyShortCut.ensureDebugId(baseID + Preferences.Ids.NOTIFICATION_SC);
+        closeShortCut.ensureDebugId(baseID + Preferences.Ids.CLOSE_SC);
 
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/preferences/shared/Preferences.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/shared/Preferences.java
@@ -1,0 +1,26 @@
+package org.iplantc.de.preferences.shared;
+
+/**
+ * @author aramsey
+ */
+public interface Preferences {
+
+    interface Ids {
+        String PREFERENCES_DLG = "preferencesDlg";
+        String DONE = ".done";
+        String CANCEL = ".cancel";
+        String DEFAULTS_BTN = ".defaults";
+        String APPS_SC = ".appsShortcut";
+        String DATA_SC = ".dataShortcut";
+        String ANALYSES_SC = ".analysesShortcut";
+        String NOTIFICATION_SC = ".notificationsShortcut";
+        String CLOSE_SC = ".closeActiveShortcut";
+        String EMAIL_ANALYSIS_NOTIFICATION = ".emailAnalysisNotification";
+        String EMAIL_IMPORT_NOTIFICATION = ".emailImportNotification";
+        String REMEMBER_LAST_PATH = ".rememberLastPath";
+        String SAVE_SESSION = ".saveSession";
+        String DEFAULT_OUTPUT_FOLDER = ".defaultOutputFolder";
+        String BROWSE_OUTPUT_FOLDER = ".browseButton";
+        String DEFAULT_OUTPUT_FIELD = ".inputField";
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/Desktop.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/Desktop.gwt.xml
@@ -38,7 +38,7 @@
     </replace-with>
 
     <replace-with class="org.iplantc.de.theme.base.client.desktop.PreferencesViewDefaultAppearance">
-        <when-type-is class="org.iplantc.de.desktop.client.views.widgets.PreferencesDialog.PreferencesViewAppearance" />
+        <when-type-is class="org.iplantc.de.preferences.client.PreferencesView.PreferencesViewAppearance"/>
     </replace-with>
 
     <replace-with class="org.iplantc.de.theme.base.client.desktop.presenter.DesktopPresenterDefaultAppearance">

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopErrorMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopErrorMessages.properties
@@ -1,6 +1,6 @@
 fetchNotificationsError = There was a problem fetching your current notifications
 feedbackServiceFailure = Unable to submit your feedback. We appreciate your time for giving feedback. Please contact CyVerse support at support@cyverse.org.
-loadSessionFailed = Could not load session.
+loadSessionFailed = Could not load last saved session.  Your current session will not be saved.  To retry, check Preferences.
 saveSessionFailed = Could not save session.
 systemInitializationError = Unable to retrieve the configuration settings from the server.
 permissionErrorTitle = Permission Error

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.java
@@ -102,4 +102,8 @@ public interface DesktopMessages extends Messages {
     String requestHistoryError();
 
     String waitTime();
+
+    String retrySessionConnection();
+
+    String sessionConnectionFailed();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.properties
@@ -30,3 +30,5 @@ savingSession = Saving Session
 savingSessionWaitNotice = Saving current session, please wait...
 requestHistoryError = Unable to retrieve request history!
 waitTime = Display warning about wait times for submitting HPC apps.
+retrySessionConnection = Try Again
+sessionConnectionFailed = Connection to session service failed.

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/PreferencesViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/PreferencesViewDefaultAppearance.java
@@ -146,4 +146,13 @@ public class PreferencesViewDefaultAppearance implements PreferencesDialog.Prefe
     public String waitTime() {
         return desktopMessages.waitTime();
     }
+
+    public String retrySessionConnection() {
+        return desktopMessages.retrySessionConnection();
+    }
+
+    @Override
+    public String sessionConnectionFailed() {
+        return desktopMessages.sessionConnectionFailed();
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/PreferencesViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/PreferencesViewDefaultAppearance.java
@@ -1,30 +1,43 @@
 package org.iplantc.de.theme.base.client.desktop;
 
-import org.iplantc.de.desktop.client.views.widgets.PreferencesDialog;
+import org.iplantc.de.preferences.client.PreferencesView;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtml;
+
+import com.sencha.gxt.core.client.XTemplates;
 
 /**
  * @author jstroot
  */
-public class PreferencesViewDefaultAppearance implements PreferencesDialog.PreferencesViewAppearance {
+public class PreferencesViewDefaultAppearance implements PreferencesView.PreferencesViewAppearance {
+
+    interface Templates extends XTemplates {
+        @XTemplates.XTemplate("<span style='color: red;'>{label}</span>")
+        SafeHtml redText(String label);
+    }
+
     private final IplantDisplayStrings displayStrings;
     private final DesktopContextualHelpMessages help;
     private final DesktopMessages desktopMessages;
+    private Templates templates;
 
     PreferencesViewDefaultAppearance(final IplantDisplayStrings displayStrings,
                                      final DesktopContextualHelpMessages help,
-                                     final DesktopMessages desktopMessages) {
+                                     final DesktopMessages desktopMessages,
+                                     Templates templates) {
         this.displayStrings = displayStrings;
         this.help = help;
         this.desktopMessages = desktopMessages;
+        this.templates = templates;
     }
 
     PreferencesViewDefaultAppearance() {
         this(GWT.<IplantDisplayStrings> create(IplantDisplayStrings.class),
              GWT.<DesktopContextualHelpMessages> create(DesktopContextualHelpMessages.class),
-             GWT.<DesktopMessages> create(DesktopMessages.class));
+             GWT.<DesktopMessages> create(DesktopMessages.class),
+             GWT.<Templates> create(Templates.class));
     }
 
     @Override
@@ -152,7 +165,7 @@ public class PreferencesViewDefaultAppearance implements PreferencesDialog.Prefe
     }
 
     @Override
-    public String sessionConnectionFailed() {
-        return desktopMessages.sessionConnectionFailed();
+    public SafeHtml sessionConnectionFailed() {
+        return templates.redText(desktopMessages.sessionConnectionFailed());
     }
 }

--- a/de-lib/src/test/java/org/iplantc/de/preferences/client/presenter/PreferencesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/preferences/client/presenter/PreferencesPresenterImplTest.java
@@ -1,0 +1,94 @@
+package org.iplantc.de.preferences.client.presenter;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.client.models.UserSettings;
+import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.services.UserSessionServiceFacade;
+import org.iplantc.de.desktop.client.DesktopView;
+import org.iplantc.de.preferences.client.PreferencesView;
+import org.iplantc.de.preferences.client.events.PrefDlgRetryUserSessionClicked;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class PreferencesPresenterImplTest {
+
+    @Mock PreferencesView viewMock;
+    @Mock UserSessionServiceFacade serviceFacadeMock;
+    @Mock DesktopView.Presenter desktopPresenterMock;
+    @Mock UserSettings userSettingsMock;
+    @Mock List<WindowState> windowStatesMock;
+
+    @Captor ArgumentCaptor<AsyncCallback<List<WindowState>>> userSessionCaptor;
+
+    private PreferencesPresenterImpl uut;
+
+    @Before
+    public void setUp() {
+        when(viewMock.getValue()).thenReturn(userSettingsMock);
+
+        uut = new PreferencesPresenterImpl(viewMock,
+                                           serviceFacadeMock);
+
+        uut.desktopPresenter = desktopPresenterMock;
+    }
+    
+    @Test
+    public void go() {
+        /** CALL METHOD UNDER TEST **/
+        uut.go(desktopPresenterMock, userSettingsMock);
+        verify(viewMock).initAndShow(userSettingsMock);
+    }
+
+    @Test
+    public void onPrefDlgRetryUserSessionClicked_onSuccess() {
+        PrefDlgRetryUserSessionClicked eventMock = mock(PrefDlgRetryUserSessionClicked.class);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.onPrefDlgRetryUserSessionClicked(eventMock);
+        verify(serviceFacadeMock).getUserSession(userSessionCaptor.capture());
+
+        userSessionCaptor.getValue().onSuccess(windowStatesMock);
+        verify(viewMock).userSessionSuccess();
+        verify(desktopPresenterMock).restoreWindows(windowStatesMock);
+        verify(desktopPresenterMock).doPeriodicSessionSave();
+    }
+
+    @Test
+    public void onPrefDlgRetryUserSessionClicked_onFail() {
+        PrefDlgRetryUserSessionClicked eventMock = mock(PrefDlgRetryUserSessionClicked.class);
+        Throwable caughtMock = mock(Throwable.class);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.onPrefDlgRetryUserSessionClicked(eventMock);
+        verify(serviceFacadeMock).getUserSession(userSessionCaptor.capture());
+
+        userSessionCaptor.getValue().onFailure(caughtMock);
+        verify(viewMock).userSessionFail();
+    }
+
+    @Test
+    public void saveUserSettings() {
+        /** CALL METHOD UNDER TEST **/
+        uut.saveUserSettings();
+        verify(desktopPresenterMock).saveUserSettings(eq(userSettingsMock), eq(false));
+    }
+
+}

--- a/de-webapp/src/main/java/org/iplantc/de/client/gin/DEInjector.java
+++ b/de-webapp/src/main/java/org/iplantc/de/client/gin/DEInjector.java
@@ -10,6 +10,7 @@ import org.iplantc.de.desktop.client.gin.DEGinModule;
 import org.iplantc.de.diskResource.client.gin.DiskResourceGinModule;
 import org.iplantc.de.fileViewers.client.gin.FileViewerGinModule;
 import org.iplantc.de.notifications.client.gin.NotificationGinModule;
+import org.iplantc.de.preferences.client.gin.PreferencesGinModule;
 import org.iplantc.de.tags.client.gin.TagsGinModule;
 import org.iplantc.de.tools.requests.client.gin.ToolRequestGinModule;
 
@@ -31,7 +32,8 @@ import com.google.gwt.inject.client.Ginjector;
                 CommentsGinModule.class,
                 TagsGinModule.class,
                 FileViewerGinModule.class,
-                NotificationGinModule.class})
+                NotificationGinModule.class,
+                PreferencesGinModule.class})
 public interface DEInjector extends Ginjector {
     public static final DEInjector INSTANCE = GWT.create(DEInjector.class);
 


### PR DESCRIPTION
This PR adds to the UI's resiliency (and mostly fixes a bug) where the UI will still try to save a user's session even when the /secured/sessions callback has failed.

The user will be presented with a message indicating that their saved session could not be loaded and that their current session is not being saved.  When users open the Preferences dialog, they'll have a message indicating that their session couldn't be saved and there's a button to retry hitting the /secured/sessions endpoint.

(most of the changes here are a refactor of Preferences to have a dialog + view + presenter instead of just a dialog)