### PR TITLE
CORE-8460 UI Resiliency - Data Window

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/parameters/AnalysisParametersPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/parameters/AnalysisParametersPresenterImpl.java
@@ -84,7 +84,7 @@ public class AnalysisParametersPresenterImpl implements AnalysisParametersView.P
         }
     }
 
-    private static class SaveAnalysisParametersCallback implements AsyncCallback<File> {
+    private static class SaveAnalysisParametersCallback extends DataCallback<File> {
         private final  IplantAnnouncer announcer;
         private final AnalysisParametersView.Appearance appearance;
         private final DiskResourceUtil diskResourceUtil;
@@ -113,7 +113,7 @@ public class AnalysisParametersPresenterImpl implements AnalysisParametersView.P
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             ErrorHandler.post(caught);
         }
 

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/parameters/AnalysisParametersPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/parameters/AnalysisParametersPresenterImpl.java
@@ -30,6 +30,7 @@ import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.diskResource.client.events.ShowFilePreviewEvent;
 import org.iplantc.de.shared.AsyncProviderWrapper;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -54,7 +55,7 @@ public class AnalysisParametersPresenterImpl implements AnalysisParametersView.P
                                                         SaveAnalysisParametersEvent.SaveAnalysisParametersEventHandler,
                                                         AnalysisParamValueSelectedEvent.AnalysisParamValueSelectedEventHandler {
 
-    private static class GetStatCallback implements AsyncCallback<FastMap<DiskResource>> {
+    private static class GetStatCallback extends DataCallback<FastMap<DiskResource>> {
         private final AnalysisParameter value;
         private final EventBus eventBus;
         private final IplantAnnouncer announcer;
@@ -71,7 +72,7 @@ public class AnalysisParametersPresenterImpl implements AnalysisParametersView.P
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             final SafeHtml message = SafeHtmlUtils.fromTrustedString(appearance.diskResourceDoesNotExist(value.getDisplayValue()));
             announcer.schedule(new ErrorAnnouncementConfig(message, true, 3000));
         }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
@@ -1,7 +1,5 @@
 package org.iplantc.de.client.services;
 
-import java.util.List;
-
 import org.iplantc.de.client.models.HasPaths;
 import org.iplantc.de.client.models.dataLink.DataLink;
 import org.iplantc.de.client.models.diskResources.DiskResource;
@@ -16,12 +14,16 @@ import org.iplantc.de.client.models.diskResources.RootFolders;
 import org.iplantc.de.client.models.diskResources.TYPE;
 import org.iplantc.de.client.models.services.DiskResourceMove;
 import org.iplantc.de.client.models.viewer.InfoType;
+import org.iplantc.de.shared.DECallback;
 
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.web.bindery.autobean.shared.Splittable;
+
 import com.sencha.gxt.core.shared.FastMap;
 import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfigBean;
+
+import java.util.List;
 
 /**
  * @author jstroot
@@ -36,7 +38,7 @@ public interface DiskResourceServiceFacade {
      * @param folder The parent of the subfolders to refresh from the service.
      * @param callback executed when RPC call completes.
      */
-    void refreshFolder(Folder folder, final AsyncCallback<List<Folder>> callback);
+    void refreshFolder(Folder folder, final DECallback<List<Folder>> callback);
 
     DiskResource combineDiskResources(DiskResource from, DiskResource into);
 
@@ -47,7 +49,7 @@ public interface DiskResourceServiceFacade {
      * 
      * @param callback executed when RPC call completes.
      */
-    void getRootFolders(AsyncCallback<RootFolders> callback);
+    void getRootFolders(DECallback<RootFolders> callback);
 
     /**
      * Called to retrieve the entire contents of a folder.
@@ -64,7 +66,7 @@ public interface DiskResourceServiceFacade {
                            List<InfoType> infoTypeFilterList,
                            TYPE entityType,
                            FilterPagingLoadConfigBean loadConfig,
-                           AsyncCallback<Folder> callback);
+                           DECallback<Folder> callback);
 
     /**
      * Called to retrieve the contents of a folder without its file contents.
@@ -72,7 +74,7 @@ public interface DiskResourceServiceFacade {
      * @param parent requested folder.
      * @param callback executed when RPC call completes.
      */
-    void getSubFolders(final Folder parent, final AsyncCallback<List<Folder>> callback);
+    void getSubFolders(final Folder parent, final DECallback<List<Folder>> callback);
 
     /**
      * Call service to create a new folder
@@ -80,7 +82,7 @@ public interface DiskResourceServiceFacade {
      * @param parentFolder parent folder where the new folder will be created
      * @param callback executed when RPC call completes.
      */
-    void createFolder(Folder parentFolder, final String newFolderName, AsyncCallback<Folder> callback);
+    void createFolder(Folder parentFolder, final String newFolderName, DECallback<Folder> callback);
 
     /**
      * Check if a list of files or folders exist.
@@ -89,7 +91,7 @@ public interface DiskResourceServiceFacade {
      * @param callback callback executed when RPC call completes. On success, a map that maps resource
      *            paths to whether or not they exist.
      */
-    void diskResourcesExist(HasPaths diskResourcePaths, AsyncCallback<DiskResourceExistMap> callback);
+    void diskResourcesExist(HasPaths diskResourcePaths, DECallback<DiskResourceExistMap> callback);
 
     /**
      * Calls the move folder and move file services for the list of given disk resource ids.
@@ -101,7 +103,7 @@ public interface DiskResourceServiceFacade {
     void moveDiskResources(final Folder sourceFolder,
                            final Folder destFolder,
                            final List<DiskResource> diskResources,
-                           AsyncCallback<DiskResourceMove> callback);
+                           DECallback<DiskResourceMove> callback);
 
     /**
      * Calls the move folder and move file services for moving contents of a given folder.
@@ -111,7 +113,7 @@ public interface DiskResourceServiceFacade {
      */
     void moveContents(final Folder sourceFolder,
                       final Folder destFolder,
-                      AsyncCallback<DiskResourceMove> callback);
+                      DECallback<DiskResourceMove> callback);
 
     /**
      * Call service rename a file or folder.
@@ -120,7 +122,7 @@ public interface DiskResourceServiceFacade {
      * @param destName the new name.
      * @param callback service success/failure callback
      */
-    void renameDiskResource(DiskResource src, String destName, AsyncCallback<DiskResource> callback);
+    void renameDiskResource(DiskResource src, String destName, DECallback<DiskResource> callback);
 
     /**
      * Call service to upload a file from a given URL.
@@ -129,7 +131,7 @@ public interface DiskResourceServiceFacade {
      * @param dest id of the destination folder.
      * @param callback service success/failure callback
      */
-    void importFromUrl(String url, DiskResource dest, AsyncCallback<String> callback);
+    void importFromUrl(String url, DiskResource dest, DECallback<String> callback);
 
     /**
      * @param path the path of the file to download.
@@ -144,14 +146,14 @@ public interface DiskResourceServiceFacade {
      * @param callback callback executed when service call completes.
      */
     <T extends DiskResource> void deleteDiskResources(List<T> diskResources,
-                                                      AsyncCallback<HasPaths> callback);
+                                                      DECallback<HasPaths> callback);
 
     /**
      * Call service to delete disk resources in case user selects all items
      * 
      * @param selectedFolderId the folder whose contents will be deleted.
      */
-    void deleteContents(String selectedFolderId, AsyncCallback<HasPaths> callback);
+    void deleteContents(String selectedFolderId, DECallback<HasPaths> callback);
 
     /**
      * Call service to delete disk resources (i.e. {@link File}s and {@link Folder}s)
@@ -159,14 +161,13 @@ public interface DiskResourceServiceFacade {
      * @param diskResources a set of <code>DiskResource</code>s to be deleted
      * @param callback callback executed when service call completes.
      */
-    void deleteDiskResources(HasPaths diskResources, AsyncCallback<HasPaths> callback);
+    void deleteDiskResources(HasPaths diskResources, DECallback<HasPaths> callback);
 
     /**
      * @param resource the <code>DiskResource</code> for which metadata will be retrieved.
      * @param callback callback executed when service call completes.
      */
-    void getDiskResourceMetaData(DiskResource resource,
-                                 AsyncCallback<DiskResourceMetadataList> callback);
+    void getDiskResourceMetaData(DiskResource resource, DECallback<DiskResourceMetadataList> callback);
 
     /**
      * Calls service to set disk resource metadata.
@@ -176,8 +177,8 @@ public interface DiskResourceServiceFacade {
      * @param callback executed when the service call completes.
      */
     void setDiskResourceMetaData(DiskResource resource,
-                                DiskResourceMetadataList mdList,
-                                AsyncCallback<String> callback);
+                                 DiskResourceMetadataList mdList,
+                                 DECallback<String> callback);
 
     /**
      * 
@@ -203,7 +204,7 @@ public interface DiskResourceServiceFacade {
      * @param body - Post body in JSONObject format
      * @param callback callback object
      */
-    void getPermissions(JSONObject body, AsyncCallback<String> callback);
+    void getPermissions(JSONObject body, DECallback<String> callback);
 
     /**
      * search users irods directory structure
@@ -221,47 +222,47 @@ public interface DiskResourceServiceFacade {
      * @param paths the paths to query
      * @param callback callback which returns a map of {@code DiskResource}s keyed by their paths
      */
-    void getStat(final FastMap<TYPE> paths, final AsyncCallback<FastMap<DiskResource>> callback);
+    void getStat(final FastMap<TYPE> paths, final DECallback<FastMap<DiskResource>> callback);
 
     /**
      * empty user's trash
      * 
      * @param user the user whose trash will be emptied.
      */
-    public void emptyTrash(String user, AsyncCallback<String> callback);
+    public void emptyTrash(String user, DECallback<String> callback);
 
     /**
      * Restore deleted disk resources.
      * 
      * @param request the disk resources to be restored.
      */
-    public void restoreDiskResource(HasPaths request, AsyncCallback<String> callback);
+    public void restoreDiskResource(HasPaths request, DECallback<String> callback);
 
     /**
      * Creates a set of public data links for the given disk resources.
      * 
      * @param ticketIdList the id of the disk resource for which the ticket will be created.
      */
-    public void createDataLinks(List<String> ticketIdList, AsyncCallback<List<DataLink>> callback);
+    public void createDataLinks(List<String> ticketIdList, DECallback<List<DataLink>> callback);
 
     /**
      * Requests a listing of all the tickets for the given disk resources.
      * 
      * @param diskResourceIds the disk resources whose tickets will be listed.
      */
-    public void listDataLinks(List<String> diskResourceIds, AsyncCallback<String> callback);
+    public void listDataLinks(List<String> diskResourceIds, DECallback<String> callback);
 
     /**
      * Requests that the given Kif Share tickets will be deleted.
      * 
      * @param dataLinkIds the tickets which will be deleted.
      */
-    public void deleteDataLinks(List<String> dataLinkIds, AsyncCallback<String> callback);
+    public void deleteDataLinks(List<String> dataLinkIds, DECallback<String> callback);
 
     /**
      * Get a list of files types recognized
      */
-    void getInfoTypes(AsyncCallback<List<InfoType>> callback);
+    void getInfoTypes(DECallback<List<InfoType>> callback);
 
     /**
      * Set type to a file
@@ -269,7 +270,7 @@ public interface DiskResourceServiceFacade {
      * @param filePath the path of the file whose type will be set
      * @param type the type the file will be set to.
      */
-    void setFileType(String filePath, String type, AsyncCallback<String> callback);
+    void setFileType(String filePath, String type, DECallback<String> callback);
 
     /**
      * Convenience method which returns a valid {@link DiskResourceAutoBeanFactory} instance.
@@ -282,7 +283,7 @@ public interface DiskResourceServiceFacade {
      * Restore all items in trash to its original location.
      * 
      */
-    void restoreAll(AsyncCallback<String> callback);
+    void restoreAll(DECallback<String> callback);
 
     /**
      * Method used to retrieve list of metadata templates
@@ -302,7 +303,7 @@ public interface DiskResourceServiceFacade {
      * @param diskResourcePaths the paths to query
      * @param callback callback object
      */
-    void shareWithAnonymous(final HasPaths diskResourcePaths, final AsyncCallback<String> callback);
+    void shareWithAnonymous(final HasPaths diskResourcePaths, final DECallback<String> callback);
 
     /**
      * Copy metadata to list of files / folders
@@ -311,10 +312,10 @@ public interface DiskResourceServiceFacade {
      * @param paths destination DR's path to which metadata will be copied.
      * @param callback callback object
      */
-            void
-            copyMetadata(final String srcUUID,
-                         final Splittable paths,
-                         final AsyncCallback<String> callback);
+
+    void copyMetadata(final String srcUUID,
+                      final Splittable paths,
+                      final DECallback<String> callback);
             
             /**
      * save metadata to a file
@@ -327,7 +328,7 @@ public interface DiskResourceServiceFacade {
     void saveMetadata(final String srcUUID,
                       final String path,
                       boolean recursive,
-                      final AsyncCallback<String> callback);
+                      final DECallback<String> callback);
 
     /**
      * 
@@ -337,7 +338,7 @@ public interface DiskResourceServiceFacade {
      */
     void createNcbiSraFolderStructure(Folder parentFolder,
                                       String[] foldersToCreate,
-                                      AsyncCallback<String> callback);
+                                      DECallback<String> callback);
 
     /**
      * 
@@ -347,7 +348,7 @@ public interface DiskResourceServiceFacade {
      */
     void setBulkMetadataFromFile(String metadataFilePath,
                                  String destFolder,
-                                 AsyncCallback<String> callback);
+                                 DECallback<String> callback);
 
     /**
      * @param uuid

--- a/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
@@ -207,16 +207,6 @@ public interface DiskResourceServiceFacade {
     void getPermissions(JSONObject body, DECallback<String> callback);
 
     /**
-     * search users irods directory structure
-     * 
-     * @param term search term
-     * @param size limit for results to return
-     * @param type file or folder
-     * @param callback callback object
-     */
-    void search(String term, int size, String type, AsyncCallback<String> callback);
-
-    /**
      * Get info about a selected file or folder
      * 
      * @param paths the paths to query
@@ -349,13 +339,6 @@ public interface DiskResourceServiceFacade {
     void setBulkMetadataFromFile(String metadataFilePath,
                                  String destFolder,
                                  DECallback<String> callback);
-
-    /**
-     * @param uuid
-     * @param path
-     * @param callback
-     */
-    void requestIdentifier(String uuid, String path, AsyncCallback<String> callback);
 
     /**
      *

--- a/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
@@ -167,7 +167,7 @@ public interface DiskResourceServiceFacade {
      * @param resource the <code>DiskResource</code> for which metadata will be retrieved.
      * @param callback callback executed when service call completes.
      */
-    void getDiskResourceMetaData(DiskResource resource, DECallback<DiskResourceMetadataList> callback);
+    void getDiskResourceMetaData(DiskResource resource, AsyncCallback<DiskResourceMetadataList> callback);
 
     /**
      * Calls service to set disk resource metadata.
@@ -178,7 +178,7 @@ public interface DiskResourceServiceFacade {
      */
     void setDiskResourceMetaData(DiskResource resource,
                                  DiskResourceMetadataList mdList,
-                                 DECallback<String> callback);
+                                 AsyncCallback<String> callback);
 
     /**
      * 
@@ -305,7 +305,7 @@ public interface DiskResourceServiceFacade {
 
     void copyMetadata(final String srcUUID,
                       final Splittable paths,
-                      final DECallback<String> callback);
+                      final AsyncCallback<String> callback);
             
             /**
      * save metadata to a file
@@ -318,7 +318,7 @@ public interface DiskResourceServiceFacade {
     void saveMetadata(final String srcUUID,
                       final String path,
                       boolean recursive,
-                      final DECallback<String> callback);
+                      final AsyncCallback<String> callback);
 
     /**
      * 

--- a/de-lib/src/main/java/org/iplantc/de/client/services/FileEditorServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/FileEditorServiceFacade.java
@@ -2,6 +2,7 @@ package org.iplantc.de.client.services;
 
 import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.client.models.viewer.Manifest;
+import org.iplantc.de.shared.DECallback;
 
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -17,7 +18,7 @@ public interface FileEditorServiceFacade {
      *  @param file desired manifest's file ID (path).
      * @param callback executes when RPC call is complete.
      */
-    void getManifest(File file, AsyncCallback<Manifest> callback);
+    void getManifest(File file, DECallback<Manifest> callback);
 
     /**
      * @return the file identifier string for path-list files.
@@ -41,7 +42,7 @@ public interface FileEditorServiceFacade {
      * @param callback Where you will find your stuff.
      *                 FIXME improve callback to return a data type. Clients currently have to parse content themselves.
      */
-    void readCsvChunk(File file, String delimiter, int pageNumber, long chunkSize, AsyncCallback<String> callback);
+    void readCsvChunk(File file, String delimiter, int pageNumber, long chunkSize, DECallback<String> callback);
 
     /**
      * Reads a chunk of the given file.
@@ -50,7 +51,7 @@ public interface FileEditorServiceFacade {
      * @param chunkSize the size of the chunk to be read
      * @param callback Where you will find your stuff.
      */
-    void readChunk(File file, long chunkPosition, long chunkSize, AsyncCallback<String> callback);
+    void readChunk(File file, long chunkPosition, long chunkSize, DECallback<String> callback);
 
     /**
      * Get Tree URLs for the given tree's file ID.
@@ -72,7 +73,7 @@ public interface FileEditorServiceFacade {
 
     void searchGenomesInCoge(String searchTxt, AsyncCallback<String> callback);
 
-    void uploadTextAsFile(String destination, String fileContents, boolean newFile, AsyncCallback<File> callback);
+    void uploadTextAsFile(String destination, String fileContents, boolean newFile, DECallback<File> callback);
     
     void importGenomeFromCoge(Integer id, boolean notify, AsyncCallback<String> callback);
 

--- a/de-lib/src/main/java/org/iplantc/de/client/services/PermIdRequestUserServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/PermIdRequestUserServiceFacade.java
@@ -1,13 +1,12 @@
 package org.iplantc.de.client.services;
 
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestType;
-
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.iplantc.de.shared.DECallback;
 
 public interface PermIdRequestUserServiceFacade {
 
     public final String PERMID_REQUEST = "org.iplantc.services.permIdRequests";
 
-    void requestPermId(String uuid, PermanentIdRequestType type, AsyncCallback<String> callback);
+    void requestPermId(String uuid, PermanentIdRequestType type, DECallback<String> callback);
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
@@ -30,8 +30,11 @@ import org.iplantc.de.client.models.services.DiskResourceRename;
 import org.iplantc.de.client.models.viewer.InfoType;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
+import org.iplantc.de.client.services.converters.DECallbackConverter;
 import org.iplantc.de.client.util.DiskResourceUtil;
+import org.iplantc.de.shared.DECallback;
 import org.iplantc.de.shared.DEProperties;
+import org.iplantc.de.shared.DataCallback;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.shared.services.ServiceCallWrapper;
 
@@ -129,7 +132,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public final void getRootFolders(final AsyncCallback<RootFolders> callback) {
+    public final void getRootFolders(final DECallback<RootFolders> callback) {
         if (getRootCount() > 0) {
             RootFolders result = factory.rootFolders().as();
             result.setRoots(getRootItems());
@@ -138,7 +141,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
             String address = deProperties.getDataMgmtBaseUrl() + "root"; //$NON-NLS-1$
             ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
 
-            callService(wrapper, new AsyncCallbackConverter<String, RootFolders>(callback) {
+            callService(wrapper, new DECallbackConverter<String, RootFolders>(callback) {
                 @Override
                 protected RootFolders convertFrom(final String json) {
                     RootFolders result = decode(RootFolders.class, json);
@@ -160,7 +163,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
                                   final List<InfoType> infoTypeFilterList,
                                   final TYPE entityType,
                                   final FilterPagingLoadConfigBean loadConfig,
-                                  final AsyncCallback<Folder> callback) {
+                                  final DECallback<Folder> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + "paged-directory?";
 
         SortInfoBean sortInfo = Iterables.getFirst(loadConfig.getSortInfo(),
@@ -189,7 +192,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
             }
         }
         ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
-        callService(wrapper, new AsyncCallbackConverter<String, Folder>(callback) {
+        callService(wrapper, new DECallbackConverter<String, Folder>(callback) {
 
             @Override
             protected Folder convertFrom(String object) {
@@ -200,7 +203,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void getSubFolders(final Folder parent, final AsyncCallback<List<Folder>> callback) {
+    public void getSubFolders(final Folder parent, final DECallback<List<Folder>> callback) {
         final Folder folder = findModel(parent);
 
         if (hasFoldersLoaded(folder)) {
@@ -208,7 +211,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
         } else {
             String address = getDirectoryListingEndpoint(parent.getPath(), false);
             ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
-            callService(wrapper, new AsyncCallbackConverter<String, List<Folder>>(callback) {
+            callService(wrapper, new DECallbackConverter<String, List<Folder>>(callback) {
 
                 @Override
                 protected List<Folder> convertFrom(String result) {
@@ -299,14 +302,14 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void createFolder(final Folder parentFolder,
                              final String newFolderName,
-                             AsyncCallback<Folder> callback) {
+                             DECallback<Folder> callback) {
         final String parentId = parentFolder.getPath();
 
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "directory/create"; //$NON-NLS-1$
         JSONObject obj = new JSONObject();
         obj.put("path", new JSONString(parentId + "/" + newFolderName));
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, obj.toString());
-        callService(wrapper, new AsyncCallbackConverter<String, Folder>(callback) {
+        callService(wrapper, new DECallbackConverter<String, Folder>(callback) {
 
             @Override
             protected Folder convertFrom(String result) {
@@ -330,7 +333,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void createNcbiSraFolderStructure(final Folder parentFolder,
                                              final String[] foldersToCreate,
-                                             AsyncCallback<String> callback) {
+                                             DECallback<String> callback) {
         final String parentId = parentFolder.getPath();
 
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "directories"; //$NON-NLS-1$
@@ -358,11 +361,11 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
 
     @Override
     public final void diskResourcesExist(final HasPaths diskResourcePaths,
-                                         final AsyncCallback<DiskResourceExistMap> callback) {
+                                         final DECallback<DiskResourceExistMap> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + "exists"; //$NON-NLS-1$
         final String body = encode(diskResourcePaths);
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, body);
-        callService(wrapper, new AsyncCallbackConverter<String, DiskResourceExistMap>(callback) {
+        callService(wrapper, new DECallbackConverter<String, DiskResourceExistMap>(callback) {
             @Override
             protected DiskResourceExistMap convertFrom(final String json) {
                 // TODO Verify this facade's store against these results?
@@ -375,7 +378,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     public void moveDiskResources(final Folder sourceFolder,
                                   final Folder destFolder,
                                   final List<DiskResource> diskResources,
-                                  final AsyncCallback<DiskResourceMove> callback) {
+                                  final DECallback<DiskResourceMove> callback) {
 
         String address = deProperties.getDataMgmtBaseUrl() + "move"; //$NON-NLS-1$
 
@@ -391,7 +394,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, encode(request));
 
-        callService(wrapper, new AsyncCallbackConverter<String, DiskResourceMove>(callback) {
+        callService(wrapper, new DECallbackConverter<String, DiskResourceMove>(callback) {
 
             @Override
             protected DiskResourceMove convertFrom(String result) {
@@ -427,7 +430,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     private void onFoldersMoved(Folder sourceFolder,
                                 Folder destFolder,
                                 final DiskResourceMove resourcesMoved,
-                                final AsyncCallback<DiskResourceMove> callback,
+                                final DECallback<DiskResourceMove> callback,
                                 final DiskResourcesMovedEvent movedEvent) {
         if (!diskResourceUtil.isDescendantOfFolder(destFolder, sourceFolder)) {
             // The source folder is not under the destination, so it needs to be refreshed.
@@ -441,9 +444,9 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
 
     private void refreshFolderOnChildrenMoved(Folder folder,
                                               final DiskResourceMove resourcesMoved,
-                                              final AsyncCallback<DiskResourceMove> callback,
+                                              final DECallback<DiskResourceMove> callback,
                                               final DiskResourcesMovedEvent movedEvent) {
-        refreshFolder(folder, new AsyncCallback<List<Folder>>() {
+        refreshFolder(folder, new DataCallback<List<Folder>>() {
 
             @Override
             public void onSuccess(List<Folder> folders) {
@@ -452,8 +455,8 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
             }
 
             @Override
-            public void onFailure(Throwable throwable) {
-                callback.onFailure(throwable);
+            public void onFailure(Integer statusCode, Throwable throwable) {
+                callback.onFailure(statusCode, throwable);
             }
         });
     }
@@ -481,7 +484,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void renameDiskResource(final DiskResource src,
                                    String destName,
-                                   AsyncCallback<DiskResource> callback) {
+                                   DECallback<DiskResource> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "rename"; //$NON-NLS-1$
 
         DiskResourceRename request = factory.diskResourceRename().as();
@@ -490,7 +493,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
         request.setDest(diskResourceUtil.appendNameToPath(diskResourceUtil.parseParent(srcId), destName));
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, encode(request));
-        callService(wrapper, new AsyncCallbackConverter<String, DiskResource>(callback) {
+        callService(wrapper, new DECallbackConverter<String, DiskResource>(callback) {
 
             @Override
             protected DiskResource convertFrom(String result) {
@@ -541,7 +544,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void refreshFolder(Folder parent, final AsyncCallback<List<Folder>> callback) {
+    public void refreshFolder(Folder parent, final DECallback<List<Folder>> callback) {
         final Folder folder = findModel(parent);
         if (folder == null) {
             // If this folder is not in the cache, it may be a pseudo-folder like 'Favorites'.
@@ -555,7 +558,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
         removeChildren(folder);
         folder.setFolders(null);
 
-        getSubFolders(folder, new AsyncCallback<List<Folder>>() {
+        getSubFolders(folder, new DataCallback<List<Folder>>() {
             @Override
             public void onSuccess(List<Folder> result) {
                 eventBus.fireEvent(new FolderRefreshedEvent(folder));
@@ -563,8 +566,8 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
             }
 
             @Override
-            public void onFailure(Throwable caught) {
-                callback.onFailure(caught);
+            public void onFailure(Integer statusCode, Throwable caught) {
+                callback.onFailure(statusCode, caught);
             }
         });
     }
@@ -583,7 +586,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void importFromUrl(final String url, final DiskResource dest, AsyncCallback<String> callback) {
+    public void importFromUrl(final String url, final DiskResource dest, DECallback<String> callback) {
         String fullAddress = deProperties.getFileIoBaseUrl() + "urlupload"; //$NON-NLS-1$
         JSONObject body = new JSONObject();
         body.put("dest", new JSONString(dest.getPath())); //$NON-NLS-1$
@@ -606,7 +609,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
 
     @Override
     public <T extends DiskResource> void deleteDiskResources(final List<T> diskResources,
-                                                             final AsyncCallback<HasPaths> callback) {
+                                                             final DECallback<HasPaths> callback) {
         final HasPaths dto = factory.pathsList().as();
         dto.setPaths(diskResourceUtil.asStringPathList(diskResources));
         deleteDiskResources(dto, callback);
@@ -614,11 +617,11 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
 
     @Override
     public final void deleteDiskResources(final HasPaths diskResources,
-                                          final AsyncCallback<HasPaths> callback) {
+                                          final DECallback<HasPaths> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "delete"; //$NON-NLS-1$
         final String body = encode(diskResources);
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, body);
-        callService(wrapper, new AsyncCallbackConverter<String, HasPaths>(callback) {
+        callService(wrapper, new DECallbackConverter<String, HasPaths>(callback) {
             @Override
             protected HasPaths convertFrom(final String json) {
                 HasPaths deletedPaths = decode(HasPaths.class, json);
@@ -649,12 +652,12 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void getDiskResourceMetaData(DiskResource resource, AsyncCallback<DiskResourceMetadataList> callback) {
+    public void getDiskResourceMetaData(DiskResource resource, DECallback<DiskResourceMetadataList> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + resource.getId()
                 + "/metadata";
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, fullAddress);
 
-        callService(wrapper, new AsyncCallbackConverter<String, DiskResourceMetadataList>(callback) {
+        callService(wrapper, new DECallbackConverter<String, DiskResourceMetadataList>(callback) {
             @Override
             protected DiskResourceMetadataList convertFrom(String object) {
                 DiskResourceMetadataList metadata = AutoBeanCodex.decode(factory, DiskResourceMetadataList.class, object).as();
@@ -666,7 +669,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void setDiskResourceMetaData(DiskResource resource,
                                         DiskResourceMetadataList mdList,
-                                        AsyncCallback<String> callback) {
+                                        DECallback<String> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + resource.getId() + "/metadata"; //$NON-NLS-1$
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, encode(mdList));
@@ -700,7 +703,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void getPermissions(JSONObject body, AsyncCallback<String> callback) {
+    public void getPermissions(JSONObject body, DECallback<String> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "user-permissions"; //$NON-NLS-1$
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, body.toString());
         callService(wrapper, callback);
@@ -708,13 +711,13 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
 
     @Override
     public final void getStat(final FastMap<TYPE> paths,
-                              final AsyncCallback<FastMap<DiskResource>> callback) {
+                              final DECallback<FastMap<DiskResource>> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + "stat"; //$NON-NLS-1$
         HasPaths pathsAb = decode(HasPaths.class, "{}");
         pathsAb.setPaths(new ArrayList<>(paths.keySet()));
         final String body = encode(pathsAb);
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, body);
-        callService(wrapper, new AsyncCallbackConverter<String, FastMap<DiskResource>>(callback) {
+        callService(wrapper, new DECallbackConverter<String, FastMap<DiskResource>>(callback) {
             @Override
             protected FastMap<DiskResource> convertFrom(final String json) {
                 FastMap<DiskResource> map = new FastMap<>();
@@ -752,8 +755,12 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
         deServiceFacade.getServiceData(wrapper, callback);
     }
 
+    void callService(ServiceCallWrapper wrapper, DECallback<String> callback) {
+        deServiceFacade.getServiceData(wrapper, callback);
+    }
+
     @Override
-    public void restoreDiskResource(HasPaths request, AsyncCallback<String> callback) {
+    public void restoreDiskResource(HasPaths request, DECallback<String> callback) {
         final String fullAddress = deProperties.getDataMgmtBaseUrl() + "restore"; //$NON-NLS-1$
         final String body = encode(request);
         final ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, body);
@@ -761,14 +768,14 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void emptyTrash(String user, AsyncCallback<String> callback) {
+    public void emptyTrash(String user, DECallback<String> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + "trash"; //$NON-NLS-1$
         ServiceCallWrapper wrapper = new ServiceCallWrapper(DELETE, address);
         callService(wrapper, callback);
     }
 
     @Override
-    public void createDataLinks(List<String> ticketIdList, AsyncCallback<List<DataLink>> callback) {
+    public void createDataLinks(List<String> ticketIdList, DECallback<List<DataLink>> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "tickets"; //$NON-NLS-1$
         String args = "public=1";
 
@@ -787,7 +794,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
         wrapper.setArguments(args);
         deServiceFacade.getServiceData(wrapper,
                                        mdcMap,
-                                       new AsyncCallbackConverter<String, List<DataLink>>(callback) {
+                                       new DECallbackConverter<String, List<DataLink>>(callback) {
             @Override
             protected List<DataLink> convertFrom(String object) {
                 AutoBean<DataLinkList> tickets = AutoBeanCodex.decode(factory, DataLinkList.class, object);
@@ -798,7 +805,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void listDataLinks(List<String> diskResourceIds, AsyncCallback<String> callback) {
+    public void listDataLinks(List<String> diskResourceIds, DECallback<String> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "list-tickets"; //$NON-NLS-1$
 
         JSONObject body = new JSONObject();
@@ -810,7 +817,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void deleteDataLinks(List<String> dataLinkIds, AsyncCallback<String> callback) {
+    public void deleteDataLinks(List<String> dataLinkIds, DECallback<String> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "delete-tickets"; //$NON-NLS-1$
 
         JSONObject body = new JSONObject();
@@ -841,11 +848,11 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void getInfoTypes(AsyncCallback<List<InfoType>> callback) {
+    public void getInfoTypes(DECallback<List<InfoType>> callback) {
         String address = deProperties.getMuleServiceBaseUrl() + "filetypes/type-list";
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
-        deServiceFacade.getServiceData(wrapper, new AsyncCallbackConverter<String, List<InfoType>>(callback) {
+        deServiceFacade.getServiceData(wrapper, new DECallbackConverter<String, List<InfoType>>(callback) {
             @Override
             protected List<InfoType> convertFrom(String object) {
                 Splittable split = StringQuoter.split(object);
@@ -862,7 +869,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void setFileType(String filePath, String type, AsyncCallback<String> callback) {
+    public void setFileType(String filePath, String type, DECallback<String> callback) {
         JSONObject obj = new JSONObject();
         obj.put("path", new JSONString(filePath));
         obj.put("type", new JSONString(type));
@@ -880,7 +887,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void moveContents(final Folder sourceFolder,
                              final Folder destFolder,
-                             final AsyncCallback<DiskResourceMove> callback) {
+                             final DECallback<DiskResourceMove> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + "move-contents"; //$NON-NLS-1$
 
         DiskResourceMove request = factory.diskResourceMove().as();
@@ -894,7 +901,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
                                                                                true);
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, encode(request));
-        callService(wrapper, new AsyncCallbackConverter<String, DiskResourceMove>(callback) {
+        callService(wrapper, new DECallbackConverter<String, DiskResourceMove>(callback) {
 
             @Override
             protected DiskResourceMove convertFrom(String result) {
@@ -915,11 +922,11 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void deleteContents(String selectedFolderId, AsyncCallback<HasPaths> callback) {
+    public void deleteContents(String selectedFolderId, DECallback<HasPaths> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "delete-contents"; //$NON-NLS-1$
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, "{\"path\":\""
                 + selectedFolderId + "\"}");
-        callService(wrapper, new AsyncCallbackConverter<String, HasPaths>(callback) {
+        callService(wrapper, new DECallbackConverter<String, HasPaths>(callback) {
             @Override
             protected HasPaths convertFrom(final String json) {
                 HasPaths deletedPaths = decode(HasPaths.class, json);
@@ -935,7 +942,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void restoreAll(AsyncCallback<String> callback) {
+    public void restoreAll(DECallback<String> callback) {
         final String fullAddress = deProperties.getDataMgmtBaseUrl() + "restore-all"; //$NON-NLS-1$
         final ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, "{}");
         callService(wrapper, callback);
@@ -969,7 +976,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void shareWithAnonymous(HasPaths diskResourcePaths, AsyncCallback<String> callback) {
+    public void shareWithAnonymous(HasPaths diskResourcePaths, DECallback<String> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + "anon-files"; //$NON-NLS-1$
         final String body = encode(diskResourcePaths);
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, body);
@@ -979,7 +986,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void copyMetadata(String srcUUID,
                               Splittable paths,
-                              AsyncCallback<String> callback) {
+                              DECallback<String> callback) {
         String address = null;
         address = deProperties.getDataMgmtBaseUrl() + srcUUID + "/metadata/copy";
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, paths.getPayload());
@@ -990,7 +997,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     public void saveMetadata(String srcUUID,
                              String path,
                              boolean recursive,
-                             AsyncCallback<String> callback) {
+                             DECallback<String> callback) {
         Splittable body = StringQuoter.createSplittable();
         String address = deProperties.getDataMgmtBaseUrl() + srcUUID + "/metadata/save";
         Splittable sppath = StringQuoter.create(path);
@@ -1006,7 +1013,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void setBulkMetadataFromFile(String metadataFilePath,
                                         String destFolder,
-                                        AsyncCallback<String> callback) {
+                                        DECallback<String> callback) {
         StringBuilder address = new StringBuilder(deProperties.getDataMgmtBaseUrl()
                 + "metadata/csv-parser?");
 

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
@@ -639,12 +639,12 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void getDiskResourceMetaData(DiskResource resource, DECallback<DiskResourceMetadataList> callback) {
+    public void getDiskResourceMetaData(DiskResource resource, AsyncCallback<DiskResourceMetadataList> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + resource.getId()
                 + "/metadata";
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, fullAddress);
 
-        callService(wrapper, new DECallbackConverter<String, DiskResourceMetadataList>(callback) {
+        callService(wrapper, new AsyncCallbackConverter<String, DiskResourceMetadataList>(callback) {
             @Override
             protected DiskResourceMetadataList convertFrom(String object) {
                 DiskResourceMetadataList metadata = AutoBeanCodex.decode(factory, DiskResourceMetadataList.class, object).as();
@@ -656,7 +656,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void setDiskResourceMetaData(DiskResource resource,
                                         DiskResourceMetadataList mdList,
-                                        DECallback<String> callback) {
+                                        AsyncCallback<String> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + resource.getId() + "/metadata"; //$NON-NLS-1$
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, encode(mdList));
@@ -973,7 +973,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     @Override
     public void copyMetadata(String srcUUID,
                               Splittable paths,
-                              DECallback<String> callback) {
+                              AsyncCallback<String> callback) {
         String address = null;
         address = deProperties.getDataMgmtBaseUrl() + srcUUID + "/metadata/copy";
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, paths.getPayload());
@@ -984,7 +984,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     public void saveMetadata(String srcUUID,
                              String path,
                              boolean recursive,
-                             DECallback<String> callback) {
+                             AsyncCallback<String> callback) {
         Splittable body = StringQuoter.createSplittable();
         String address = deProperties.getDataMgmtBaseUrl() + srcUUID + "/metadata/save";
         Splittable sppath = StringQuoter.create(path);

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
@@ -573,19 +573,6 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void search(String term, int size, String type, AsyncCallback<String> callback) {
-        String fullAddress = deProperties.getMuleServiceBaseUrl() + "search?search-term="
-                + URL.encodeQueryString(term) + "&size=" + size;
-
-        if (type != null && !type.isEmpty()) {
-            fullAddress = fullAddress + "&type=" + type;
-        }
-
-        ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, fullAddress);
-        deServiceFacade.getServiceData(wrapper, callback);
-    }
-
-    @Override
     public void importFromUrl(final String url, final DiskResource dest, DECallback<String> callback) {
         String fullAddress = deProperties.getFileIoBaseUrl() + "urlupload"; //$NON-NLS-1$
         JSONObject body = new JSONObject();
@@ -1022,21 +1009,6 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address.toString(), "{}");
         callService(wrapper, callback);
-    }
-
-    @Override
-    public void requestIdentifier(String uuid, String path, AsyncCallback<String> callback) {
-        StringBuilder address = new StringBuilder(deProperties.getPermIdBaseUrl());
-
-        Splittable body = StringQuoter.createSplittable();
-        Splittable sppath = StringQuoter.create(uuid);
-        sppath.assign(body, "folder");
-        Splittable sprec = StringQuoter.create("DOI");
-        sprec.assign(body, "type");
-
-        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address.toString(), body.getPayload());
-        callService(wrapper, callback);
-
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/FileEditorServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/FileEditorServiceFacadeImpl.java
@@ -8,7 +8,8 @@ import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.client.models.viewer.FileViewerAutoBeanFactory;
 import org.iplantc.de.client.models.viewer.Manifest;
 import org.iplantc.de.client.services.FileEditorServiceFacade;
-import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
+import org.iplantc.de.client.services.converters.DECallbackConverter;
+import org.iplantc.de.shared.DECallback;
 import org.iplantc.de.shared.DEProperties;
 import org.iplantc.de.shared.services.BaseServiceCallWrapper.Type;
 import org.iplantc.de.shared.services.DiscEnvApiService;
@@ -55,12 +56,12 @@ public class FileEditorServiceFacadeImpl implements FileEditorServiceFacade {
     }
 
     @Override
-    public void getManifest(File file, AsyncCallback<Manifest> callback) {
+    public void getManifest(File file, DECallback<Manifest> callback) {
         String address = deProperties.getDataMgmtBaseUrl() + "file/manifest?path=" //$NON-NLS-1$
                 + URL.encodeQueryString(file.getPath());
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
-        callService(wrapper, new AsyncCallbackConverter<String, Manifest>(callback) {
+        callService(wrapper, new DECallbackConverter<String, Manifest>(callback) {
             @Override
             protected Manifest convertFrom(String object) {
                 final AutoBean<Manifest> manifest = AutoBeanCodex.decode(viewerFactory, Manifest.class, object);
@@ -83,7 +84,7 @@ public class FileEditorServiceFacadeImpl implements FileEditorServiceFacade {
     }
 
     @Override
-    public void readChunk(final File file, final long chunkPosition, final long chunkSize, final AsyncCallback<String> callback){
+    public void readChunk(final File file, final long chunkPosition, final long chunkSize, final DECallback<String> callback){
         Preconditions.checkNotNull(file);
         Preconditions.checkNotNull(file.getPath());
         String address = deProperties.getDataMgmtBaseUrl() + "read-chunk";
@@ -101,7 +102,7 @@ public class FileEditorServiceFacadeImpl implements FileEditorServiceFacade {
 
     @Override
     public void readCsvChunk(File file, String delimiter, int pageNumber, long chunkSize,
-                             AsyncCallback<String> callback) {
+                             DECallback<String> callback) {
         Preconditions.checkNotNull(file);
         Preconditions.checkNotNull(file.getPath());
         Preconditions.checkArgument(COMMA_DELIMITER.equals(delimiter)
@@ -131,7 +132,7 @@ public class FileEditorServiceFacadeImpl implements FileEditorServiceFacade {
 
     @Override
     public void uploadTextAsFile(String destination, String fileContents, boolean newFile,
-            AsyncCallback<File> callback) {
+            DECallback<File> callback) {
 
         String fullAddress = deProperties.getFileIoBaseUrl()
                 + (newFile ? "saveas" : "save"); //$NON-NLS-1$
@@ -140,7 +141,7 @@ public class FileEditorServiceFacadeImpl implements FileEditorServiceFacade {
         obj.put("content", new JSONString(fileContents));
         ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress,
                 obj.toString());
-        callService(wrapper, new AsyncCallbackConverter<String, File>(callback) {
+        callService(wrapper, new DECallbackConverter<String, File>(callback) {
             @Override
             protected File convertFrom(String object) {
                 Splittable split = StringQuoter.split(object);
@@ -157,6 +158,10 @@ public class FileEditorServiceFacadeImpl implements FileEditorServiceFacade {
      * @param callback executed when RPC call completes.
      */
     private void callService(ServiceCallWrapper wrapper, AsyncCallback<String> callback) {
+        deServiceFacade.getServiceData(wrapper, callback);
+    }
+
+    private void callService(ServiceCallWrapper wrapper, DECallback<String> callback) {
         deServiceFacade.getServiceData(wrapper, callback);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/PermIdRequestUserServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/PermIdRequestUserServiceFacadeImpl.java
@@ -2,12 +2,12 @@ package org.iplantc.de.client.services.impl;
 
 import org.iplantc.de.client.models.identifiers.PermanentIdRequestType;
 import org.iplantc.de.client.services.PermIdRequestUserServiceFacade;
+import org.iplantc.de.shared.DECallback;
 import org.iplantc.de.shared.services.BaseServiceCallWrapper.Type;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.shared.services.ServiceCallWrapper;
 
 import com.google.gwt.core.shared.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.autobean.shared.Splittable;
 import com.google.web.bindery.autobean.shared.impl.StringQuoter;
@@ -22,7 +22,7 @@ public class PermIdRequestUserServiceFacadeImpl implements PermIdRequestUserServ
     }
 
     @Override
-    public void requestPermId(String uuid, PermanentIdRequestType type, AsyncCallback<String> callback) {
+    public void requestPermId(String uuid, PermanentIdRequestType type, DECallback<String> callback) {
         String address = PERMID_REQUEST;
         Splittable s = StringQuoter.createSplittable();
         StringQuoter.create(uuid).assign(s, "folder");

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
@@ -58,6 +58,8 @@ import org.iplantc.de.diskResource.client.views.dialogs.RenameFolderDialog;
 import org.iplantc.de.diskResource.client.views.search.DiskResourceSearchField;
 import org.iplantc.de.diskResource.share.DiskResourceModule;
 import org.iplantc.de.shared.AsyncProviderWrapper;
+import org.iplantc.de.shared.DECallback;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.base.Strings;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -420,14 +422,14 @@ public class DiskResourcePresenterImpl implements
     private void refreshFolder(final Folder selectedFolder) {
         checkState(selectedFolder != null, "Selected folder should not be null");
         view.mask(appearance.loadingMask());
-        diskResourceService.refreshFolder(selectedFolder, new AsyncCallback<List<Folder>>() {
+        diskResourceService.refreshFolder(selectedFolder, new DataCallback<List<Folder>>() {
             @Override
             public void onSuccess(List<Folder> result) {
                 view.unmask();
             }
 
             @Override
-            public void onFailure(Throwable caught) {
+            public void onFailure(Integer statusCode, Throwable caught) {
                 view.unmask();
                 announcer.schedule(new ErrorAnnouncementConfig(appearance.folderRefreshFailed(selectedFolder.getName())));
             }
@@ -706,10 +708,10 @@ public class DiskResourcePresenterImpl implements
 
     void doEmptyTrash() {
         view.mask(appearance.loadingMask());
-        diskResourceService.emptyTrash(userInfo.getUsername(), new AsyncCallback<String>() {
+        diskResourceService.emptyTrash(userInfo.getUsername(), new DataCallback<String>() {
 
             @Override
-            public void onFailure(Throwable caught) {
+            public void onFailure(Integer statusCode, Throwable caught) {
                 ErrorHandler.post(caught);
                 view.unmask();
             }
@@ -740,10 +742,10 @@ public class DiskResourcePresenterImpl implements
     private void delete(List<DiskResource> drSet, String announce) {
         view.mask(appearance.loadingMask());
         Folder selectedFolder = navigationPresenter.getSelectedFolder();
-        final AsyncCallback<HasPaths> callback = new DiskResourceDeleteCallback(drSet,
-                                                                                selectedFolder,
-                                                                                view,
-                                                                                announce);
+        final DECallback<HasPaths> callback = new DiskResourceDeleteCallback(drSet,
+                                                                             selectedFolder,
+                                                                             view,
+                                                                             announce);
 
         if (gridViewPresenter.isSelectAllChecked() && selectedFolder != null) {
             diskResourceService.deleteContents(selectedFolder.getPath(), callback);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/CreateDataLinkCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/CreateDataLinkCallback.java
@@ -4,9 +4,9 @@ import org.iplantc.de.client.models.dataLink.DataLink;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.diskResource.client.DataLinkView;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import com.sencha.gxt.data.shared.TreeStore;
 import com.sencha.gxt.widget.core.client.tree.Tree;
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * @author jstroot
  */
-public class CreateDataLinkCallback implements AsyncCallback<List<DataLink>> {
+public class CreateDataLinkCallback extends DataCallback<List<DataLink>> {
 
     private final Tree<DiskResource, DiskResource> tree;
     private final DataLinkView view;
@@ -29,7 +29,7 @@ public class CreateDataLinkCallback implements AsyncCallback<List<DataLink>> {
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         ErrorHandler.post(appearance.createDataLinksError(), caught);
         view.unmask();
     }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/CreateFolderCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/CreateFolderCallback.java
@@ -32,7 +32,7 @@ public class CreateFolderCallback extends DiskResourceServiceCallback<Folder> {
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         unmaskCaller();
         DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
         AutoBean<ErrorCreateFolder> errorBean = AutoBeanCodex.decode(factory, ErrorCreateFolder.class,

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DeleteDataLinksCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DeleteDataLinksCallback.java
@@ -4,18 +4,18 @@ import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.util.JsonUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.diskResource.client.DataLinkView;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import com.sencha.gxt.widget.core.client.tree.Tree;
 
 /**
  * @author jstroot
  */
-public class DeleteDataLinksCallback implements AsyncCallback<String> {
+public class DeleteDataLinksCallback extends DataCallback<String> {
 
     private final Tree<DiskResource, DiskResource> tree;
     private final DataLinkView view;
@@ -29,7 +29,7 @@ public class DeleteDataLinksCallback implements AsyncCallback<String> {
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         ErrorHandler.post(appearance.deleteDataLinksError(), caught);
         view.unmask();
     }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceDeleteCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceDeleteCallback.java
@@ -44,7 +44,7 @@ public class DiskResourceDeleteCallback extends DiskResourceServiceCallback<HasP
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         unmaskCaller();
 
         if(caught instanceof HttpException) {

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceMetadataUpdateCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceMetadataUpdateCallback.java
@@ -14,7 +14,7 @@ import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 /**
  * @author jstroot
  */
-public class DiskResourceMetadataUpdateCallback extends DiskResourceServiceCallback<String> {
+public class DiskResourceMetadataUpdateCallback extends DiskResourceServiceAsyncCallback<String> {
 
     private final IPlantDialog dialog;
     private final DiskResourceCallbackAppearance appearance = GWT.create(DiskResourceCallbackAppearance.class);
@@ -36,13 +36,19 @@ public class DiskResourceMetadataUpdateCallback extends DiskResourceServiceCallb
     }
 
     @Override
-    public void onFailure(Integer statusCode, Throwable caught) {
+    public void onFailure(Throwable caught) {
         unmaskCaller();
-        DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
-        AutoBean<ErrorUpdateMetadata> errorBean = AutoBeanCodex.decode(factory,
-                ErrorUpdateMetadata.class, caught.getMessage());
+        try {
+            DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
+            AutoBean<ErrorUpdateMetadata> errorBean =
+                    AutoBeanCodex.decode(factory, ErrorUpdateMetadata.class, caught.getMessage());
+            ErrorHandler.post(errorBean.as(), caught);
+        }
+        catch (Exception e) {
+            ErrorHandler.post(caught);
+        }
 
-       ErrorHandler.post(errorBean.as(), caught);
+
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceMetadataUpdateCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceMetadataUpdateCallback.java
@@ -1,6 +1,5 @@
 package org.iplantc.de.diskResource.client.presenters.callbacks;
 
-import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.errors.diskResources.DiskResourceErrorAutoBeanFactory;
 import org.iplantc.de.client.models.errors.diskResources.ErrorUpdateMetadata;
 import org.iplantc.de.commons.client.ErrorHandler;
@@ -37,7 +36,7 @@ public class DiskResourceMetadataUpdateCallback extends DiskResourceServiceCallb
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         unmaskCaller();
         DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
         AutoBean<ErrorUpdateMetadata> errorBean = AutoBeanCodex.decode(factory,

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceMoveCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceMoveCallback.java
@@ -32,7 +32,7 @@ public class DiskResourceMoveCallback extends DiskResourceServiceCallback<DiskRe
     }
 
     @Override
-    public void onFailure(Throwable caught){
+    public void onFailure(Integer statusCode, Throwable caught){
         unmaskCaller();
         DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
         AutoBean<ErrorDiskResourceMove> errorBean = AutoBeanCodex.decode(factory, ErrorDiskResourceMove.class, caught.getMessage());

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceRestoreCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceRestoreCallback.java
@@ -60,7 +60,7 @@ public class DiskResourceRestoreCallback extends DiskResourceServiceCallback<Str
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         unmaskCaller();
         DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
         AutoBean<ErrorDiskResourceMove> errorBean = AutoBeanCodex.decode(factory, ErrorDiskResourceMove.class, caught.getMessage());

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceServiceAsyncCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceServiceAsyncCallback.java
@@ -1,0 +1,61 @@
+package org.iplantc.de.diskResource.client.presenters.callbacks;
+
+import org.iplantc.de.client.models.IsMaskable;
+import org.iplantc.de.commons.client.ErrorHandler;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+/**
+ * A common callback for disk resource service calls that implements a common onFailure method that will
+ * parse JSON error messages from the given Throwable::getMessage method to display to the user.
+ * 
+ * @author psarando
+ * 
+ */
+public abstract class DiskResourceServiceAsyncCallback<T> implements AsyncCallback<T> {
+
+    private IsMaskable maskedCaller;
+
+    public DiskResourceServiceAsyncCallback(IsMaskable maskedCaller) {
+        setMaskedCaller(maskedCaller);
+    }
+
+    private void setMaskedCaller(IsMaskable maskedCaller) {
+        this.maskedCaller = maskedCaller;
+    }
+
+    protected void unmaskCaller() {
+        if (maskedCaller == null) {
+            return;
+        }
+
+        maskedCaller.unmask();
+    }
+
+    /**
+     * Child classes are expected to override this method and call it as super. {@inheritDoc}
+     */
+    @Override
+    public void onSuccess(final T result) {
+        unmaskCaller();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onFailure(Throwable caught) {
+        unmaskCaller();
+
+        ErrorHandler.post(caught);
+    }
+
+    /**
+     * Gets a default error message to display to the user on failure, if no error code could be parsed
+     * from the service response.
+     * 
+     * @return Default error message to display to the user.
+     */
+    protected abstract String getErrorMessageDefault();
+
+}

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceServiceCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/DiskResourceServiceCallback.java
@@ -2,8 +2,7 @@ package org.iplantc.de.diskResource.client.presenters.callbacks;
 
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.commons.client.ErrorHandler;
-
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.iplantc.de.shared.DataCallback;
 
 /**
  * A common callback for disk resource service calls that implements a common onFailure method that will
@@ -12,7 +11,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
  * @author psarando
  * 
  */
-public abstract class DiskResourceServiceCallback<T> implements AsyncCallback<T> {
+public abstract class DiskResourceServiceCallback<T> extends DataCallback<T> {
 
     private IsMaskable maskedCaller;
 
@@ -44,7 +43,7 @@ public abstract class DiskResourceServiceCallback<T> implements AsyncCallback<T>
      * {@inheritDoc}
      */
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         unmaskCaller();
 
         ErrorHandler.post(caught);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/ListDataLinksCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/ListDataLinksCallback.java
@@ -6,11 +6,11 @@ import org.iplantc.de.client.models.dataLink.DataLinkList;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.util.JsonUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 import com.google.web.bindery.autobean.shared.Splittable;
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * @author jstroot
  */
-public class ListDataLinksCallback<M> implements AsyncCallback<String> {
+public class ListDataLinksCallback<M> extends DataCallback<String> {
 
     private final Tree<M, M> tree;
     private final DataLinkFactory dlFactory;
@@ -79,7 +79,7 @@ public class ListDataLinksCallback<M> implements AsyncCallback<String> {
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         ErrorHandler.post(appearance.listDataLinksError(), caught);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/NcbiSraSetupCompleteCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/NcbiSraSetupCompleteCallback.java
@@ -38,7 +38,7 @@ public class NcbiSraSetupCompleteCallback extends DiskResourceServiceCallback<St
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         unmaskCaller();
         DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
         AutoBean<ErrorCreateFolder> errorBean = AutoBeanCodex.decode(factory,

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/RenameDiskResourceCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/callbacks/RenameDiskResourceCallback.java
@@ -33,7 +33,7 @@ public class RenameDiskResourceCallback extends DiskResourceServiceCallback<Disk
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         unmaskCaller();
         DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
         String errMessage = caught.getMessage();

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -61,6 +61,7 @@ import org.iplantc.de.diskResource.client.views.metadata.dialogs.SelectMetadataT
 import org.iplantc.de.diskResource.client.views.sharing.dialogs.DataSharingDialog;
 import org.iplantc.de.diskResource.client.views.sharing.dialogs.ShareResourceLinkDialog;
 import org.iplantc.de.shared.AsyncProviderWrapper;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -99,7 +100,7 @@ public class GridViewPresenterImpl implements
                                   DiskResourceSelectionChangedEvent.DiskResourceSelectionChangedEventHandler
                                   {
 
-    private final class SaveMetadataCallback implements AsyncCallback<String> {
+    private final class SaveMetadataCallback extends DataCallback<String> {
         private final SaveAsDialog save_dialog;
 
         private SaveMetadataCallback(SaveAsDialog save_dialog) {
@@ -107,7 +108,7 @@ public class GridViewPresenterImpl implements
         }
 
         @Override
-         public void onFailure(Throwable caught) {
+         public void onFailure(Integer statusCode, Throwable caught) {
              save_dialog.hide();
              announcer.schedule(new ErrorAnnouncementConfig("Unable to save your file. Please try again or contact support."));
          }
@@ -123,7 +124,7 @@ public class GridViewPresenterImpl implements
          }
     }
 
-    private final class CopyMetadataCallback implements AsyncCallback<String> {
+    private final class CopyMetadataCallback extends DataCallback<String> {
         private final DiskResource selected;
         private final IPlantDialog win;
         private final List<HasPath> paths;
@@ -135,7 +136,7 @@ public class GridViewPresenterImpl implements
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             win.unmask();
             ErrorHandler.post(appearance.copyMetadataFailure(), caught);
 
@@ -149,10 +150,10 @@ public class GridViewPresenterImpl implements
         }
     }
 
-    private class CreateDataLinksCallback implements AsyncCallback<List<DataLink>> {
+    private class CreateDataLinksCallback extends DataCallback<List<DataLink>> {
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             ErrorHandler.post(appearance.createDataLinksError(), caught);
         }
 
@@ -594,9 +595,9 @@ public class GridViewPresenterImpl implements
         diskResourceService.getStat(diskResourceUtil.asStringPathTypeMap(Arrays.asList(resource),
                                                                          resource instanceof File ? TYPE.FILE
                                                                                                  : TYPE.FOLDER),
-                                    new AsyncCallback<FastMap<DiskResource>>() {
+                                    new DataCallback<FastMap<DiskResource>>() {
                                         @Override
-                                        public void onFailure(Throwable caught) {
+                                        public void onFailure(Integer statusCode, Throwable caught) {
                                             ErrorHandler.post(appearance.retrieveStatFailed(), caught);
                                             // This unmasks the sendTo.. toolbar buttons
                                             // presenter.unmaskVizMenuOptions();
@@ -626,10 +627,10 @@ public class GridViewPresenterImpl implements
     }
 
     void setInfoType(final DiskResource dr, String newType) {
-        diskResourceService.setFileType(dr.getPath(), newType, new AsyncCallback<String>() {
+        diskResourceService.setFileType(dr.getPath(), newType, new DataCallback<String>() {
 
             @Override
-            public void onFailure(Throwable arg0) {
+            public void onFailure(Integer statusCode, Throwable arg0) {
                 ErrorHandler.post(arg0);
             }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -100,7 +100,7 @@ public class GridViewPresenterImpl implements
                                   DiskResourceSelectionChangedEvent.DiskResourceSelectionChangedEventHandler
                                   {
 
-    private final class SaveMetadataCallback extends DataCallback<String> {
+    private final class SaveMetadataCallback implements AsyncCallback<String> {
         private final SaveAsDialog save_dialog;
 
         private SaveMetadataCallback(SaveAsDialog save_dialog) {
@@ -108,7 +108,7 @@ public class GridViewPresenterImpl implements
         }
 
         @Override
-         public void onFailure(Integer statusCode, Throwable caught) {
+         public void onFailure(Throwable caught) {
              save_dialog.hide();
              announcer.schedule(new ErrorAnnouncementConfig("Unable to save your file. Please try again or contact support."));
          }
@@ -124,7 +124,7 @@ public class GridViewPresenterImpl implements
          }
     }
 
-    private final class CopyMetadataCallback extends DataCallback<String> {
+    private final class CopyMetadataCallback implements AsyncCallback<String> {
         private final DiskResource selected;
         private final IPlantDialog win;
         private final List<HasPath> paths;
@@ -136,7 +136,7 @@ public class GridViewPresenterImpl implements
         }
 
         @Override
-        public void onFailure(Integer statusCode, Throwable caught) {
+        public void onFailure(Throwable caught) {
             win.unmask();
             ErrorHandler.post(appearance.copyMetadataFailure(), caught);
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/proxy/FolderContentsRpcProxyImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/proxy/FolderContentsRpcProxyImpl.java
@@ -12,6 +12,7 @@ import org.iplantc.de.client.services.SearchServiceFacade;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.diskResource.client.GridView;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
@@ -111,7 +112,7 @@ public class FolderContentsRpcProxyImpl extends RpcProxy<FolderContentsLoadConfi
      * @author jstroot
      * 
      */
-    static class FolderContentsCallback implements AsyncCallback<Folder> {
+    static class FolderContentsCallback extends DataCallback<Folder> {
         private final FolderContentsLoadConfig loadConfig;
         private final AsyncCallback<PagingLoadResult<DiskResource>> callback;
         private final IplantAnnouncer announcer;
@@ -133,7 +134,7 @@ public class FolderContentsRpcProxyImpl extends RpcProxy<FolderContentsLoadConfi
         @Override
         public void onSuccess(Folder result) {
             if (callback == null || result == null) {
-                onFailure(null);
+                onFailure(null, null);
                 return;
             }
             // Create list of all items within the result folder
@@ -149,7 +150,7 @@ public class FolderContentsRpcProxyImpl extends RpcProxy<FolderContentsLoadConfi
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             if (loadConfig.getFolder() instanceof DiskResourceQueryTemplate) {
                 announcer.schedule(new ErrorAnnouncementConfig(SafeHtmlUtils.fromString(appearance.searchFailure()), true));
             }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
@@ -15,7 +15,6 @@ import org.iplantc.de.diskResource.client.presenters.callbacks.DiskResourceMetad
 import org.iplantc.de.diskResource.client.views.metadata.dialogs.MetadataTemplateViewDialog;
 import org.iplantc.de.diskResource.client.views.metadata.dialogs.SelectMetadataTemplateDialog;
 import org.iplantc.de.resources.client.messages.I18N;
-import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -141,7 +140,7 @@ public class MetadataPresenterImpl implements MetadataView.Presenter{
 
     @Override
     public void setDiskResourceMetadata(final DiskResourceMetadataUpdateCallback callback) {
-        DataCallback<String> batchAvuCallback = new DataCallback<String>() {
+        AsyncCallback<String> batchAvuCallback = new AsyncCallback<String>() {
 
             @Override
             public void onSuccess(String result) {
@@ -149,8 +148,8 @@ public class MetadataPresenterImpl implements MetadataView.Presenter{
             }
 
             @Override
-            public void onFailure(Integer statusCode, Throwable caught) {
-                callback.onFailure(statusCode, caught);
+            public void onFailure(Throwable caught) {
+                callback.onFailure(caught);
             }
         };
 
@@ -259,7 +258,7 @@ public class MetadataPresenterImpl implements MetadataView.Presenter{
 
 
     private class DiskResourceMetadataListAsyncCallback
-            extends DataCallback<DiskResourceMetadataList> {
+            implements AsyncCallback<DiskResourceMetadataList> {
         @Override
         public void onSuccess(final DiskResourceMetadataList result) {
             view.loadMetadata(result.getOtherMetadata());
@@ -276,7 +275,7 @@ public class MetadataPresenterImpl implements MetadataView.Presenter{
 
 
         @Override
-        public void onFailure(Integer statusCode, Throwable caught) {
+        public void onFailure(Throwable caught) {
             view.unmask();
             ErrorHandler.post(caught);
         }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
@@ -15,6 +15,7 @@ import org.iplantc.de.diskResource.client.presenters.callbacks.DiskResourceMetad
 import org.iplantc.de.diskResource.client.views.metadata.dialogs.MetadataTemplateViewDialog;
 import org.iplantc.de.diskResource.client.views.metadata.dialogs.SelectMetadataTemplateDialog;
 import org.iplantc.de.resources.client.messages.I18N;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -140,7 +141,7 @@ public class MetadataPresenterImpl implements MetadataView.Presenter{
 
     @Override
     public void setDiskResourceMetadata(final DiskResourceMetadataUpdateCallback callback) {
-        AsyncCallback<String> batchAvuCallback = new AsyncCallback<String>() {
+        DataCallback<String> batchAvuCallback = new DataCallback<String>() {
 
             @Override
             public void onSuccess(String result) {
@@ -148,8 +149,8 @@ public class MetadataPresenterImpl implements MetadataView.Presenter{
             }
 
             @Override
-            public void onFailure(Throwable caught) {
-                callback.onFailure(caught);
+            public void onFailure(Integer statusCode, Throwable caught) {
+                callback.onFailure(statusCode, caught);
             }
         };
 
@@ -258,7 +259,7 @@ public class MetadataPresenterImpl implements MetadataView.Presenter{
 
 
     private class DiskResourceMetadataListAsyncCallback
-            implements AsyncCallback<DiskResourceMetadataList> {
+            extends DataCallback<DiskResourceMetadataList> {
         @Override
         public void onSuccess(final DiskResourceMetadataList result) {
             view.loadMetadata(result.getOtherMetadata());
@@ -275,7 +276,7 @@ public class MetadataPresenterImpl implements MetadataView.Presenter{
 
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             view.unmask();
             ErrorHandler.post(caught);
         }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/proxy/FolderRpcProxyImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/navigation/proxy/FolderRpcProxyImpl.java
@@ -17,6 +17,7 @@ import org.iplantc.de.diskResource.client.events.RootFoldersRetrievedEvent;
 import org.iplantc.de.diskResource.client.events.SavedSearchesRetrievedEvent;
 import org.iplantc.de.diskResource.client.events.search.SubmitDiskResourceQueryEvent;
 import org.iplantc.de.diskResource.client.events.search.SubmitDiskResourceQueryEvent.SubmitDiskResourceQueryEventHandler;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -59,7 +60,7 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
         }
     }
 
-    class RootFolderCallback implements AsyncCallback<RootFolders> {
+    class RootFolderCallback extends DataCallback<RootFolders> {
 
         final AsyncCallback<List<Folder>> callback;
         final IplantAnnouncer ipAnnouncer;
@@ -83,7 +84,7 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             ErrorHandler.post(appearance.retrieveFolderInfoFailed(), caught);
 
             if (callback != null) {
@@ -116,7 +117,7 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
         }
     }
 
-    class SubFoldersCallback implements AsyncCallback<List<Folder>> {
+    class SubFoldersCallback extends DataCallback<List<Folder>> {
         final AsyncCallback<List<Folder>> callback;
         private final NavigationView.Presenter.Appearance appearance;
 
@@ -127,7 +128,7 @@ public class FolderRpcProxyImpl extends RpcProxy<Folder, List<Folder>> implement
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             ErrorHandler.post(appearance.retrieveFolderInfoFailed(), caught);
             if (callback != null) {
                 callback.onFailure(caught);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
@@ -14,6 +14,7 @@ import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.diskResource.client.DataSharingView;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONArray;
@@ -35,7 +36,7 @@ import java.util.List;
  */
 public class DataSharingPresenterImpl implements SharingPresenter {
 
-    private final class LoadPermissionsCallback implements AsyncCallback<String> {
+    private final class LoadPermissionsCallback extends DataCallback<String> {
         private final class GetUserInfoCallback implements AsyncCallback<FastMap<Collaborator>> {
             private final List<String> usernames;
 
@@ -78,7 +79,7 @@ public class DataSharingPresenterImpl implements SharingPresenter {
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             permissionsPanel.unmask();
             ErrorHandler.post(caught);
         }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/toolbar/ToolbarViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/toolbar/ToolbarViewPresenterImpl.java
@@ -47,6 +47,7 @@ import org.iplantc.de.diskResource.client.views.dialogs.CreateFolderDialog;
 import org.iplantc.de.diskResource.client.views.dialogs.CreateNcbiSraFolderStructureDialog;
 import org.iplantc.de.diskResource.client.views.dialogs.GenomeSearchDialog;
 import org.iplantc.de.diskResource.client.views.toolbar.dialogs.TabFileConfigDialog;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.base.Preconditions;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -69,7 +70,7 @@ import java.util.logging.Logger;
 public class ToolbarViewPresenterImpl implements ToolbarView.Presenter, SimpleDownloadSelectedHandler {
 
 
-    private final class BulkMetadataCallback implements AsyncCallback<String> {
+    private final class BulkMetadataCallback extends DataCallback<String> {
 
 
         private final String filePath;
@@ -81,7 +82,7 @@ public class ToolbarViewPresenterImpl implements ToolbarView.Presenter, SimpleDo
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
                 IplantAnnouncer.getInstance()
                                .schedule(new ErrorAnnouncementConfig(appearance.bulkMetadataError()));
         }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/toolbar/ToolbarViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/toolbar/ToolbarViewPresenterImpl.java
@@ -375,10 +375,10 @@ public class ToolbarViewPresenterImpl implements ToolbarView.Presenter, SimpleDo
 
     @Override
     public void onDoiRequest(String uuid) {
-        prFacade.requestPermId(uuid, PermanentIdRequestType.DOI, new AsyncCallback<String>() {
+        prFacade.requestPermId(uuid, PermanentIdRequestType.DOI, new DataCallback<String>() {
 
             @Override
-            public void onFailure(Throwable caught) {
+            public void onFailure(Integer statusCode, Throwable caught) {
                 IplantAnnouncer.getInstance()
                                .schedule(new ErrorAnnouncementConfig(appearance.doiRequestFail()));
                 ErrorHandler.post(appearance.doiRequestFail(),caught);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/DuplicateDiskResourceCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/DuplicateDiskResourceCallback.java
@@ -50,7 +50,7 @@ public abstract class DuplicateDiskResourceCallback extends DiskResourceServiceC
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         unmaskCaller();
         DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
         AutoBean<ErrorDuplicateDiskResource> errorBean = AutoBeanCodex.decode(factory, ErrorDuplicateDiskResource.class,

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileUploadByUrlDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileUploadByUrlDialog.java
@@ -8,7 +8,7 @@ import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.validators.ImportUrlValidator;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
-import org.iplantc.de.shared.DataCallback;
+import org.iplantc.de.shared.AppsCallback;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -247,7 +247,8 @@ public class FileUploadByUrlDialog extends IPlantDialog implements HasPending<En
         }
     }
 
-    private final class ImportFromUrlCallback <D extends UIObject & IsHideable & HasPending<Entry<Field<String>, Status>>> extends DataCallback<String> {
+    private final class ImportFromUrlCallback <D extends UIObject & IsHideable & HasPending<Entry<Field<String>, Status>>> extends
+                                                                                                                           AppsCallback<String> {
         private final D dlg;
         private final Entry<Field<String>, Status> pending;
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileUploadByUrlDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileUploadByUrlDialog.java
@@ -8,6 +8,7 @@ import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.validators.ImportUrlValidator;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -18,7 +19,6 @@ import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.uibinder.client.UiTemplate;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.Widget;
@@ -247,7 +247,7 @@ public class FileUploadByUrlDialog extends IPlantDialog implements HasPending<En
         }
     }
 
-    private final class ImportFromUrlCallback <D extends UIObject & IsHideable & HasPending<Entry<Field<String>, Status>>> implements AsyncCallback<String> {
+    private final class ImportFromUrlCallback <D extends UIObject & IsHideable & HasPending<Entry<Field<String>, Status>>> extends DataCallback<String> {
         private final D dlg;
         private final Entry<Field<String>, Status> pending;
 
@@ -266,7 +266,7 @@ public class FileUploadByUrlDialog extends IPlantDialog implements HasPending<En
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             // TODO JDS Determine how to update the UI
             if (dlg.getNumPending() == 1) {
                 // ErrorHandler.post(caught);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/InfoTypeEditorDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/InfoTypeEditorDialog.java
@@ -7,8 +7,8 @@ import org.iplantc.de.client.models.viewer.InfoType;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
+import org.iplantc.de.shared.DataCallback;
 
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
 import com.sencha.gxt.cell.core.client.form.ComboBoxCell.TriggerAction;
@@ -65,10 +65,10 @@ public class InfoTypeEditorDialog extends IPlantDialog {
     }
 
     private void loadInfoTypes(final InfoType currentType) {
-        diskResourceService.getInfoTypes(new AsyncCallback<List<InfoType>>() {
+        diskResourceService.getInfoTypes(new DataCallback<List<InfoType>>() {
 
             @Override
-            public void onFailure(Throwable arg0) {
+            public void onFailure(Integer statusCode, Throwable arg0) {
                 ErrorHandler.post(arg0);
             }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/AbstractDiskResourceSelector.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/AbstractDiskResourceSelector.java
@@ -9,6 +9,7 @@ import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.widgets.IPlantSideErrorHandler;
 import org.iplantc.de.resources.client.constants.IplantValidationConstants;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -30,7 +31,6 @@ import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
@@ -491,10 +491,10 @@ public abstract class AbstractDiskResourceSelector<R extends DiskResource> exten
 
         // FIXME No service calls in widgets!!
         drServiceFacade.getStat(asStringPathTypeMap,
-                                new AsyncCallback<FastMap<DiskResource>>() {
+                                new DataCallback<FastMap<DiskResource>>() {
 
                                     @Override
-                                    public void onFailure(Throwable caught) {
+                                    public void onFailure(Integer statusCode, Throwable caught) {
 
                                         SimpleServiceError serviceError = AutoBeanCodex.decode(drServiceFacade.getDiskResourceFactory(),
                                                                                                SimpleServiceError.class,

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/MultiFileSelectorField.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/widgets/MultiFileSelectorField.java
@@ -22,6 +22,7 @@ import org.iplantc.de.diskResource.client.views.dialogs.FileFolderSelectDialog;
 import org.iplantc.de.diskResource.client.views.dialogs.FileSelectDialog;
 import org.iplantc.de.resources.client.constants.IplantValidationConstants;
 import org.iplantc.de.shared.AsyncProviderWrapper;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -60,11 +61,9 @@ import com.sencha.gxt.dnd.core.client.StatusProxy;
 import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.Dialog.PredefinedButton;
 import com.sencha.gxt.widget.core.client.button.TextButton;
-import com.sencha.gxt.widget.core.client.event.HideEvent;
-import com.sencha.gxt.widget.core.client.event.HideEvent.HideHandler;
-import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
 import com.sencha.gxt.widget.core.client.event.DialogHideEvent.DialogHideHandler;
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.form.IsField;
 import com.sencha.gxt.widget.core.client.form.error.DefaultEditorError;
 import com.sencha.gxt.widget.core.client.form.error.SideErrorHandler;
@@ -528,10 +527,10 @@ public class MultiFileSelectorField extends Composite implements
         permissionErrors.clear();
         existsErrors.clear();
         drServiceFacade.getStat(diskResourceUtil.asStringPathTypeMap(value, TYPE.FILE),
-                                new AsyncCallback<FastMap<DiskResource>>() {
+                                new DataCallback<FastMap<DiskResource>>() {
 
                                     @Override
-                                    public void onFailure(Throwable caught) {
+                                    public void onFailure(Integer statusCode, Throwable caught) {
                                         // Assuming that if there are any non-existent files, that this
                                         // will kick off.
                                         SimpleServiceError serviceError = AutoBeanCodex.decode(factory,

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/EnsemblUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/EnsemblUtil.java
@@ -11,10 +11,10 @@ import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.CommonModelUtils;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.views.dialogs.IplantInfoBox;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.base.Strings;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import com.sencha.gxt.core.shared.FastMap;
 
@@ -87,10 +87,10 @@ public class EnsemblUtil {
         }
 
         diskResourceServiceFacade.getStat(diskResourceUtil.asStringPathTypeMap(list, TYPE.FILE),
-                                          new AsyncCallback<FastMap<DiskResource>>() {
+                                          new DataCallback<FastMap<DiskResource>>() {
 
                                               @Override
-                                              public void onFailure(Throwable caught) {
+                                              public void onFailure(Integer statusCode, Throwable caught) {
                                                   IplantInfoBox info = new IplantInfoBox(appearance.indexFileMissing(),
                                                                                          appearance.indexFileMissingError());
                                                   info.show();

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/FileSaveCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/FileSaveCallback.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.fileViewers.client.callbacks;
 
 import static org.iplantc.de.resources.client.messages.I18N.ERROR;
+
 import org.iplantc.de.client.events.FileSavedEvent;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.diskResources.File;
@@ -9,17 +10,17 @@ import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.diskResource.client.events.DefaultUploadCompleteHandler;
 import org.iplantc.de.resources.client.messages.IplantErrorStrings;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.event.shared.HasHandlers;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 import com.google.web.bindery.autobean.shared.AutoBeanUtils;
 
 /**
  * @author jstroot
  */
-public class FileSaveCallback implements AsyncCallback<File> {
+public class FileSaveCallback extends DataCallback<File> {
 
     private final IplantErrorStrings errorStrings;
     private final HasHandlers hasHandlers;
@@ -56,7 +57,7 @@ public class FileSaveCallback implements AsyncCallback<File> {
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         maskingContainer.unmask();
         ErrorHandler.post(errorStrings.fileUploadsFailed(Lists.newArrayList(fileName)),
                           caught);

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/ShareAnonymousCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/ShareAnonymousCallback.java
@@ -5,11 +5,11 @@ import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.client.util.JsonUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Label;
 
 import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
@@ -19,7 +19,7 @@ import com.sencha.gxt.widget.core.client.form.TextField;
 import com.sencha.gxt.widget.core.client.tips.QuickTip;
 
 
-public class ShareAnonymousCallback implements AsyncCallback<String> {
+public class ShareAnonymousCallback extends DataCallback<String> {
 
     public interface ShareAnonymousCallbackAppearance {
 
@@ -47,7 +47,7 @@ public class ShareAnonymousCallback implements AsyncCallback<String> {
     }
 
     @Override
-    public void onFailure(Throwable caught) {
+    public void onFailure(Integer statusCode, Throwable caught) {
         if (container != null) {
             container.unmask();
         }

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
@@ -37,6 +37,7 @@ import org.iplantc.de.fileViewers.client.views.SaveAsDialogCancelSelectHandler;
 import org.iplantc.de.fileViewers.client.views.SaveAsDialogOkSelectHandler;
 import org.iplantc.de.fileViewers.client.views.TextViewerImpl;
 import org.iplantc.de.shared.AsyncProviderWrapper;
+import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -66,7 +67,7 @@ import java.util.logging.Logger;
  * @author sriram, jstroot
  */
 public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedEvent.FileSavedEventHandler {
-    class GetManifestCallback implements AsyncCallback<Manifest> {
+    class GetManifestCallback extends DataCallback<Manifest> {
         private final AsyncCallback<String> asyncCallback;
         private final FileViewer.FileViewerPresenterAppearance presenterAppearance;
         private final boolean editing;
@@ -96,7 +97,7 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
         }
 
         @Override
-        public void onFailure(Throwable caught) {
+        public void onFailure(Integer statusCode, Throwable caught) {
             asyncCallback.onFailure(caught);
             DiskResourceErrorAutoBeanFactory factory = GWT.create(DiskResourceErrorAutoBeanFactory.class);
             String message = caught.getMessage();
@@ -217,9 +218,9 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
         Preconditions.checkNotNull(file, "Cannot have null file if attempting to load its contents");
 
         simpleContainer.mask(appearance.retrievingFileContentsMask());
-        fileEditorService.readCsvChunk(file, separator, pageNumber, pageSize, new AsyncCallback<String>() {
+        fileEditorService.readCsvChunk(file, separator, pageNumber, pageSize, new DataCallback<String>() {
             @Override
-            public void onFailure(Throwable caught) {
+            public void onFailure(Integer statusCode, Throwable caught) {
                 simpleContainer.unmask();
                 ErrorHandler.post(appearance.unableToRetrieveFileData(file.getName()));
             }
@@ -245,9 +246,9 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
 
         simpleContainer.mask(appearance.retrievingFileContentsMask());
         long chunkPosition = pageSize * (pageNumber - 1);
-        fileEditorService.readChunk(file, chunkPosition, pageSize, new AsyncCallback<String>() {
+        fileEditorService.readChunk(file, chunkPosition, pageSize, new DataCallback<String>() {
             @Override
-            public void onFailure(Throwable caught) {
+            public void onFailure(Integer statusCode, Throwable caught) {
                 simpleContainer.unmask();
                 ErrorHandler.post(appearance.unableToRetrieveFileData(file.getName()));
             }

--- a/de-lib/src/main/java/org/iplantc/de/shared/DataCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/DataCallback.java
@@ -1,0 +1,20 @@
+package org.iplantc.de.shared;
+
+import org.iplantc.de.client.models.WindowType;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public abstract class DataCallback<T> implements DECallback<T> {
+
+    @Override
+    public List<WindowType> getWindowTypes() {
+        return Lists.newArrayList(WindowType.DATA,
+                                  WindowType.DATA_VIEWER,
+                                  WindowType.SIMPLE_DOWNLOAD);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/tools/requests/client/presenter/NewToolRequestFormPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/tools/requests/client/presenter/NewToolRequestFormPresenterImpl.java
@@ -16,6 +16,7 @@ import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.services.ToolRequestServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.resources.client.messages.I18N;
+import org.iplantc.de.shared.DataCallback;
 import org.iplantc.de.tools.requests.client.views.NewToolRequestFormView;
 import org.iplantc.de.tools.requests.client.views.NewToolRequestFormView.Presenter;
 import org.iplantc.de.tools.requests.client.views.Uploader;
@@ -196,9 +197,9 @@ public class NewToolRequestFormPresenterImpl implements Presenter {
     private void getDiskResourceExistMap(final Iterable<String> files, final Continuation<DiskResourceExistMap> checkExistence) {
         final HasPaths dto = FS_FACTORY.pathsList().as();
         dto.setPaths(Lists.newArrayList(files));
-        fsServices.diskResourcesExist(dto, new AsyncCallback<DiskResourceExistMap>() {
+        fsServices.diskResourcesExist(dto, new DataCallback<DiskResourceExistMap>() {
             @Override
-            public void onFailure(final Throwable caught) {
+            public void onFailure(Integer statusCode, final Throwable caught) {
                 view.indicateSubmissionFailure(I18N.ERROR.newToolRequestError());
             }
             @Override
@@ -364,9 +365,9 @@ public class NewToolRequestFormPresenterImpl implements Presenter {
         if (!filesToDelete.isEmpty()) {
             final HasPaths dto = FS_FACTORY.pathsList().as();
             dto.setPaths(filesToDelete);
-            fsServices.deleteDiskResources(dto, new AsyncCallback<HasPaths>() {
+            fsServices.deleteDiskResources(dto, new DataCallback<HasPaths>() {
                 @Override
-                public void onFailure(final Throwable unused) {}
+                public void onFailure(Integer statusCode, final Throwable unused) {}
                 @Override
                 public void onSuccess(final HasPaths unused) {}
             });

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/dataLink/DataLinkPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/dataLink/DataLinkPresenterImplTest.java
@@ -16,8 +16,8 @@ import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.diskResource.client.DataLinkView;
 import org.iplantc.de.diskResource.client.events.selection.DeleteDataLinkSelected;
 import org.iplantc.de.diskResource.client.gin.factory.DataLinkViewFactory;
+import org.iplantc.de.shared.DECallback;
 
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 
 import org.junit.Before;
@@ -48,8 +48,8 @@ public class DataLinkPresenterImplTest {
     @Mock List<String> stringListMock;
     @Mock DataLink dataLinkMock;
 
-    @Captor ArgumentCaptor<AsyncCallback<String>> stringCallbackCaptor;
-    @Captor ArgumentCaptor<AsyncCallback<List<DataLink>>> dataLinkCallbackCaptor;
+    @Captor ArgumentCaptor<DECallback<String>> stringCallbackCaptor;
+    @Captor ArgumentCaptor<DECallback<List<DataLink>>> dataLinkCallbackCaptor;
 
 
     private DataLinkPresenterImpl uut;

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/grid/proxy/FolderContentsRpcProxyTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/grid/proxy/FolderContentsRpcProxyTest.java
@@ -1,5 +1,19 @@
 package org.iplantc.de.diskResource.client.presenters.grid.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.models.diskResources.TYPE;
@@ -23,15 +37,6 @@ import com.sencha.gxt.data.shared.SortInfoBean;
 import com.sencha.gxt.data.shared.loader.PagingLoadResult;
 import com.sencha.gxt.data.shared.loader.PagingLoadResultBean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyDouble;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -219,7 +224,7 @@ public class FolderContentsRpcProxyTest {
             = ArgumentCaptor.forClass(FolderContentsRpcProxyImpl.FolderContentsCallback.class);
         verify(diskResourceService).getFolderContents(any(Folder.class), anyList(), any(TYPE.class), eq(loadConfigMock), callBackCaptor.capture());
 
-        callBackCaptor.getValue().onFailure(mock(Throwable.class));
+        callBackCaptor.getValue().onFailure(500, mock(Throwable.class));
         verify(pagingAsyncMock).onFailure(any(Throwable.class));
     }
 

--- a/de-lib/src/test/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImplTest.java
@@ -34,6 +34,7 @@ import org.iplantc.de.fileViewers.client.views.SaveAsDialogOkSelectHandler;
 import org.iplantc.de.fileViewers.client.views.StructuredTextViewer;
 import org.iplantc.de.fileViewers.client.views.TextViewerImpl;
 import org.iplantc.de.shared.AsyncProviderWrapper;
+import org.iplantc.de.shared.DECallback;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -96,9 +97,10 @@ public class FileViewerPresenterImplTest {
     @Mock OngoingStubbing<? extends FileViewer> extendedViewersMock;
 
     @Captor ArgumentCaptor<FileViewerPresenterImpl.GetManifestCallback> manifestCaptor;
-    @Captor ArgumentCaptor<AsyncCallback<String>> stringCaptor;
+    @Captor ArgumentCaptor<DECallback<String>> stringDECaptor;
+    @Captor ArgumentCaptor<AsyncCallback<String>> stringAsyncCaptor;
     @Captor ArgumentCaptor<AsyncCallback<SaveAsDialog>> saveAsDialogCaptor;
-    @Captor ArgumentCaptor<AsyncCallback<File>> fileCaptor;
+    @Captor ArgumentCaptor<DECallback<File>> fileCaptor;
 
     private FileViewerPresenterImpl uut;
 
@@ -196,9 +198,9 @@ public class FileViewerPresenterImplTest {
                                                    anyString(),
                                                    anyInt(),
                                                    anyLong(),
-                                                   stringCaptor.capture());
+                                                   stringDECaptor.capture());
 
-        stringCaptor.getValue().onSuccess("result");
+        stringDECaptor.getValue().onSuccess("result");
         verify(structuredTextViewerMock).setData(structuredTextMock);
         verify(simpleContainerMock).unmask();
     }
@@ -213,9 +215,9 @@ public class FileViewerPresenterImplTest {
         verify(fileEditorServiceMock).readChunk(eq(fileMock),
                                                 anyLong(),
                                                 anyInt(),
-                                                stringCaptor.capture());
+                                                stringDECaptor.capture());
 
-        stringCaptor.getValue().onSuccess("{chunk:test}");
+        stringDECaptor.getValue().onSuccess("{chunk:test}");
         verify(textViewerMock).setData(anyString());
         verify(simpleContainerMock).unmask();
     }
@@ -346,7 +348,7 @@ public class FileViewerPresenterImplTest {
         uut.callTreeCreateService(fileViewerMock, fileMock);
 
         verify(simpleContainerMock).mask(eq(appearanceMock.retrieveTreeUrlsMask()));
-        verify(fileEditorServiceMock).getTreeUrl(eq("path"), eq(false), stringCaptor.capture());
+        verify(fileEditorServiceMock).getTreeUrl(eq("path"), eq(false), stringAsyncCaptor.capture());
     }
 
     @Test


### PR DESCRIPTION
This PR builds on top of PR #49 but with changes for the Data window.

Really the only tricky thing with this PR is some of the endpoints in the Disk Resource service facades go from terrain to the metadata service, not data-info.  I tried to check them all to make sure only the data-info endpoints got updated (don't want to disable the entire Data window if only the metadata service is down).