### PR TITLE
CORE-8400 Improvements to saved sessions resiliency

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
@@ -28,7 +28,7 @@ public class UserSettings {
     private String defaultFileSelectorPath;
     private boolean rememberLastPath;
     private boolean saveSession;
-    private boolean sessionConnectionFailed;
+    private boolean userSessionConnection;
     private Folder defaultOutputFolder;
     private String dataShortCut;
     private String appShortCut;
@@ -242,8 +242,8 @@ public class UserSettings {
         return (defaultFileSelectorPath == null) ? "" : defaultFileSelectorPath;
     }
 
-    public boolean sessionConnectionFailed() {
-        return sessionConnectionFailed;
+    public boolean hasUserSessionConnection() {
+        return userSessionConnection;
     }
 
     /**
@@ -309,8 +309,8 @@ public class UserSettings {
         this.saveSession = saveSession;
     }
 
-    public void setSessionConnectionFailed(boolean failedConnection) {
-        this.sessionConnectionFailed = failedConnection;
+    public void setUserSessionConnection(boolean connected) {
+        this.userSessionConnection = connected;
     }
 
     public boolean isSaveSession() {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -216,7 +216,7 @@ public interface DesktopView extends IsWidget {
 
         void restoreWindows(List<WindowState> windowStates);
 
-        void setPeriodicSessionFailFlags();
+        void setUserSessionConnection(boolean connected);
 
         void onFaqSelect();
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -809,7 +809,6 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
 
     @Override
     public void setPeriodicSessionFailFlags() {
-        userSettings.setSaveSession(false);
         userSettings.setSessionConnectionFailed(true);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -808,7 +808,7 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
     }-*/;
 
     @Override
-    public void setPeriodicSessionFailFlags() {
-        userSettings.setSessionConnectionFailed(true);
+    public void setUserSessionConnection(boolean connected) {
+        userSettings.setUserSessionConnection(connected);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -156,7 +156,7 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
     @Inject UserSettings userSettings;
     @Inject NotifyInfo notifyInfo;
     @Inject DiskResourceUtil diskResourceUtil;
-    @Inject DesktopPresenterAppearance appearance;
+    private DesktopPresenterAppearance appearance;
 
     private final EventBus eventBus;
     private final MessagePoller messagePoller;
@@ -176,14 +176,16 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
                                 final EventBus eventBus,
                                 final WindowManager windowManager,
                                 final DesktopWindowManager desktopWindowManager,
-                                final MessagePoller messagePoller) {
+                                final MessagePoller messagePoller,
+                                final DesktopPresenterAppearance appearance) {
         this.view = view;
         this.eventBus = eventBus;
         this.windowManager = windowManager;
         this.messagePoller = messagePoller;
         this.desktopWindowManager = desktopWindowManager;
         this.desktopWindowManager.setDesktopContainer(view.getDesktopContainer());
-        this.ssp = new SaveSessionPeriodic(this);
+        this.appearance = appearance;
+        this.ssp = new SaveSessionPeriodic(this, appearance, 8);
         this.loggedOut = false;
         this.view.setPresenter(this);
         globalEventHandler.setPresenter(this, this.view);
@@ -643,7 +645,7 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
 
     @Override
     public void doPeriodicSessionSave() {
-        if (userSettings.isSaveSession()) {
+        if (userSettings.hasUserSessionConnection() && userSettings.isSaveSession()) {
             ssp.run();
             messagePoller.addTask(ssp);
             // start if not started...

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
@@ -45,12 +45,13 @@ class RuntimeCallbacks {
         public void onFailure(Throwable caught) {
             final SafeHtml message = SafeHtmlUtils.fromTrustedString(appearance.loadSessionFailed());
             announcer.schedule(new ErrorAnnouncementConfig(message, true, 5000));
-            presenter.setPeriodicSessionFailFlags();
+            presenter.setUserSessionConnection(false);
             progressMessageBox.hide();
         }
 
         @Override
         public void onSuccess(List<WindowState> result) {
+            presenter.setUserSessionConnection(true);
             presenter.restoreWindows(result);
             presenter.doPeriodicSessionSave();
             progressMessageBox.hide();
@@ -160,11 +161,12 @@ class RuntimeCallbacks {
                     @Override
                     public void onFailure(Throwable caught) {
                         announcer.schedule(new ErrorAnnouncementConfig(appearance.saveSessionFailed()));
-                        presenter.setPeriodicSessionFailFlags();
+                        presenter.setUserSessionConnection(false);
                     }
 
                     @Override
                     public void onSuccess(Void result) {
+                        presenter.setUserSessionConnection(true);
                         showSaveSettingSuccess();
                     }
                 });

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/presenter/PreferencesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/presenter/PreferencesPresenterImpl.java
@@ -49,11 +49,13 @@ public class PreferencesPresenterImpl implements PreferencesView.Presenter,
 
             @Override
             public void onFailure(Throwable caught) {
+                desktopPresenter.setUserSessionConnection(false);
                 view.userSessionFail();
             }
 
             @Override
             public void onSuccess(List<WindowState> result) {
+                desktopPresenter.setUserSessionConnection(true);
                 view.userSessionSuccess();
                 desktopPresenter.restoreWindows(result);
                 desktopPresenter.doPeriodicSessionSave();

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
@@ -122,7 +122,7 @@ public class PreferencesViewImpl extends Composite implements PreferencesView,
     public void initAndShow(final UserSettings userSettings) {
         this.usValue = userSettings;
         editorDriver.edit(userSettings);
-        if (userSettings.sessionConnectionFailed()) {
+        if (!userSettings.hasUserSessionConnection()) {
             userSessionFail();
         }
         show();

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopErrorMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopErrorMessages.properties
@@ -1,7 +1,7 @@
 fetchNotificationsError = There was a problem fetching your current notifications
 feedbackServiceFailure = Unable to submit your feedback. We appreciate your time for giving feedback. Please contact CyVerse support at support@cyverse.org.
 loadSessionFailed = Could not load last saved session.  Your current session will not be saved.  To retry, check Preferences.
-saveSessionFailed = Could not save session.
+saveSessionFailed = Could not save session.  To retry, check Preferences.
 systemInitializationError = Unable to retrieve the configuration settings from the server.
 permissionErrorTitle = Permission Error
 permissionErrorMessage = You do not have the permission to perform this operation on the selected item(s).


### PR DESCRIPTION
This PR should fix:
- Saved Session checkbox getting unchecked when the saved sessions service comes back up
- When the saved sessions service comes back up, the Try Again button and error message in the Preferences window are removed
- If saved sessions goes down while the user is logged in, the periodic session save will continue to attempt to save their session for a certain number of retries (currently 8 retries is 2 minutes) before disabling itself and letting the user know their session was not saved