### PR TITLE
CORE-8443 Improve UI's handling of individual bootstrap service errors

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppCategoriesView.java
@@ -46,6 +46,8 @@ public interface AppCategoriesView extends IsWidget,
         String workspaceTab();
 
         String hpcTab();
+
+        String agaveRedirectCheckFail();
     }
 
     /**
@@ -76,6 +78,8 @@ public interface AppCategoriesView extends IsWidget,
         void go(HasId selectedAppCategory, boolean selectDefaultCategory, DETabPanel tabPanel);
 
         void setViewDebugId(String baseID);
+
+        void checkForAgaveRedirect();
     }
 
     interface AppCategoryHierarchyProvider {

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
@@ -46,6 +46,8 @@ public interface AppsView extends IsWidget,
         Presenter hideWorkflowMenu();
 
         void setViewDebugId(String baseId);
+
+        void checkForAgaveRedirect();
     }
 
     DETabPanel getCategoryTabPanel();

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
@@ -8,6 +8,7 @@ import org.iplantc.de.apps.client.OntologyHierarchiesView;
 import org.iplantc.de.apps.client.events.selection.RefreshAppsSelectedEvent;
 import org.iplantc.de.apps.client.gin.factory.AppsViewFactory;
 import org.iplantc.de.client.models.HasId;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
@@ -35,6 +36,7 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
     private final AppsListView.Presenter appsListPresenter;
     private final OntologyHierarchiesView.Presenter hierarchiesPresenter;
     private final AppsToolbarView.Presenter toolbarPresenter;
+    @Inject UserInfo userInfo;
     OntologyUtil ontologyUtil;
 
     @Inject
@@ -120,6 +122,11 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
     @Override
     public void setViewDebugId(String baseId) {
         view.asWidget().ensureDebugId(baseId);
+    }
+
+    @Override
+    public void checkForAgaveRedirect() {
+        categoriesPresenter.checkForAgaveRedirect();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/categories/AppCategoriesPresenterImpl.java
@@ -198,26 +198,29 @@ public class AppCategoriesPresenterImpl implements AppCategoriesView.Presenter,
 
     @Override
     public void checkForAgaveRedirect() {
-        if (!userInfo.hasSessionError()) {
-            return;
-        }
-
-        oauthServiceFacade.getRedirectUris(new AsyncCallback<Map<String, String>>() {
-            @Override
-            public void onFailure(Throwable caught) {
-                announcer.schedule(new ErrorAnnouncementConfig(appearance.agaveRedirectCheckFail()));
-            }
-
-            @Override
-            public void onSuccess(Map<String, String> result) {
-                userInfo.setAuthRedirects(result);
-
-                if (userInfo.hasAgaveRedirect()) {
-                    AgaveAuthPrompt prompt = AgaveAuthPrompt.getInstance();
-                    prompt.show();
+        if (userInfo.hasSessionError()){
+            oauthServiceFacade.getRedirectUris(new AsyncCallback<Map<String, String>>() {
+                @Override
+                public void onFailure(Throwable caught) {
+                    announcer.schedule(new ErrorAnnouncementConfig(appearance.agaveRedirectCheckFail()));
                 }
-            }
-        });
+
+                @Override
+                public void onSuccess(Map<String, String> result) {
+                    userInfo.setAuthRedirects(result);
+                    showAgaveAuth();
+                }
+            });
+        } else {
+            showAgaveAuth();
+        }
+    }
+
+    void showAgaveAuth() {
+        if (userInfo.hasAgaveRedirect()) {
+            AgaveAuthPrompt prompt = AgaveAuthPrompt.getInstance();
+            prompt.show();
+        }
     }
 
     void selectDesiredCategory(HasId selectedAppCategory, boolean selectDefaultCategory) {

--- a/de-lib/src/main/java/org/iplantc/de/client/gin/ServicesInjector.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/gin/ServicesInjector.java
@@ -12,6 +12,7 @@ import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.services.FileEditorServiceFacade;
 import org.iplantc.de.client.services.FileSystemMetadataServiceFacade;
 import org.iplantc.de.client.services.MessageServiceFacade;
+import org.iplantc.de.client.services.OauthServiceFacade;
 import org.iplantc.de.client.services.PermIdRequestUserServiceFacade;
 import org.iplantc.de.client.services.SearchServiceFacade;
 import org.iplantc.de.client.services.SystemMessageServiceFacade;
@@ -69,4 +70,6 @@ public interface ServicesInjector extends Ginjector {
     AppMetadataServiceFacade getAppMetadataServiceFacade();
 
     PermIdRequestUserServiceFacade getPermIdRequestUserServiceFacade();
+
+    OauthServiceFacade getOauthService();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/gin/ServicesModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/gin/ServicesModule.java
@@ -37,6 +37,7 @@ final class ServicesModule extends AbstractGinModule {
         bind(FileSystemMetadataServiceFacade.class).to(FileSystemMetadataServiceFacadeImpl.class);
         bind(AppMetadataServiceFacade.class).to(AppMetadataServiceFacadeImpl.class);
         bind(PermIdRequestUserServiceFacade.class).to(PermIdRequestUserServiceFacadeImpl.class);
+        bind(OauthServiceFacade.class).to(OauthServiceFacadeImpl.class);
         bind(DiscEnvApiService.class).in(Singleton.class);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/client/models/CommonModelAutoBeanFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/CommonModelAutoBeanFactory.java
@@ -23,4 +23,6 @@ public interface CommonModelAutoBeanFactory extends AutoBeanFactory {
     AutoBean<UserSession> userSession();
 
     AutoBean<StructuredText> getStructuredText();
+
+    AutoBean<RootLevelMap> rootLevelMap();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/CommonModelAutoBeanFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/CommonModelAutoBeanFactory.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.client.models;
 
+import org.iplantc.de.client.models.bootstrap.Session;
 import org.iplantc.de.client.models.bootstrap.UserBootstrap;
 import org.iplantc.de.client.models.viewer.StructuredText;
 
@@ -23,6 +24,8 @@ public interface CommonModelAutoBeanFactory extends AutoBeanFactory {
     AutoBean<UserSession> userSession();
 
     AutoBean<StructuredText> getStructuredText();
+
+    AutoBean<Session> session();
 
     AutoBean<RootLevelMap> rootLevelMap();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/RootLevelMap.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/RootLevelMap.java
@@ -1,0 +1,22 @@
+package org.iplantc.de.client.models;
+
+import com.google.web.bindery.autobean.shared.AutoBean;
+
+import java.util.Map;
+
+/**
+ * @author aramsey
+ */
+public interface RootLevelMap {
+
+    class Payload {
+        public static String get(String json) {
+            return "{\"" + RootLevelMap.MAP_JSON_KEY + "\": " + json + "}";
+        }
+    }
+
+    String MAP_JSON_KEY = "root_map";
+
+    @AutoBean.PropertyName(MAP_JSON_KEY)
+    Map<String, String> getRootMap();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -239,7 +239,7 @@ public class UserInfo {
      * @return the newUser
      */
     public boolean isNewUser() {
-        return workspace == null ? false : workspace.isNewUser();
+        return workspace == null || hasWorkspaceError() ? true : workspace.isNewUser();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -215,6 +215,10 @@ public class UserInfo {
         return dataInfo.getBaseTrashPath();
     }
 
+    public void setDataInfo(DataInfo dataInfo) {
+        this.dataInfo = dataInfo;
+    }
+
     /**
      * Gets the username for the user.
      *

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -255,13 +255,11 @@ public class UserInfo {
 
     public void setAuthRedirects(Map<String, String> redirects) {
         if (session == null) {
-            Session newSession = factory.session().as();
-            newSession.setAuthRedirects(redirects);
-            session = newSession;
+            session = factory.session().as();
         } else {
-            session.setAuthRedirects(redirects);
             session.setError(null);
         }
+        session.setAuthRedirects(redirects);
     }
 
     public Map<String, String> getAuthRedirects() {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -128,14 +128,14 @@ public class UserInfo {
      * @return email address.
      */
     public String getEmail() {
-        return userProfile == null ? null : userProfile.getEmail();
+        return userProfile == null || hasUserProfileError() ? null : userProfile.getEmail();
     }
 
     /**
      * @return the firstName
      */
     public String getFirstName() {
-        return userProfile == null ? null : userProfile.getFirstName();
+        return userProfile == null || hasUserProfileError() ? null : userProfile.getFirstName();
     }
 
     /**
@@ -144,14 +144,14 @@ public class UserInfo {
      * @return the fully qualified username.
      */
     public String getFullUsername() {
-        return userProfile == null ? null : userProfile.getFullUsername();
+        return userProfile == null || hasUserProfileError() ? null : userProfile.getFullUsername();
     }
 
     /**
      * @return the path to the user's home directory.
      */
     public String getHomePath() {
-        if (hasDataInfoError()) {
+        if (dataInfo == null || hasDataInfoError()) {
             String irodsHome = DEProperties.getInstance().getIrodsHomePath();
             String username = userProfile.getUsername();
 
@@ -168,11 +168,11 @@ public class UserInfo {
      * @return the lastName
      */
     public String getLastName() {
-        return userProfile == null ? null : userProfile.getLastName();
+        return userProfile == null || hasUserProfileError() ? null : userProfile.getLastName();
     }
 
     public Long getLoginTime() {
-        return session == null ? null : session.getLoginTime();
+        return session == null || hasSessionError() ? null : session.getLoginTime();
     }
 
     /**
@@ -186,7 +186,7 @@ public class UserInfo {
      * @return the path to the user's trash.
      */
     public String getTrashPath() {
-        if (hasDataInfoError()) {
+        if (dataInfo == null || hasDataInfoError()) {
             String baseTrashPath = getBaseTrashPath();
             String username = userProfile.getUsername();
 
@@ -203,7 +203,7 @@ public class UserInfo {
      * @return the base trash path of the data store for all users.
      */
     public String getBaseTrashPath() {
-        if (hasDataInfoError()) {
+        if (dataInfo == null || hasDataInfoError()) {
             String baseTrashPath = DEProperties.getInstance().getBaseTrashPath();
 
             if (Strings.isNullOrEmpty(baseTrashPath)) {
@@ -223,7 +223,7 @@ public class UserInfo {
      * @return a string representing the username for the user.
      */
     public String getUsername() {
-        return userProfile == null ? null : userProfile.getUsername();
+        return userProfile == null || hasUserProfileError() ? null : userProfile.getUsername();
     }
 
     /**
@@ -250,7 +250,7 @@ public class UserInfo {
     }
 
     public Map<String, String> getAuthRedirects() {
-        return session == null ? null : session.getAuthRedirects();
+        return session == null || hasSessionError() ? null : session.getAuthRedirects();
     }
 
     public boolean hasAgaveRedirect() {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -253,6 +253,17 @@ public class UserInfo {
         this.savedOrderedWindowStates = savedOrderedWindowStates;
     }
 
+    public void setAuthRedirects(Map<String, String> redirects) {
+        if (session == null) {
+            Session newSession = factory.session().as();
+            newSession.setAuthRedirects(redirects);
+            session = newSession;
+        } else {
+            session.setAuthRedirects(redirects);
+            session.setError(null);
+        }
+    }
+
     public Map<String, String> getAuthRedirects() {
         return session == null || hasSessionError() ? null : session.getAuthRedirects();
     }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -6,6 +6,7 @@ import org.iplantc.de.client.models.bootstrap.Session;
 import org.iplantc.de.client.models.bootstrap.UserBootstrap;
 import org.iplantc.de.client.models.bootstrap.UserProfile;
 import org.iplantc.de.client.models.bootstrap.Workspace;
+import org.iplantc.de.client.models.userSettings.UserSetting;
 import org.iplantc.de.shared.DEProperties;
 
 import com.google.common.base.Strings;
@@ -145,6 +146,10 @@ public class UserInfo {
      */
     public String getFullUsername() {
         return userProfile == null || hasUserProfileError() ? null : userProfile.getFullUsername();
+    }
+
+    public UserSetting getUserPreferences() {
+        return preferences;
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserSettings.java
@@ -25,6 +25,7 @@ public class UserSettings {
     private UserSetting userSetting;
     private static UserSettings instance;
     private boolean userSessionConnection = true;
+    private boolean isDefaults;
     private static String ANALYSES_DIR = "analyses";
 
     public UserSettings(final UserSetting userSetting) {
@@ -54,7 +55,10 @@ public class UserSettings {
 
     void setUserSettings() {
         if (userSetting == null) {
+            isDefaults = true;
             userSetting = factory.getUserSetting().as();
+        } else {
+            isDefaults = false;
         }
 
         if (userSetting.isEnableAnalysisEmailNotification() == null) {
@@ -291,5 +295,9 @@ public class UserSettings {
 
     public void setEnableWaitTimeMessage(boolean enableWaitTimeMessage) {
         userSetting.setEnableWaitTimeMessage(enableWaitTimeMessage);
+    }
+
+    public boolean isUsingDefaults() {
+        return isDefaults;
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Preferences.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Preferences.java
@@ -1,22 +1,15 @@
 package org.iplantc.de.client.models.bootstrap;
 
 import org.iplantc.de.client.models.HasStatus;
-import org.iplantc.de.client.models.diskResources.Folder;
+import org.iplantc.de.client.models.userSettings.UserSetting;
 
-import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 import com.google.web.bindery.autobean.shared.Splittable;
 
 /**
  *
  * @author aramsey
  */
-public interface Preferences extends HasStatus {
-
-    @PropertyName("system_default_output_dir")
-    Folder getSystemDefaultOutputDir();
-
-    @PropertyName("default_output_folder")
-    Folder getDefaultOutputDir();
+public interface Preferences extends HasStatus, UserSetting {
 
     Splittable getError();
 

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Session.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Session.java
@@ -16,5 +16,9 @@ public interface Session {
     @PropertyName("auth_redirect")
     Map<String, String> getAuthRedirects();
 
+    @PropertyName("auth_redirect")
+    void setAuthRedirects(Map<String, String> redirects);
+
     Splittable getError();
+    void setError(Splittable error);
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/RootFolders.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/RootFolders.java
@@ -1,5 +1,9 @@
 package org.iplantc.de.client.models.diskResources;
 
+import org.iplantc.de.client.models.bootstrap.DataInfo;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
 import java.util.List;
 
 
@@ -8,4 +12,8 @@ public interface RootFolders {
     List<Folder> getRoots();
 
     void setRoots(List<Folder> roots);
+
+    @PropertyName("base-paths")
+    DataInfo getBasePaths();
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/OauthServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/OauthServiceFacade.java
@@ -1,0 +1,13 @@
+package org.iplantc.de.client.services;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+import java.util.Map;
+
+/**
+ * @author aramsey
+ */
+public interface OauthServiceFacade {
+
+    void getRedirectUris(AsyncCallback<Map<String,String>> callback);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/OauthServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/OauthServiceFacadeImpl.java
@@ -1,0 +1,48 @@
+package org.iplantc.de.client.services.impl;
+
+import org.iplantc.de.client.models.CommonModelAutoBeanFactory;
+import org.iplantc.de.client.models.RootLevelMap;
+import org.iplantc.de.client.services.OauthServiceFacade;
+import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
+import org.iplantc.de.shared.services.DiscEnvApiService;
+import org.iplantc.de.shared.services.ServiceCallWrapper;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.inject.Inject;
+import com.google.web.bindery.autobean.shared.AutoBeanCodex;
+
+import java.util.Map;
+
+/**
+ * @author aramsey
+ */
+public class OauthServiceFacadeImpl implements OauthServiceFacade {
+
+    private final String OAUTH = "org.iplantc.services.oauth";
+
+    private final DiscEnvApiService deServiceFacade;
+    private CommonModelAutoBeanFactory factory;
+
+    @Inject
+    public OauthServiceFacadeImpl(final DiscEnvApiService deServiceFacade,
+                                  CommonModelAutoBeanFactory factory) {
+        this.deServiceFacade = deServiceFacade;
+        this.factory = factory;
+    }
+
+    @Override
+    public void getRedirectUris(AsyncCallback<Map<String, String>> callback) {
+        String address = OAUTH + "/redirect-uris";
+
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
+        deServiceFacade.getServiceData(wrapper, new AsyncCallbackConverter<String, Map<String, String>>(callback) {
+            @Override
+            protected Map<String, String> convertFrom(String object) {
+                RootLevelMap rootLevelMap = AutoBeanCodex.decode(factory,
+                                                       RootLevelMap.class,
+                                                       RootLevelMap.Payload.get(object)).as();
+                return rootLevelMap.getRootMap();
+            }
+        });
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/gin/DEGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/gin/DEGinModule.java
@@ -95,6 +95,11 @@ public class DEGinModule extends AbstractGinModule {
         return ServicesInjector.INSTANCE.getDeployedComponentServices();
     }
 
+    @Provides
+    public OauthServiceFacade createOauthServices() {
+        return ServicesInjector.INSTANCE.getOauthService();
+    }
+
     //</editor-fold>
 
     @Provides @Singleton public NotifyInfo createNotifyInfo() {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/InitializationCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/InitializationCallbacks.java
@@ -73,6 +73,12 @@ class InitializationCallbacks {
         @Override
         public void onSuccess(String result) {
             userInfo.init(result);
+
+            if (userInfo.hasUserProfileError()) {
+                presenter.onBootstrapError(null);
+                return;
+            }
+
             if (userInfo.isNewUser()) {
                 ConfirmMessageBox box = getIntroConfirmation();
                 box.addDialogHideHandler(new DialogHideHandler() {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
@@ -2,10 +2,8 @@ package org.iplantc.de.desktop.client.views.windows;
 
 import org.iplantc.de.apps.client.AppsView;
 import org.iplantc.de.apps.shared.AppsModule;
-import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
 import org.iplantc.de.commons.client.util.WindowUtil;
-import org.iplantc.de.commons.client.views.dialogs.AgaveAuthPrompt;
 import org.iplantc.de.commons.client.views.window.configs.AppsWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
@@ -22,7 +20,6 @@ import com.sencha.gxt.widget.core.client.event.SelectEvent;
 public class DEAppsWindow extends IplantWindowBase {
 
     public static final String APPS = "#apps";
-    @Inject UserInfo userInfo;
     private final AppsView.Presenter presenter;
 
     @Inject
@@ -55,10 +52,7 @@ public class DEAppsWindow extends IplantWindowBase {
     @Override
     protected void afterShow() {
         super.afterShow();
-        if (userInfo.hasAgaveRedirect()) {
-            AgaveAuthPrompt prompt = AgaveAuthPrompt.getInstance();
-            prompt.show();
-        }
+        presenter.checkForAgaveRedirect();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/proxy/FolderRpcProxyImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/proxy/FolderRpcProxyImpl.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.diskResource.client.presenters.navigation.proxy;
 
 import org.iplantc.de.client.models.IsMaskable;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.diskResources.DiskResourceFavorite;
 import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.models.diskResources.RootFolders;
@@ -65,15 +66,17 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
         final IsMaskable maskable;
         private final NavigationView.Presenter.Appearance appearance;
         final SearchServiceFacade searchSvc;
+        UserInfo userInfo;
 
         public RootFolderCallback(final SearchServiceFacade searchService,
                                   final AsyncCallback<List<Folder>> callback,
-                                  final IplantAnnouncer announcer,
+                                  final IplantAnnouncer announcer, UserInfo userInfo,
                                   final IsMaskable isMaskable,
                                   final NavigationView.Presenter.Appearance appearance) {
             this.searchSvc = searchService;
             this.callback = callback;
             this.ipAnnouncer = announcer;
+            this.userInfo = userInfo;
             this.maskable = isMaskable;
             this.appearance = appearance;
         }
@@ -90,6 +93,10 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
 
         @Override
         public void onSuccess(final RootFolders rootFolders) {
+            if (userInfo.hasDataInfoError() && rootFolders.getBasePaths() != null) {
+                userInfo.setDataInfo(rootFolders.getBasePaths());
+            }
+
             if (callback != null) {
                 List<Folder> roots = rootFolders.getRoots();
                 callback.onSuccess(roots);
@@ -140,6 +147,7 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
     private final HandlerManager handlerManager;
     private final SearchServiceFacade searchService;
     private IsMaskable isMaskable;
+    @Inject UserInfo userInfo;
 
     @Inject
     FolderRpcProxyImpl(final DiskResourceServiceFacade drService,
@@ -178,6 +186,7 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
             drService.getRootFolders(new RootFolderCallback(searchService,
                                                             callback,
                                                             announcer,
+                                                            userInfo,
                                                             isMaskable,
                                                             appearance));
         } else if (parentFolder.isFilter() || parentFolder instanceof DiskResourceFavorite) {

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/proxy/FolderRpcProxyImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/proxy/FolderRpcProxyImpl.java
@@ -66,11 +66,12 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
         final IsMaskable maskable;
         private final NavigationView.Presenter.Appearance appearance;
         final SearchServiceFacade searchSvc;
-        UserInfo userInfo;
+        final UserInfo userInfo;
 
         public RootFolderCallback(final SearchServiceFacade searchService,
                                   final AsyncCallback<List<Folder>> callback,
-                                  final IplantAnnouncer announcer, UserInfo userInfo,
+                                  final IplantAnnouncer announcer,
+                                  final UserInfo userInfo,
                                   final IsMaskable isMaskable,
                                   final NavigationView.Presenter.Appearance appearance) {
             this.searchSvc = searchService;

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/PreferencesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/PreferencesView.java
@@ -66,6 +66,10 @@ public interface PreferencesView extends IsWidget,
         String retrySessionConnection();
 
         SafeHtml sessionConnectionFailed();
+
+        String preferencesFailure();
+
+        String preferencesSuccess();
     }
 
     void userSessionSuccess();

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.java
@@ -147,4 +147,6 @@ public interface AppsMessages extends Messages {
     String completedRun();
 
     String appLoadError();
+
+    String agaveRedirectCheckFail();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsMessages.properties
@@ -68,3 +68,4 @@ privateAppRatingNotSupported = Rating private apps is not supported
 completedDate = Last Completed
 completedRun =  Analyses Completed
 appLoadError = Error Loading Apps - Please Try Again
+agaveRedirectCheckFail = We were unable to verify if you''ve authenticated with Agave. HPC apps may not be visible at this time.

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/categories/AppCategoriesViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/categories/AppCategoriesViewDefaultAppearance.java
@@ -87,4 +87,9 @@ public class AppCategoriesViewDefaultAppearance implements AppCategoriesView.App
     public String hpcTab() {
         return appsMessages.hpcTab();
     }
+
+    @Override
+    public String agaveRedirectCheckFail() {
+        return appsMessages.agaveRedirectCheckFail();
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.java
@@ -110,4 +110,8 @@ public interface DesktopMessages extends Messages {
     String faqs();
 
     String feedback();
+
+    String preferencesFailure();
+
+    String preferencesSuccess();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.properties
@@ -34,3 +34,5 @@ retrySessionConnection = Try Again
 sessionConnectionFailed = Connection to session service failed.
 faqs = FAQs
 feedback = Feedback
+preferencesFailure = We were unable to fetch your preferences.  A default set of preferences will be used instead.
+preferencesSuccess = Preferences successfully restored!

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/PreferencesViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/PreferencesViewDefaultAppearance.java
@@ -168,4 +168,14 @@ public class PreferencesViewDefaultAppearance implements PreferencesView.Prefere
     public SafeHtml sessionConnectionFailed() {
         return templates.redText(desktopMessages.sessionConnectionFailed());
     }
+
+    @Override
+    public String preferencesFailure() {
+        return desktopMessages.preferencesFailure();
+    }
+
+    @Override
+    public String preferencesSuccess() {
+        return desktopMessages.preferencesSuccess();
+    }
 }


### PR DESCRIPTION
* If the `user_info` key is missing the username, name, or email information, the user will now be redirected to the DE's error page so they can try logging in again.
* If the `session` key contains an error, the loginTime will not be populated (which is acceptable) and the UI will recheck for any redirects from the oauth service when the Apps window is opened (for example, the Agave redirect).
* If the `workspace` key contains an error, the UI will by default assume the user is a new user and show the prompt for the introduction/tutorial upon login.  The workspace ID isn't used in the UI, so that is ignored.
* If the `data_info` key contains an error, default home and trash paths will be used.  If the user opens the Data window and gets a successful callback from `/filesystem/root` the home and trash paths from that callback will be used instead.
* If the `preferences` key contains an error, default preferences (specifically their job output folder) will be used.

(requires ansible and terrain changes as well)