### PR TITLE
CORE-8420 Construct user home dir from configs if data-info is down

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -1,5 +1,8 @@
 package org.iplantc.de.client.models;
 
+import org.iplantc.de.shared.DEProperties;
+
+import com.google.common.base.Strings;
 import com.google.gwt.core.shared.GWT;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 
@@ -82,7 +85,17 @@ public class UserInfo {
      * @return the path to the user's home directory.
      */
     public String getHomePath() {
-        return userInfo == null ? null : userInfo.getHomePath();
+        if (userInfo == null || Strings.isNullOrEmpty(userInfo.getHomePath())) {
+            String irodsHome = DEProperties.getInstance().getIrodsHomePath();
+            String username = userInfo.getUsername();
+
+            if (Strings.isNullOrEmpty(irodsHome) || Strings.isNullOrEmpty(username)) {
+                return "";
+            }
+
+            return irodsHome + "/" + username;
+        }
+        return userInfo.getHomePath();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -120,14 +120,33 @@ public class UserInfo {
      * @return the path to the user's trash.
      */
     public String getTrashPath() {
-        return userInfo == null ? null : userInfo.getTrashPath();
+        if (userInfo == null || Strings.isNullOrEmpty(userInfo.getTrashPath())) {
+            String baseTrashPath = getBaseTrashPath();
+            String username = userInfo.getUsername();
+
+            if (Strings.isNullOrEmpty(baseTrashPath) || Strings.isNullOrEmpty(username)) {
+                return "";
+            }
+
+            return baseTrashPath + "/" + username;
+        }
+        return userInfo.getTrashPath();
     }
 
     /**
      * @return the base trash path of the data store for all users.
      */
     public String getBaseTrashPath() {
-        return userInfo == null ? null : userInfo.getBaseTrashPath();
+        if (userInfo == null || Strings.isNullOrEmpty(userInfo.getBaseTrashPath())) {
+            String baseTrashPath = DEProperties.getInstance().getBaseTrashPath();
+
+            if (Strings.isNullOrEmpty(baseTrashPath)) {
+                return "";
+            }
+
+            return baseTrashPath;
+        }
+        return userInfo.getBaseTrashPath();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
@@ -3,9 +3,7 @@ package org.iplantc.de.client.models;
 import org.iplantc.de.client.KeyBoardShortcutConstants;
 import org.iplantc.de.client.models.diskResources.DiskResourceAutoBeanFactory;
 import org.iplantc.de.client.models.diskResources.Folder;
-import org.iplantc.de.shared.DEProperties;
 
-import com.google.common.base.Strings;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
@@ -278,7 +276,7 @@ public class UserSettings {
         JSONObject defaults = new JSONObject();
         JSONObject defaultHomeDir = new JSONObject();
 
-        String homeDir = getHomeDir(userInfo);
+        String homeDir = userInfo.getHomePath();
 
         JSONString id = new JSONString(homeDir);
         JSONString path = new JSONString(homeDir);
@@ -288,23 +286,6 @@ public class UserSettings {
         defaults.put(DEFAULT_OUTPUT_FOLDER, defaultHomeDir);
 
         setValues(defaults);
-    }
-
-    String getHomeDir(UserInfo userInfo) {
-        String userHomePath = userInfo.getHomePath();
-
-        if (!Strings.isNullOrEmpty(userHomePath)) {
-            return userHomePath;
-        }
-
-        String irodsHome = DEProperties.getInstance().getIrodsHomePath();
-        String username = userInfo.getUsername();
-
-        if (Strings.isNullOrEmpty(irodsHome) || Strings.isNullOrEmpty(username)) {
-            return "";
-        }
-
-        return irodsHome + "/" + username;
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
@@ -3,7 +3,9 @@ package org.iplantc.de.client.models;
 import org.iplantc.de.client.KeyBoardShortcutConstants;
 import org.iplantc.de.client.models.diskResources.DiskResourceAutoBeanFactory;
 import org.iplantc.de.client.models.diskResources.Folder;
+import org.iplantc.de.shared.DEProperties;
 
+import com.google.common.base.Strings;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
@@ -272,18 +274,37 @@ public class UserSettings {
         return ret;
     }
 
-    public void useDefaultValues(UserInfo instance) {
+    public void useDefaultValues(UserInfo userInfo) {
         JSONObject defaults = new JSONObject();
         JSONObject defaultHomeDir = new JSONObject();
 
-        JSONString id = new JSONString(instance.getHomePath());
-        JSONString path = new JSONString(instance.getHomePath());
+        String homeDir = getHomeDir(userInfo);
+
+        JSONString id = new JSONString(homeDir);
+        JSONString path = new JSONString(homeDir);
         defaultHomeDir.put("id", id);
         defaultHomeDir.put("path", path);
 
         defaults.put(DEFAULT_OUTPUT_FOLDER, defaultHomeDir);
 
         setValues(defaults);
+    }
+
+    String getHomeDir(UserInfo userInfo) {
+        String userHomePath = userInfo.getHomePath();
+
+        if (!Strings.isNullOrEmpty(userHomePath)) {
+            return userHomePath;
+        }
+
+        String irodsHome = DEProperties.getInstance().getIrodsHomePath();
+        String username = userInfo.getUsername();
+
+        if (Strings.isNullOrEmpty(irodsHome) || Strings.isNullOrEmpty(username)) {
+            return "";
+        }
+
+        return irodsHome + "/" + username;
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
@@ -6,7 +6,6 @@ import org.iplantc.de.client.models.diskResources.Folder;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.json.client.JSONString;
 import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 import com.google.web.bindery.autobean.shared.AutoBeanUtils;
@@ -273,17 +272,14 @@ public class UserSettings {
     }
 
     public void useDefaultValues(UserInfo userInfo) {
-        JSONObject defaults = new JSONObject();
-        JSONObject defaultHomeDir = new JSONObject();
+        Splittable defaults = StringQuoter.createSplittable();
+        Splittable defaultHomeDir = StringQuoter.createSplittable();
 
         String homeDir = userInfo.getHomePath();
 
-        JSONString id = new JSONString(homeDir);
-        JSONString path = new JSONString(homeDir);
-        defaultHomeDir.put("id", id);
-        defaultHomeDir.put("path", path);
-
-        defaults.put(DEFAULT_OUTPUT_FOLDER, defaultHomeDir);
+        StringQuoter.create(homeDir).assign(defaultHomeDir, "id");
+        StringQuoter.create(homeDir).assign(defaultHomeDir, "path");
+        defaultHomeDir.assign(defaults, DEFAULT_OUTPUT_FOLDER);
 
         setValues(defaults);
     }

--- a/de-lib/src/main/java/org/iplantc/de/shared/DEProperties.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/DEProperties.java
@@ -110,6 +110,8 @@ public class DEProperties {
 
     private static final String IRODS_HOME_PATH = "org.iplantc.irodshome.path";
 
+    private static final String BASE_TRASH_PATH = "org.iplantc.basetrash.path";
+
     /**
      * The single instance of this class.
      */
@@ -212,6 +214,8 @@ public class DEProperties {
 
     private String irodsHomePath;
 
+    private String baseTrashPath;
+
     private String dataMgmtAdminBaseUrl;
 
     /**
@@ -241,6 +245,7 @@ public class DEProperties {
         List<String> keys = new ArrayList<>();
         keys.add(COMMUNITY_DATA_PATH);
         keys.add(IRODS_HOME_PATH);
+        keys.add(BASE_TRASH_PATH);
         keys.add(PATH_LIST_FILE_IDENTIFIER);
         keys.add(MULE_SERVICE_BASE_URL);
         keys.add(DATA_MGMT_BASE_URL);
@@ -286,6 +291,7 @@ public class DEProperties {
         pathListFileIdentifier = properties.get(PATH_LIST_FILE_IDENTIFIER);
         communityDataPath = properties.get(COMMUNITY_DATA_PATH);
         irodsHomePath = properties.get(IRODS_HOME_PATH);
+        baseTrashPath = properties.get(BASE_TRASH_PATH);
         permIdBaseUrl = properties.get(PERM_ID_BASE_URL);
         betaAvuIri = properties.get(BETA_AVU_IRI);
         betaAvuLabel = properties.get(BETA_AVU_LABEL);
@@ -407,6 +413,10 @@ public class DEProperties {
 
     public String getIrodsHomePath() {
         return irodsHomePath;
+    }
+
+    public String getBaseTrashPath() {
+        return baseTrashPath;
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/shared/DEProperties.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/DEProperties.java
@@ -108,6 +108,8 @@ public class DEProperties {
      */
     private static final String COMMUNITY_DATA_PATH = "org.iplantc.communitydata.path";
 
+    private static final String IRODS_HOME_PATH = "org.iplantc.irodshome.path";
+
     /**
      * The single instance of this class.
      */
@@ -208,6 +210,8 @@ public class DEProperties {
      */
     private String communityDataPath;
 
+    private String irodsHomePath;
+
     private String dataMgmtAdminBaseUrl;
 
     /**
@@ -236,6 +240,7 @@ public class DEProperties {
     public List<String> getPropertyList() {
         List<String> keys = new ArrayList<>();
         keys.add(COMMUNITY_DATA_PATH);
+        keys.add(IRODS_HOME_PATH);
         keys.add(PATH_LIST_FILE_IDENTIFIER);
         keys.add(MULE_SERVICE_BASE_URL);
         keys.add(DATA_MGMT_BASE_URL);
@@ -280,6 +285,7 @@ public class DEProperties {
         notificationPollInterval = getInt(properties, NOTIFICATION_POLL_INTERVAL, 60);
         pathListFileIdentifier = properties.get(PATH_LIST_FILE_IDENTIFIER);
         communityDataPath = properties.get(COMMUNITY_DATA_PATH);
+        irodsHomePath = properties.get(IRODS_HOME_PATH);
         permIdBaseUrl = properties.get(PERM_ID_BASE_URL);
         betaAvuIri = properties.get(BETA_AVU_IRI);
         betaAvuLabel = properties.get(BETA_AVU_LABEL);
@@ -397,6 +403,10 @@ public class DEProperties {
 
     public String getCommunityDataPath() {
         return communityDataPath;
+    }
+
+    public String getIrodsHomePath() {
+        return irodsHomePath;
     }
 
     /**


### PR DESCRIPTION
If the UI is unable to get a user's preferences, a default set of user preferences is used.  One of those default settings is using the user's home directory, retrieved from the bootstrap endpoint, as the default output folder for analyses.  If the data-info service is down while the UI is calling bootstrap, the path to the user's home directory stored in `UserInfo` will be empty.  

This PR attempts to use the irods home path from the configs plus the user's username to construct their home directory path as a default value in the case that data-info is down.  If this effort fails, then no default output folder is set.  The user will have to pick some directory they have write access to at app launch or change their preferences.