### PR TITLE
CORE-8366 Add retry btn to notification dropdown on /secured/notifications failure

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -242,6 +242,8 @@ public interface DesktopView extends IsWidget {
         void doSeeAllNotifications();
 
         void doSeeNewNotifications();
+
+        void getNotifications();
     }
 
     void ensureDebugId(String baseID);
@@ -262,4 +264,6 @@ public interface DesktopView extends IsWidget {
     void setUnseenSystemMessageCount(int count);
 
     void hideNotificationMenu();
+
+    void setNotificationConnection(boolean visible);
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -651,9 +651,13 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
         initKBShortCuts();
         panel.add(view);
         processQueryStrings();
-        messageServiceFacade.getRecentMessages(new InitializationCallbacks.GetInitialNotificationsCallback(view, appearance, announcer));
-        messageServiceFacade.getMessageCounts(new NewSysMessageCountCallback());
-   
+        getNotifications();
+   }
+
+   @Override
+   public void getNotifications() {
+       messageServiceFacade.getRecentMessages(new InitializationCallbacks.GetInitialNotificationsCallback(view, appearance, announcer));
+       messageServiceFacade.getMessageCounts(new NewSysMessageCountCallback());
    }
 
    @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/InitializationCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/InitializationCallbacks.java
@@ -108,11 +108,13 @@ class InitializationCallbacks {
         public void onFailure(Throwable caught) {
             announcer.schedule(new ErrorAnnouncementConfig(appearance.fetchNotificationsError(),
                                                            true,
-                                                           3000));
+                                                           5000));
+            view.setNotificationConnection(false);
         }
 
         @Override
         public void onSuccess(NotificationList result) {
+            view.setNotificationConnection(true);
             if(result != null) {
                 GWT.log("unseen count ^^^^^^" + result.getUnseenTotal());
                 view.setUnseenNotificationCount(Integer.parseInt(result.getUnseenTotal()));

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
@@ -109,6 +109,11 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
     }
 
     @Override
+    public void setNotificationConnection(boolean connected) {
+        notificationsListView.setNotificationConnection(connected);
+    }
+
+    @Override
     public void onRegister(RegisterEvent<Widget> event) {
         final Widget eventItem = event.getItem();
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/UnseenNotificationsView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/UnseenNotificationsView.ui.xml
@@ -2,6 +2,7 @@
              xmlns:g='urn:import:com.google.gwt.user.client.ui'
              xmlns:container='urn:import:com.sencha.gxt.widget.core.client.container'
              xmlns:widget='urn:import:com.sencha.gxt.widget.core.client'
+             xmlns:button="urn:import:com.sencha.gxt.widget.core.client.button"
              xmlns:anchor='urn:import:org.iplantc.de.commons.client.widgets'>
 
     <ui:with field="appearance"
@@ -11,6 +12,17 @@
         <container:child>
             <g:HTML ui:field="emptyNotificationsText"
                     text="{appearance.noNewNotifications}"/>
+        </container:child>
+        <container:child>
+            <g:HTML ui:field="retryNotificationsText"
+                    visible="false"
+                    text="{appearance.retryNotificationsText}"/>
+        </container:child>
+        <container:child>
+            <button:TextButton ui:field="retryButton"
+                               visible="false"
+                               text="{appearance.retryButtonText}"
+            />
         </container:child>
         <container:child>
             <widget:ListView ui:field="listView"

--- a/de-lib/src/main/java/org/iplantc/de/notifications/shared/Notifications.java
+++ b/de-lib/src/main/java/org/iplantc/de/notifications/shared/Notifications.java
@@ -1,0 +1,17 @@
+package org.iplantc.de.notifications.shared;
+
+/**
+ * @author aramsey
+ */
+public class Notifications {
+
+    public interface UnseenIds {
+        String NOTIFICATIONS_MENU = "notificationsMenu";
+        String EMPTY_NOTIFICATION = ".emptyNotification";
+        String MARK_ALL_SEEN = ".markAllSeenLink";
+        String SEE_ALL_NOTIFICATIONS = ".seeAllNotificationsLink";
+        String RETRY_NOTIFICATIONS = ".retryNotifications";
+        String RETRY_BTN = ".retryBtn";
+        String NOTIFICATION_LIST = ".notificationList";
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/views/BaseUnseenNotificationsAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/views/BaseUnseenNotificationsAppearance.java
@@ -113,4 +113,14 @@ public class BaseUnseenNotificationsAppearance implements UnseenNotificationsVie
         return "220px";
     }
 
+    @Override
+    public String retryNotificationsText() {
+        return strings.retryNotificationsText();
+    }
+
+    @Override
+    public String retryButtonText() {
+        return strings.retryButtonText();
+    }
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/views/UnseenNotificationsStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/views/UnseenNotificationsStrings.java
@@ -13,4 +13,8 @@ public interface UnseenNotificationsStrings extends Messages {
     String newNotificationsLink(int unseenCount);
 
     String noNewNotifications();
+
+    String retryNotificationsText();
+
+    String retryButtonText();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/views/UnseenNotificationsStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/views/UnseenNotificationsStrings.properties
@@ -2,3 +2,5 @@ allNotifications= See all notifications
 newNotificationsLink= New Notifications ({0})
 markAllAsSeen= Mark All As Read
 noNewNotifications= No new notifications!
+retryNotificationsText = Connection to notifications service failed.
+retryButtonText = Try Again


### PR DESCRIPTION
This PR gives users the chance to retry fetching their recent notifications for viewing in the notification dropdown if the /secured/notifications callback fails during login.  Currently, if this callback fails, there's no other chance in the UI to get the list of recent notifications (though users could still attempt to view them via the Notification window).