### PR TITLE
CORE-8490 UI Resiliency - App Launch Window

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/AppsEditorView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/AppsEditorView.java
@@ -29,7 +29,7 @@ public interface AppsEditorView extends IsWidget, Editor<AppTemplate>, ArgumentS
     interface EditorDriver extends SimpleBeanEditorDriver<AppTemplate, AppsEditorView> {
     }
 
-    public interface Presenter extends org.iplantc.de.apps.widgets.client.view.AppLaunchView.BasePresenter, AppEditorToolbar.Presenter, BeforeHideHandler, UpdateCommandLinePreviewEventHandler,
+    public interface Presenter extends AppEditorToolbar.Presenter, BeforeHideHandler, UpdateCommandLinePreviewEventHandler,
             HasLabelOnlyEditMode, DeleteArgumentGroupEventHandler {
 
         /**
@@ -49,6 +49,14 @@ public interface AppsEditorView extends IsWidget, Editor<AppTemplate>, ArgumentS
         boolean orderingRequired(Argument arg);
 
         void setBeforeHideHandlerRegistration(HandlerRegistration hr);
+
+        AppTemplate getAppTemplate();
+
+        void go(final HasOneWidget container, final AppTemplate appTemplate);
+
+        void go(final HasOneWidget container);
+
+        void setViewDebugId(String baseID);
 
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/events/AppTemplateFetched.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/events/AppTemplateFetched.java
@@ -1,0 +1,42 @@
+package org.iplantc.de.apps.widgets.client.events;
+
+import org.iplantc.de.client.models.apps.integration.AppTemplate;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class AppTemplateFetched extends GwtEvent<AppTemplateFetched.AppTemplateFetchedHandler> {
+    public static interface AppTemplateFetchedHandler extends EventHandler {
+        void onAppTemplateFetched(AppTemplateFetched event);
+    }
+
+    public interface HasAppTemplateFetchedHandlers {
+        HandlerRegistration addAppTemplateFetchedHandler(AppTemplateFetchedHandler handler);
+    }
+
+    private AppTemplate template;
+
+    public AppTemplateFetched(AppTemplate template) {
+        this.template = template;
+
+    }
+
+    public static Type<AppTemplateFetchedHandler> TYPE = new Type<AppTemplateFetchedHandler>();
+
+    public Type<AppTemplateFetchedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(AppTemplateFetchedHandler handler) {
+        handler.onAppTemplateFetched(this);
+    }
+
+
+    public AppTemplate getTemplate() {
+        return template;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/AppLaunchView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/AppLaunchView.java
@@ -1,9 +1,11 @@
 package org.iplantc.de.apps.widgets.client.view;
 
 import org.iplantc.de.apps.widgets.client.events.AnalysisLaunchEvent.AnalysisLaunchEventHandler;
+import org.iplantc.de.apps.widgets.client.events.AppTemplateFetched;
 import org.iplantc.de.apps.widgets.client.events.RequestAnalysisLaunchEvent.HasRequestAnalysisLaunchHandlers;
 import org.iplantc.de.client.models.apps.integration.AppTemplate;
 import org.iplantc.de.client.models.apps.integration.JobExecution;
+import org.iplantc.de.commons.client.views.window.configs.AppWizardConfig;
 
 import com.google.gwt.editor.client.Editor;
 import com.google.gwt.user.client.Command;
@@ -30,14 +32,23 @@ public interface AppLaunchView extends IsWidget, Editor<AppTemplate>, HasRequest
         String waitTimes();
 
         String dontShow();
+
+        String appUnavailable();
+
+        String unableToRetrieveWorkflowGuide();
+
+        String loadingMask();
     }
 
+    public interface Presenter extends AppTemplateFetched.HasAppTemplateFetchedHandlers {
 
+        AppTemplate getAppTemplate();
 
         void setViewDebugId(String baseID);
 
         void addAnalysisLaunchHandler(AnalysisLaunchEventHandler handler);
 
+        void go(HasOneWidget container, AppWizardConfig config);
     }
 
     public interface RenameWindowHeaderCommand extends Command {

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/AppLaunchView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/AppLaunchView.java
@@ -32,22 +32,10 @@ public interface AppLaunchView extends IsWidget, Editor<AppTemplate>, HasRequest
         String dontShow();
     }
 
-    /**
-     * FIXME JDS Re-evaluate necessity for two different presenters.
-     * 
-     * @author jstroot
-     * 
-     */
-    public interface BasePresenter extends org.iplantc.de.commons.client.presenter.Presenter{
-    
-        AppTemplate getAppTemplate();
 
-        void go(final HasOneWidget container, final AppTemplate appTemplate);
 
         void setViewDebugId(String baseID);
-    }
 
-    public interface Presenter extends BasePresenter {
         void addAnalysisLaunchHandler(AnalysisLaunchEventHandler handler);
 
     }

--- a/de-lib/src/main/java/org/iplantc/de/client/util/AppTemplateUtils.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/util/AppTemplateUtils.java
@@ -8,6 +8,7 @@ import org.iplantc.de.client.models.apps.integration.ArgumentType;
 import org.iplantc.de.client.models.apps.integration.SelectionItem;
 import org.iplantc.de.client.models.apps.integration.SelectionItemGroup;
 import org.iplantc.de.client.services.converters.AppTemplateCallbackConverter;
+import org.iplantc.de.commons.client.views.window.configs.AppWizardConfig;
 import org.iplantc.de.resources.client.messages.I18N;
 import org.iplantc.de.resources.client.uiapps.widgets.AppsWidgetsDisplayMessages;
 
@@ -79,6 +80,10 @@ public class AppTemplateUtils {
 
         final String payload = AutoBeanCodex.encode(argAb).getPayload();
         return new AppTemplateCallbackConverter(factory, null).convertFrom(payload, false);
+    }
+
+    public AppTemplate convertConfigToTemplate(AppWizardConfig config) {
+        return new AppTemplateCallbackConverter(factory, null).convertFrom(config.getAppTemplate().getPayload(), true);
     }
 
     public ArgumentGroup copyArgumentGroup(ArgumentGroup value) {

--- a/de-lib/src/main/java/org/iplantc/de/shared/AppLaunchCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/AppLaunchCallback.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.shared;
+
+import org.iplantc.de.client.models.WindowType;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public abstract class AppLaunchCallback<T> implements DECallback<T> {
+
+    @Override
+    public List<WindowType> getWindowTypes() {
+        return Lists.newArrayList(WindowType.APP_WIZARD);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/shared/AppsCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/AppsCallback.java
@@ -15,7 +15,6 @@ public abstract class AppsCallback<T> implements DECallback<T> {
     public List<WindowType> getWindowTypes() {
         return Lists.newArrayList(WindowType.APPS,
                                   WindowType.APP_INTEGRATION,
-                                  WindowType.APP_WIZARD,
                                   WindowType.WORKFLOW_INTEGRATION);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/widgets/AppLaunchViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/widgets/AppLaunchViewDefaultAppearance.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.theme.base.client.apps.widgets;
 
 import org.iplantc.de.apps.widgets.client.view.AppLaunchView;
+import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
+import org.iplantc.de.resources.client.messages.IplantErrorStrings;
 
 import com.google.gwt.core.client.GWT;
 
@@ -9,14 +11,22 @@ import com.google.gwt.core.client.GWT;
  */
 public class AppLaunchViewDefaultAppearance implements AppLaunchView.AppLaunchViewAppearance {
 
+    private final IplantDisplayStrings iplantDisplayStrings;
     private AppLaunchViewDisplayStrings displayStrings;
+    private final IplantErrorStrings errorStrings;
 
     public AppLaunchViewDefaultAppearance() {
-        this(GWT.<AppLaunchViewDisplayStrings> create(AppLaunchViewDisplayStrings.class));
+        this(GWT.<AppLaunchViewDisplayStrings> create(AppLaunchViewDisplayStrings.class),
+             GWT.<IplantDisplayStrings> create(IplantDisplayStrings.class),
+             GWT.<IplantErrorStrings> create(IplantErrorStrings.class));
     }
 
-    public AppLaunchViewDefaultAppearance(AppLaunchViewDisplayStrings displayStrings) {
+    public AppLaunchViewDefaultAppearance(AppLaunchViewDisplayStrings displayStrings,
+                                          IplantDisplayStrings iplantDisplayStrings,
+                                          IplantErrorStrings errorStrings) {
         this.displayStrings = displayStrings;
+        this.errorStrings = errorStrings;
+        this.iplantDisplayStrings = iplantDisplayStrings;
     }
 
     @Override
@@ -37,5 +47,20 @@ public class AppLaunchViewDefaultAppearance implements AppLaunchView.AppLaunchVi
     @Override
     public String dontShow() {
         return displayStrings.dontShow();
+    }
+
+    @Override
+    public String appUnavailable() {
+        return iplantDisplayStrings.appUnavailable();
+    }
+
+    @Override
+    public String unableToRetrieveWorkflowGuide() {
+        return errorStrings.unableToRetrieveWorkflowGuide();
+    }
+
+    @Override
+    public String loadingMask() {
+        return iplantDisplayStrings.loadingMask();
     }
 }

--- a/de-lib/src/test/java/org/iplantc/de/apps/widgets/client/presenter/AppLaunchPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/widgets/client/presenter/AppLaunchPresenterImplTest.java
@@ -1,0 +1,200 @@
+package org.iplantc.de.apps.widgets.client.presenter;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.apps.widgets.client.events.AnalysisLaunchEvent;
+import org.iplantc.de.apps.widgets.client.view.AppLaunchView;
+import org.iplantc.de.client.DEClientConstants;
+import org.iplantc.de.client.models.HasId;
+import org.iplantc.de.client.models.HasQualifiedId;
+import org.iplantc.de.client.models.UserSettings;
+import org.iplantc.de.client.models.apps.integration.AppTemplate;
+import org.iplantc.de.client.models.apps.integration.AppTemplateAutoBeanFactory;
+import org.iplantc.de.client.models.apps.integration.JobExecution;
+import org.iplantc.de.client.models.diskResources.Folder;
+import org.iplantc.de.client.services.AppTemplateServices;
+import org.iplantc.de.client.services.impl.models.AnalysisSubmissionResponse;
+import org.iplantc.de.client.util.AppTemplateUtils;
+import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
+import org.iplantc.de.commons.client.views.window.configs.AppWizardConfig;
+import org.iplantc.de.resources.client.constants.IplantValidationConstants;
+import org.iplantc.de.resources.client.uiapps.widgets.AppsWidgetsDisplayMessages;
+import org.iplantc.de.resources.client.uiapps.widgets.AppsWidgetsErrorMessages;
+import org.iplantc.de.shared.AppLaunchCallback;
+
+import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.web.bindery.autobean.shared.Splittable;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+/**
+ * @author aramsey
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class AppLaunchPresenterImplTest {
+
+    @Mock AppsWidgetsDisplayMessages appsWidgetsDisplayMessagesMock;
+    @Mock AppsWidgetsErrorMessages appsWidgetsErrorMessagesMock;
+    @Mock AppTemplate appTemplateMock;
+    @Mock AppTemplateServices atServicesMock;
+    @Mock HandlerManager handlerManagerMock;
+    @Mock UserSettings userSettingsMock;
+    @Mock AppTemplateAutoBeanFactory factoryMock;
+    @Mock DEClientConstants deClientConstantsMock;
+    @Mock AppTemplateUtils appTemplateUtilsMock;
+    @Mock AppLaunchView.AppLaunchViewAppearance appearanceMock;
+    @Mock IplantValidationConstants valConstantsMock;
+    @Mock AppLaunchView viewMock;
+    @Mock HasOneWidget containerMock;
+    @Mock AppWizardConfig configMock;
+    @Mock Splittable templateSplittableMock;
+    @Mock JobExecution jeMock;
+    @Mock Folder defaultOutputFolder;
+    @Mock HasId hasIdMock;
+    @Mock HasQualifiedId hasQualifiedIdMock;
+    @Mock IplantAnnouncer announcerMock;
+    @Mock AnalysisSubmissionResponse responseMock;
+
+    @Captor ArgumentCaptor<AppLaunchCallback<AppTemplate>> appTemplateCaptor;
+    @Captor ArgumentCaptor<AppLaunchCallback<AnalysisSubmissionResponse>> analysisSubmissionCaptor;
+
+    private AppLaunchPresenterImpl uut;
+
+    @Before
+    public void setUp() {
+        when(appTemplateUtilsMock.convertConfigToTemplate(configMock)).thenReturn(appTemplateMock);
+        when(appsWidgetsDisplayMessagesMock.defaultAnalysisName()).thenReturn("name");
+        when(appsWidgetsDisplayMessagesMock.launchAnalysisSuccess(anyString())).thenReturn("success");
+        when(appsWidgetsErrorMessagesMock.launchAnalysisFailure(anyString())).thenReturn("fail");
+        when(appTemplateMock.getId()).thenReturn("id");
+        when(appTemplateMock.getName()).thenReturn("name");
+        when(userSettingsMock.getDefaultOutputFolder()).thenReturn(defaultOutputFolder);
+        when(defaultOutputFolder.getPath()).thenReturn("path");
+        when(userSettingsMock.isEnableAnalysisEmailNotification()).thenReturn(true);
+
+
+        uut = new AppLaunchPresenterImpl(viewMock,
+                                         userSettingsMock,
+                                         atServicesMock,
+                                         factoryMock,
+                                         deClientConstantsMock,
+                                         appTemplateUtilsMock,
+                                         appearanceMock){
+            @Override
+            JobExecution getJobExecution() {
+                return jeMock;
+            }
+
+            @Override
+            String getRestrictedCharRegEx() {
+                return "@!";
+            }
+
+            @Override
+            HasQualifiedId getQualifiedIdFromConfig(AppWizardConfig config) {
+                return hasQualifiedIdMock;
+            }
+        };
+        uut.appTemplate = appTemplateMock;
+        uut.handlerManager = handlerManagerMock;
+        uut.container = containerMock;
+        uut.appsWidgetsDisplayMessages = appsWidgetsDisplayMessagesMock;
+        uut.appsWidgetsErrMessages = appsWidgetsErrorMessagesMock;
+        uut.announcer = announcerMock;
+    }
+
+    @Test
+    public void go_withTemplate() {
+        AppLaunchPresenterImpl spy = spy(uut);
+        when(configMock.getAppTemplate()).thenReturn(templateSplittableMock);
+
+        /** CALL METHOD UNDER TEST **/
+        spy.go(containerMock, configMock);
+        verify(configMock).getAppTemplate();
+        verify(spy).createJobExecution();
+        verifyZeroInteractions(atServicesMock);
+    }
+
+    @Test
+    public void go_relaunch() {
+        AppLaunchPresenterImpl spy = spy(uut);
+        when(configMock.getAppTemplate()).thenReturn(null);
+        when(configMock.isRelaunchAnalysis()).thenReturn(true);
+        when(configMock.getAppId()).thenReturn("id");
+        when(configMock.getAnalysisId()).thenReturn(hasIdMock);
+        when(appTemplateMock.isAppDisabled()).thenReturn(false);
+
+        /** CALL METHOD UNDER TEST **/
+        spy.go(containerMock, configMock);
+        verify(configMock).getAppTemplate();
+        verify(atServicesMock).rerunAnalysis(eq(hasIdMock),
+                                             eq("id"),
+                                             appTemplateCaptor.capture());
+
+        appTemplateCaptor.getValue().onSuccess(appTemplateMock);
+        verify(spy).createJobExecution();
+    }
+
+    @Test
+    public void go_nullTemplate() {
+        AppLaunchPresenterImpl spy = spy(uut);
+        when(configMock.getAppTemplate()).thenReturn(null);
+        when(configMock.isRelaunchAnalysis()).thenReturn(false);
+        when(configMock.getAppId()).thenReturn("id");
+        when(configMock.getAnalysisId()).thenReturn(hasIdMock);
+        when(appTemplateMock.isAppDisabled()).thenReturn(false);
+
+        /** CALL METHOD UNDER TEST **/
+        spy.go(containerMock, configMock);
+        verify(configMock).getAppTemplate();
+        verify(atServicesMock).getAppTemplate(eq(hasQualifiedIdMock),
+                                             appTemplateCaptor.capture());
+
+        appTemplateCaptor.getValue().onSuccess(appTemplateMock);
+        verify(spy).createJobExecution();
+    }
+
+    @Test
+    public void createJobExecution() {
+        /** CALL METHOD UNDER TEST **/
+        uut.createJobExecution();
+
+        verify(jeMock).setAppTemplateId(eq("id"));
+        verify(jeMock).setEmailNotificationEnabled(eq(userSettingsMock.isEnableAnalysisEmailNotification()));
+        verify(jeMock).setName(anyString());
+        verify(jeMock).setOutputDirectory(eq("path"));
+        verify(viewMock).edit(eq(appTemplateMock), eq(jeMock));
+        verify(containerMock).setWidget(eq(viewMock));
+    }
+
+    @Test
+    public void onAnalysisLaunchRequest() {
+        when(responseMock.getMissingPaths()).thenReturn(null);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.launchAnalysis(appTemplateMock, jeMock);
+
+        verify(atServicesMock).launchAnalysis(eq(appTemplateMock),
+                                              eq(jeMock),
+                                              analysisSubmissionCaptor.capture());
+
+        analysisSubmissionCaptor.getValue().onSuccess(responseMock);
+        verify(announcerMock).schedule(isA(SuccessAnnouncementConfig.class));
+        verify(handlerManagerMock).fireEvent(isA(AnalysisLaunchEvent.class));
+    }
+
+}


### PR DESCRIPTION
This turned out to be a bit of a refactor since we were making service calls directly from `AppLaunchWindow` that I moved to `AppLaunchPresenterImpl`.  Otherwise, the goal of this PR was to refactor any calls related to the App Launch window to use `AppLaunchCallback` instead of `AppsCallback` since it is possible for users to be able to launch apps even if the metadata service is down.  (Currently the metadata service being down is capable of causing most `AppsCallbacks` to fail which would disable the Apps, App Editor, and Workflow builder windows.)
