### PR TITLE
Update ServiceDownPanel appearance

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/ServiceDownPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/ServiceDownPanel.java
@@ -5,7 +5,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.HTML;
 
 import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.Window;
@@ -24,13 +24,15 @@ public class ServiceDownPanel extends Composite {
     }
 
     @UiField TextButton retry;
-    @UiField Label label;
+    @UiField HTML serviceDownMsg;
     @UiField ServiceDownPanelAppearance appearance;
 
     public interface ServiceDownPanelAppearance {
         String serviceDownText();
 
         String retryBtnText();
+
+        String loadingMask();
     }
 
     private List<SelectEvent.SelectHandler> handlers = Lists.newArrayList();
@@ -38,9 +40,11 @@ public class ServiceDownPanel extends Composite {
     public ServiceDownPanel() {
         ServiceDownPanelUiBinder uiBinder = GWT.create(ServiceDownPanelUiBinder.class);
         initWidget(uiBinder.createAndBindUi(this));
+        serviceDownMsg.setHTML(appearance.serviceDownText());
         retry.addSelectHandler(new SelectEvent.SelectHandler() {
             @Override
             public void onSelect(SelectEvent event) {
+                mask(appearance.loadingMask());
                 for (SelectEvent.SelectHandler handler : handlers) {
                     handler.onSelect(event);
                 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/ServiceDownPanel.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/widgets/ServiceDownPanel.ui.xml
@@ -27,8 +27,7 @@
 
     <container:VBoxLayoutContainer padding="{padding5}" VBoxLayoutAlign="CENTER" pack="CENTER">
         <container:child layoutData="{boxLayoutDataMargins0050}">
-            <gwt:Label ui:field="label"
-                       text="{appearance.serviceDownText}"/>
+            <gwt:HTML ui:field="serviceDownMsg"/>
         </container:child>
         <container:child layoutData="{boxLayoutDataMargins0050}">
             <button:TextButton ui:field="retry"

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/IplantWindowBase.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/IplantWindowBase.java
@@ -397,6 +397,7 @@ public abstract class IplantWindowBase extends Window implements IPlantWindowInt
         }
 
         serviceDownPanel.addHandler(handler);
+        serviceDownPanel.unmask();
     }
 
     @Override
@@ -405,6 +406,7 @@ public abstract class IplantWindowBase extends Window implements IPlantWindowInt
             this.setWidget(currentWidget);
             currentWidget = null;
         }
+        serviceDownPanel.unmask();
     }
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/ServiceDownPanelDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/ServiceDownPanelDefaultAppearance.java
@@ -28,4 +28,9 @@ public class ServiceDownPanelDefaultAppearance implements ServiceDownPanel.Servi
     public String retryBtnText() {
         return displayStrings.retryBtnText();
     }
+
+    @Override
+    public String loadingMask() {
+        return displayStrings.loadingMask();
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/ServiceDownPanelDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/ServiceDownPanelDisplayStrings.java
@@ -9,4 +9,6 @@ public interface ServiceDownPanelDisplayStrings extends Messages {
     String serviceDownText();
 
     String retryBtnText();
+
+    String loadingMask();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/ServiceDownPanelDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/ServiceDownPanelDisplayStrings.properties
@@ -1,2 +1,3 @@
 retryBtnText = Try Again
-serviceDownText = The service that powers this window currently appears to be down.
+serviceDownText = <b>The service that powers this window currently appears to be down.</b><BR><BR>Try connecting again using the button below or reopening the window.<BR>If the error persists, you can contact support at <a href="mailto:support@cyverse.org">support@cyverse.org</a>.<BR><BR>
+loadingMask = Retrying...

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/ServiceDownPanelDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/ServiceDownPanelDisplayStrings.properties
@@ -1,3 +1,3 @@
 retryBtnText = Try Again
-serviceDownText = <b>The service that powers this window currently appears to be down.</b><BR><BR>Try connecting again using the button below or reopening the window.<BR>If the error persists, you can contact support at <a href="mailto:support@cyverse.org">support@cyverse.org</a>.<BR><BR>
+serviceDownText = <b>The service that powers this window currently appears to be down.</b><BR><BR>Try connecting again by clicking the Try Again button or reopening the window.<BR>If the error persists, you can contact support at <a href="mailto:support@cyverse.org">support@cyverse.org</a>.<BR><BR>
 loadingMask = Retrying...


### PR DESCRIPTION
This PR is just to update the wording and appearance of the panel that gets swapped into the Apps/Data/Analysis window when the UI discovers that the backend services those windows require are down. 

![image](https://cloud.githubusercontent.com/assets/8909156/20935410/d45e0c5e-bb9b-11e6-82b9-191bf898de7f.png)

