### PR TITLE
CORE-8434 Clear Apps grid when HPC app load fails

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsListView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsListView.java
@@ -75,6 +75,8 @@ public interface AppsListView extends IsWidget,
         String agaveAuthRequiredMsg();
 
         String sortLabel();
+
+        String appLoadError();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
@@ -119,6 +119,9 @@ public class AppCategoriesPresenterImpl implements AppCategoriesView.Presenter,
         this.trees.add(workspaceView.getTree());
         this.trees.add(hpcView.getTree());
 
+        workspaceView.addAppCategorySelectedEventHandler(this);
+        hpcView.addAppCategorySelectedEventHandler(this);
+
         initConstants(props, jsonUtil);
 
         eventBus.addHandler(AppUpdatedEvent.TYPE, this);
@@ -246,7 +249,6 @@ public class AppCategoriesPresenterImpl implements AppCategoriesView.Presenter,
     }
 
     void addCategoriesToHPCTree() {
-        hpcView.addAppCategorySelectedEventHandler(this);
         addAppCategories(hpcView.getTree().getStore(), null, hpcCategories);
     }
 
@@ -255,7 +257,6 @@ public class AppCategoriesPresenterImpl implements AppCategoriesView.Presenter,
         final Store.StoreSortInfo<AppCategory> info = new Store.StoreSortInfo<>(new AppCategoryComparator(treeStore),
                                                                                 SortDir.ASC);
         treeStore.addSortInfo(info);
-        workspaceView.addAppCategorySelectedEventHandler(this);
         addAppCategories(treeStore, null, workspaceCategories);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java
@@ -92,6 +92,9 @@ public class AppsListPresenterImpl implements AppsListView.Presenter,
                 });
             } else {
                 ErrorHandler.post(caught);
+                listStore.clear();
+                gridView.setHeadingText(appearance.appLoadError());
+                tileView.setHeadingText(appearance.appLoadError());
             }
             activeView.unmask();
         }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java
@@ -91,7 +91,7 @@ public class AppsListPresenterImpl implements AppsListView.Presenter,
                     }
                 });
             } else {
-                ErrorHandler.post(caught);
+                postToErrorHandler(caught);
                 listStore.clear();
                 gridView.setHeadingText(appearance.appLoadError());
                 tileView.setHeadingText(appearance.appLoadError());
@@ -410,5 +410,9 @@ public class AppsListPresenterImpl implements AppsListView.Presenter,
         if (handlerManager != null) {
             handlerManager.fireEvent(event);
         }
+    }
+
+    void postToErrorHandler(Throwable caught) {
+        ErrorHandler.post(caught);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
@@ -145,4 +145,6 @@ public interface AppsMessages extends Messages {
     String completedDate();
 
     String completedRun();
+
+    String appLoadError();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
@@ -67,3 +67,4 @@ sortLabel = Sort By:
 privateAppRatingNotSupported = Rating private apps is not supported
 completedDate = Last Completed
 completedRun =  Analyses Completed
+appLoadError = Error Loading Apps - Please Try Again

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/list/AppsListViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/list/AppsListViewDefaultAppearance.java
@@ -83,4 +83,9 @@ public class AppsListViewDefaultAppearance implements AppsListView.AppsListAppea
     public String sortLabel() {
         return appsMessages.sortLabel();
     }
+
+    @Override
+    public String appLoadError() {
+        return appsMessages.appLoadError();
+    }
 }

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImplTest.java
@@ -277,6 +277,8 @@ public class AppCategoriesPresenterImplTest {
         verify(viewFactoryMock, times(2)).create(Matchers.<TreeStore<AppCategory>> any(), eq(uut));
         verify(workspaceViewMock).getTree();
         verify(hpcViewMock).getTree();
+        verify(workspaceViewMock).addAppCategorySelectedEventHandler(eq(uut));
+        verify(hpcViewMock).addAppCategorySelectedEventHandler(eq(uut));
         verify(eventBusMock, times(2)).addHandler(Matchers.<GwtEvent.Type<AppCategoriesPresenterImpl>>any(), eq(uut));
     }
 


### PR DESCRIPTION
If HPC apps fail to load, the Apps grid will mistakenly appear as if HPC apps did load because apps are listed.  These apps are actually the same apps listed from whatever previous category/hierarchy the user had selected.  Now, if HPC is down, the grid will clear and the grid's heading will inform the user of the app load error.

Also, discovered that when the user hits Refresh, duplicate handlers were getting added to the view - this is now fixed.