### PR TITLE
WIP CORE-8367 first pass

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
@@ -26,6 +26,7 @@ import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.commons.client.widgets.DETabPanel;
+import org.iplantc.de.shared.AppsCallback;
 import org.iplantc.de.shared.AsyncProviderWrapper;
 import org.iplantc.de.shared.DEProperties;
 
@@ -165,9 +166,9 @@ public class AppCategoriesPresenterImpl implements AppCategoriesView.Presenter,
         workspaceView.getTree().mask(appearance.getAppCategoriesLoadingMask());
         hpcView.getTree().mask(appearance.getAppCategoriesLoadingMask());
 
-        appService.getAppCategories(true, new AsyncCallback<List<AppCategory>>() {
+        appService.getAppCategories(true, new AppsCallback<List<AppCategory>>() {
             @Override
-            public void onFailure(Throwable caught) {
+            public void onFailure(Integer statusCode, Throwable caught) {
                 ErrorHandler.post(caught);
                 viewTabPanel.unmask();
             }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/AppServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/AppServiceFacade.java
@@ -4,8 +4,10 @@ package org.iplantc.de.client.services;
 import org.iplantc.de.client.models.HasId;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppCategory;
+import org.iplantc.de.client.models.apps.AppCategoryList;
 import org.iplantc.de.client.models.apps.AppList;
 import org.iplantc.de.client.models.apps.proxy.AppListLoadResult;
+import org.iplantc.de.shared.AppsCallback;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.web.bindery.autobean.shared.AutoBean;
@@ -26,6 +28,8 @@ public interface AppServiceFacade {
         AutoBean<AppListLoadResult> loadResult();
 
         AutoBean<HasId> hasId();
+
+        AutoBean<AppCategoryList> appCategoryList();
     }
 
     /**
@@ -62,7 +66,17 @@ public interface AppServiceFacade {
      *
      * @param callback
      */
+
     void getAppCategories(boolean privateOnly, AsyncCallback<List<AppCategory>> callback);
 
+    void getAppCategories(boolean privateOnly, AppsCallback<List<AppCategory>> callback);
+
+    /**
+     * Searches for all active Apps with a name or description that contains the given search term.
+     *
+     * @param search the search query
+     * @param callback called when the RPC call is complete.
+     */
+    void searchApp(String search, AsyncCallback<AppListLoadResult> callback);
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/DECallbackConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/DECallbackConverter.java
@@ -1,0 +1,48 @@
+package org.iplantc.de.client.services.converters;
+
+import org.iplantc.de.client.models.WindowType;
+import org.iplantc.de.shared.DECallback;
+
+/**
+ * An abstract class which structures the conversion from one <code>AsyncCallback</code> type, to another
+ * <code>AsyncCallback</code> type.
+ *
+ * @author jstroot
+ *
+ * @param <F> The class type to convert from
+ * @param <T> The class type to convert to
+ */
+public abstract class DECallbackConverter<F, T> implements DECallback<F> {
+
+    private final DECallback<T> callback;
+
+    public DECallbackConverter(DECallback<T> callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public void onSuccess(F result) {
+        // JDS Perform conversion and pass result to callback.
+        this.callback.onSuccess(convertFrom(result));
+    }
+
+    @Override
+    public void onFailure(Integer statusCode, Throwable caught) {
+        // JDS Forward the failure to the callback by default.
+        this.callback.onFailure(statusCode, caught);
+    }
+
+    @Override
+    public WindowType getWindowType() {
+        return callback.getWindowType();
+    }
+
+    /**
+     * Converts from the given object, to the object T.
+     *
+     * @param object the object to be converted.
+     * @return the converted object.
+     */
+    protected abstract T convertFrom(F object);
+
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/AppUserServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/AppUserServiceFacadeImpl.java
@@ -10,6 +10,7 @@ import org.iplantc.de.client.models.HasQualifiedId;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppAutoBeanFactory;
 import org.iplantc.de.client.models.apps.AppCategory;
+import org.iplantc.de.client.models.apps.AppCategoryList;
 import org.iplantc.de.client.models.apps.AppDeletionRequest;
 import org.iplantc.de.client.models.apps.AppDoc;
 import org.iplantc.de.client.models.apps.AppFeedback;
@@ -25,10 +26,12 @@ import org.iplantc.de.client.services.AppUserServiceFacade;
 import org.iplantc.de.client.services.converters.AppCategoryListCallbackConverter;
 import org.iplantc.de.client.services.converters.AppTemplateCallbackConverter;
 import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
+import org.iplantc.de.client.services.converters.DECallbackConverter;
 import org.iplantc.de.client.services.converters.StringToVoidCallbackConverter;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.client.util.JsonUtil;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
+import org.iplantc.de.shared.AppsCallback;
 import org.iplantc.de.shared.services.BaseServiceCallWrapper.Type;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.shared.services.EmailServiceAsync;
@@ -111,6 +114,22 @@ public class AppUserServiceFacadeImpl implements AppUserServiceFacade {
         }
         ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
         deServiceFacade.getServiceData(wrapper, new AppCategoryListCallbackConverter(callback));
+    }
+
+    @Override
+    public void getAppCategories(boolean privateOnly, AppsCallback<List<AppCategory>> callback) {
+        String address = "org.iplantc.services.admin.apps.categories";
+        if (privateOnly) {
+            address += "?public=false";
+        }
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
+        deServiceFacade.getServiceData(wrapper,
+                                       new DECallbackConverter<String, List<AppCategory>>(callback) {
+                                           @Override
+                                           protected List<AppCategory> convertFrom(String object) {
+                                               return AutoBeanCodex.decode(svcFactory, AppCategoryList.class, object).as().getCategories();
+                                           }
+                                       });
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterEventHandler.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterEventHandler.java
@@ -10,6 +10,8 @@ import org.iplantc.de.diskResource.client.events.DefaultUploadCompleteHandler;
 import org.iplantc.de.diskResource.client.events.FileUploadedEvent;
 import org.iplantc.de.notifications.client.events.NotificationClickedEvent;
 import org.iplantc.de.notifications.client.events.NotificationCountUpdateEvent;
+import org.iplantc.de.shared.events.ServiceDown;
+import org.iplantc.de.shared.events.ServiceRestored;
 import org.iplantc.de.shared.events.UserLoggedOutEvent;
 
 import com.google.common.collect.Lists;
@@ -30,7 +32,9 @@ public class DesktopPresenterEventHandler implements LastSelectedPathChangedEven
                                                      NotificationCountUpdateEvent.NotificationCountUpdateEventHandler,
                                                      FileUploadedEvent.FileUploadedEventHandler,
                                                      UserLoggedOutEvent.UserLoggedOutEventHandler,
-                                                     NotificationClickedEvent.NotificationClickedEventHandler {
+                                                     NotificationClickedEvent.NotificationClickedEventHandler,
+                                                     ServiceDown.ServiceDownHandler,
+                                                     ServiceRestored.ServiceRestoredHandler {
 
     @Inject EventBus eventBus;
     @Inject UserSessionServiceFacade userSessionService;
@@ -86,6 +90,10 @@ public class DesktopPresenterEventHandler implements LastSelectedPathChangedEven
         handlerRegistrations.add(handlerRegistration);
         handlerRegistration = eventBus.addHandler(NotificationClickedEvent.TYPE,this);
         handlerRegistrations.add(handlerRegistration);
+        handlerRegistration = eventBus.addHandler(ServiceDown.TYPE, this);
+        handlerRegistrations.add(handlerRegistration);
+        handlerRegistration = eventBus.addHandler(ServiceRestored.TYPE, this);
+        handlerRegistrations.add(handlerRegistration);
     }
 
     @Override
@@ -98,5 +106,15 @@ public class DesktopPresenterEventHandler implements LastSelectedPathChangedEven
     @Override
     public void onNotificationClicked(NotificationClickedEvent event) {
         presenter.markAsSeen(event.getMessage());
+    }
+
+    @Override
+    public void onServiceDown(ServiceDown event) {
+        presenter.disableWindow(event);
+    }
+
+    @Override
+    public void onServiceRestored(ServiceRestored event) {
+        presenter.restoreWindow(event.getWindowType());
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -59,6 +59,7 @@ import org.iplantc.de.notifications.client.events.WindowShowRequestEvent;
 import org.iplantc.de.notifications.client.utils.NotifyInfo;
 import org.iplantc.de.notifications.client.views.dialogs.RequestHistoryDialog;
 import org.iplantc.de.shared.DEProperties;
+import org.iplantc.de.shared.events.ServiceDown;
 import org.iplantc.de.shared.services.PropertyServiceAsync;
 import org.iplantc.de.systemMessages.client.events.NewSystemMessagesEvent;
 
@@ -414,6 +415,14 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
                                                                         announcer,
                                                                         panel,
                                                                         this));
+    }
+
+    public void disableWindow(ServiceDown event) {
+        desktopWindowManager.disable(event);
+    }
+
+    public void restoreWindow(WindowType windowType) {
+        desktopWindowManager.restoreWindow(windowType);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopWindowManager.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopWindowManager.java
@@ -5,9 +5,11 @@ import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
+import org.iplantc.de.desktop.client.views.windows.DEAppsWindow;
 import org.iplantc.de.desktop.client.views.windows.IPlantWindowInterface;
 import org.iplantc.de.desktop.client.views.windows.util.WindowFactory;
 import org.iplantc.de.shared.AsyncProviderWrapper;
+import org.iplantc.de.shared.events.ServiceDown;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -172,6 +174,27 @@ public class DesktopWindowManager {
                 }
             }
         });
+    }
+
+    public void disable(ServiceDown event) {
+        WindowType type = event.getWindowType();
+        for (Widget w : windowManager.getStack()) {
+            Window window = (Window) w;
+            if (Strings.nullToEmpty(window.getStateId()).startsWith(type.toString())) {
+                DEAppsWindow appsWindow = (DEAppsWindow)window;
+                appsWindow.serviceDown(event.getSelectionHandler());
+            }
+        }
+    }
+
+    public void restoreWindow(WindowType windowType) {
+        for (Widget w : windowManager.getStack()) {
+            Window window = (Window) w;
+            if (Strings.nullToEmpty(window.getStateId()).startsWith(windowType.toString())) {
+                DEAppsWindow appsWindow = (DEAppsWindow)window;
+                appsWindow.restoreWindow();
+            }
+        }
     }
 
     private void resizeOversizeWindow(IPlantWindowInterface window) {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
@@ -12,6 +12,7 @@ import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
 import org.iplantc.de.desktop.shared.DeModule;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 
+import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
@@ -24,6 +25,7 @@ public class DEAppsWindow extends IplantWindowBase {
     public static final String APPS = "#apps";
     @Inject UserInfo userInfo;
     private final AppsView.Presenter presenter;
+    private Widget currentWidget;
 
     @Inject
     DEAppsWindow(final AppsView.Presenter presenter, final IplantDisplayStrings displayStrings) {
@@ -80,4 +82,15 @@ public class DEAppsWindow extends IplantWindowBase {
         presenter.setViewDebugId(baseID + AppsModule.Ids.APPS_VIEW);
     }
 
+    public void serviceDown(SelectEvent.SelectHandler handler) {
+        if (currentWidget == null) {
+            currentWidget = getWidget();
+            this.setWidget(new ServiceDownPanel(handler));
+        }
+    }
+
+    public void restoreWindow() {
+        this.setWidget(currentWidget);
+        currentWidget = null;
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/ServiceDownPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/ServiceDownPanel.java
@@ -1,0 +1,34 @@
+package org.iplantc.de.desktop.client.views.windows;
+
+import org.iplantc.de.shared.services.DEServiceAsync;
+
+import com.google.gwt.user.client.ui.Label;
+import com.google.inject.Inject;
+
+import com.sencha.gxt.widget.core.client.button.TextButton;
+import com.sencha.gxt.widget.core.client.container.CenterLayoutContainer;
+import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
+
+/**
+ * @author aramsey
+ */
+public class ServiceDownPanel extends CenterLayoutContainer {
+
+    @Inject DEServiceAsync deService;
+
+    public ServiceDownPanel(SelectEvent.SelectHandler handler) {
+        VerticalLayoutContainer vlc = new VerticalLayoutContainer();
+        Label label = new Label();
+        label.setText("This service currently appears to be down.");
+
+        TextButton retry = new TextButton();
+        retry.setText("Try Again");
+        retry.addSelectHandler(handler);
+
+        vlc.add(label);
+        vlc.add(retry);
+
+        add(vlc);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/shared/AppsCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/AppsCallback.java
@@ -1,0 +1,14 @@
+package org.iplantc.de.shared;
+
+import org.iplantc.de.client.models.WindowType;
+
+/**
+ * @author aramsey
+ */
+public abstract class AppsCallback<T> implements DECallback<T> {
+
+    @Override
+    public WindowType getWindowType() {
+        return WindowType.APPS;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/shared/DECallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/DECallback.java
@@ -1,0 +1,15 @@
+package org.iplantc.de.shared;
+
+import org.iplantc.de.client.models.WindowType;
+
+/**
+ * @author aramsey
+ */
+public interface DECallback<T> {
+
+    WindowType getWindowType();
+
+    void onFailure(Integer statusCode, Throwable exception);
+
+    void onSuccess(T result);
+}

--- a/de-lib/src/main/java/org/iplantc/de/shared/DECallbackWrapper.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/DECallbackWrapper.java
@@ -1,0 +1,102 @@
+package org.iplantc.de.shared;
+
+import org.iplantc.de.client.events.EventBus;
+import org.iplantc.de.shared.events.ServiceDown;
+import org.iplantc.de.shared.events.ServiceRestored;
+import org.iplantc.de.shared.events.UserLoggedOutEvent;
+import org.iplantc.de.shared.exceptions.AuthenticationException;
+import org.iplantc.de.shared.exceptions.HttpException;
+import org.iplantc.de.shared.exceptions.HttpRedirectException;
+import org.iplantc.de.shared.services.DiscEnvApiService;
+import org.iplantc.de.shared.services.ServiceCallWrapper;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.rpc.StatusCodeException;
+import com.google.inject.Inject;
+
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author aramsey
+ */
+public class DECallbackWrapper<T> implements AsyncCallback<T>, SelectEvent.SelectHandler{
+
+    private DiscEnvApiService deServiceFacade;
+    private DECallback<T> callback;
+    Logger LOG = Logger.getLogger(DECallbackWrapper.class.getName());
+    private ServiceCallWrapper wrapper;
+    boolean retry = false;
+    private DECallbackWrapper<String> callbackWrapper;
+
+
+    @Inject
+    public DECallbackWrapper(DECallback<T> callback, DiscEnvApiService deServiceFacade) {
+        this.callback = callback;
+        this.deServiceFacade = deServiceFacade;
+    }
+
+    @Override
+    public void onFailure(Throwable caught) {
+        if (caught instanceof AuthenticationException) {
+            EventBus.getInstance().fireEvent(new UserLoggedOutEvent());
+            LOG.log(Level.SEVERE, "Auth error!!!!!", caught);
+            return;
+        }
+
+        Integer statusCode;
+        String response;
+
+        if (caught instanceof StatusCodeException) {
+            StatusCodeException statusCodeException = (StatusCodeException)caught;
+            statusCode = statusCodeException.getStatusCode();
+            response = statusCodeException.getEncodedResponse();
+        } else if (caught instanceof HttpRedirectException) {
+            HttpRedirectException redirectException = (HttpRedirectException)caught;
+            statusCode = redirectException.getStatusCode();
+            response = redirectException.getResponseBody();
+//            Window.Location.assign(redirectException.getLocation());
+        } else if (caught instanceof HttpException) {
+            HttpException exception = (HttpException)caught;
+            statusCode = exception.getStatusCode();
+            response = exception.getResponseBody();
+        } else {
+            callback.onFailure(null, caught);
+            return;
+        }
+
+        LOG.log(Level.SEVERE, "Status code: " + statusCode + "; Response : " + response, caught);
+
+        if (statusCode >= 300 && statusCode <= 399) {
+            //TODO FIX ME!
+            return;
+        }
+        if (statusCode == 502 || statusCode == 503 || statusCode == 403) {
+            retry = true;
+            EventBus.getInstance().fireEvent(new ServiceDown(callback.getWindowType(), this));
+            return;
+        }
+        callback.onFailure(statusCode, caught);
+
+    }
+
+    @Override
+    public void onSuccess(T result) {
+        if (retry) {
+            EventBus.getInstance().fireEvent(new ServiceRestored(callback.getWindowType()));
+        }
+        callback.onSuccess(result);
+    }
+
+    public void setRetryVars(ServiceCallWrapper wrapper, DECallbackWrapper<String> callbackWrapper) {
+        this.wrapper = wrapper;
+        this.callbackWrapper = callbackWrapper;
+    }
+
+    @Override
+    public void onSelect(SelectEvent event) {
+        deServiceFacade.getServiceData(wrapper, callbackWrapper);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/shared/events/ServiceDown.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/events/ServiceDown.java
@@ -1,0 +1,42 @@
+package org.iplantc.de.shared.events;
+
+import org.iplantc.de.client.models.WindowType;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
+
+/**
+ * @author aramsey
+ */
+public class ServiceDown extends GwtEvent<ServiceDown.ServiceDownHandler> {
+    public static Type<ServiceDownHandler> TYPE = new Type<ServiceDownHandler>();
+    private WindowType windowType;
+    private SelectEvent.SelectHandler handler;
+
+    public ServiceDown(WindowType windowType, SelectEvent.SelectHandler handler) {
+        this.windowType = windowType;
+        this.handler = handler;
+    }
+
+    public Type<ServiceDownHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(ServiceDownHandler handler) {
+        handler.onServiceDown(this);
+    }
+
+    public WindowType getWindowType() {
+        return windowType;
+    }
+
+    public SelectEvent.SelectHandler getSelectionHandler() {
+        return handler;
+    }
+
+    public static interface ServiceDownHandler extends EventHandler {
+        void onServiceDown(ServiceDown event);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/shared/events/ServiceRestored.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/events/ServiceRestored.java
@@ -1,0 +1,34 @@
+package org.iplantc.de.shared.events;
+
+import org.iplantc.de.client.models.WindowType;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * @author aramsey
+ */
+public class ServiceRestored extends GwtEvent<ServiceRestored.ServiceRestoredHandler> {
+    public static Type<ServiceRestoredHandler> TYPE = new Type<ServiceRestoredHandler>();
+    private WindowType windowType;
+
+    public ServiceRestored(WindowType windowType) {
+        this.windowType = windowType;
+    }
+
+    public Type<ServiceRestoredHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(ServiceRestoredHandler handler) {
+        handler.onServiceRestored(this);
+    }
+
+    public WindowType getWindowType() {
+        return windowType;
+    }
+
+    public static interface ServiceRestoredHandler extends EventHandler {
+        void onServiceRestored(ServiceRestored event);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/shared/services/DiscEnvApiService.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/services/DiscEnvApiService.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.shared.services;
 
 import org.iplantc.de.shared.AsyncCallbackWrapper;
+import org.iplantc.de.shared.DECallback;
+import org.iplantc.de.shared.DECallbackWrapper;
 
 import com.google.gwt.http.client.Request;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -27,6 +29,20 @@ public class DiscEnvApiService {
                                   AsyncCallback<String> callback) {
         return deService.getServiceData(wrapper,
                                         new AsyncCallbackWrapper<>(callback));
+    }
+
+    public Request getServiceData(ServiceCallWrapper wrapper,
+                                  DECallback<String> callback) {
+        DECallbackWrapper<String> deCallbackWrapper = new DECallbackWrapper<>(callback, this);
+        deCallbackWrapper.setRetryVars(wrapper, deCallbackWrapper);
+        return deService.getServiceData(wrapper,
+                                        deCallbackWrapper);
+    }
+
+    public Request getServiceData(ServiceCallWrapper wrapper,
+                                  DECallbackWrapper<String> callback) {
+        return deService.getServiceData(wrapper,
+                                        callback);
     }
 
     public Request getServiceData(ServiceCallWrapper wrapper,


### PR DESCRIPTION
This is a really rough first pass at one example of the UI resiliency changes.  I wanted to get some eyes on it as soon as possible to see if the direction is sane or if folks have different ideas or if things can be simplified/generalized better.

The basics are:
* There is a `DECallback` which has onSuccess(T) and onFailure(Integer statusCode, Throwable caught).
* For any call that should disable the Apps window on a 502 or 503 failure, those calls will use `AppsCallback` which extends `DECallback` (I just have one callback using it right now)
* `DECallbackWrapper` processes the status codes, logs them, and fires off a `ServiceDown` event
* When a service is down, any instances of the affected windows will have their contents replaced with a "This service is currently down" message and a "Try Again" button
* If the "Try Again" button's callback comes back successful, a `ServiceRestored` event gets fired and the affected windows will switch back to their original contents