### PR TITLE
CORE-8535: Add bigBed support (mostly) where BED is supported

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/viewer/InfoType.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/viewer/InfoType.java
@@ -6,6 +6,7 @@ public enum InfoType {
     BAM("bam"),
     BASH("bash"),
     BED("bed"),
+    BIGBED("bigbed"),
     BLAST("blast"),
     BOWTIE("bowtie"),
     CLUSTALW("clustalw"),

--- a/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
@@ -409,7 +409,8 @@ public class DiskResourceUtil {
 
     public boolean isEnsemblInfoType(InfoType infoType) {
         return InfoType.BAM.equals(infoType) || InfoType.VCF.equals(infoType)
-                || InfoType.GFF.equals(infoType) || InfoType.BED.equals(infoType);
+                || InfoType.GFF.equals(infoType) || InfoType.BED.equals(infoType)
+		|| InfoType.BIGBED.equals(infoType);
     }
 
     private String getInfoType(Splittable obj) {
@@ -440,7 +441,7 @@ public class DiskResourceUtil {
         String infoType = getInfoType(obj);
         return (infoType != null) && infoType.equals(InfoType.BAM.toString())
                 || infoType.equals(InfoType.VCF.toString()) || infoType.equals(InfoType.GFF.toString())
-                || infoType.equals(InfoType.BED.toString());
+                || infoType.equals(InfoType.BED.toString()) || infoType.equals(InfoType.BIGBED.toString());
     }
 
     public Splittable createStringPathListSplittable(List<HasPath> hasPathList) {

--- a/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
@@ -410,7 +410,7 @@ public class DiskResourceUtil {
     public boolean isEnsemblInfoType(InfoType infoType) {
         return InfoType.BAM.equals(infoType) || InfoType.VCF.equals(infoType)
                 || InfoType.GFF.equals(infoType) || InfoType.BED.equals(infoType)
-		|| InfoType.BIGBED.equals(infoType);
+                || InfoType.BIGBED.equals(infoType);
     }
 
     private String getInfoType(Splittable obj) {

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/EnsemblUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/EnsemblUtil.java
@@ -68,7 +68,7 @@ public class EnsemblUtil {
             indexFile = filename + ".bai";
         } else if (infoType.equals(InfoType.VCF.toString())) {
             indexFile = filename + ".tbi";
-        } else if (infoType.equals(InfoType.GFF.toString()) || infoType.equals(InfoType.BED.toString())) {
+        } else if (infoType.equals(InfoType.GFF.toString()) || infoType.equals(InfoType.BED.toString()) || infotype.equals(InfoType.BIGBED.toString())) {
             indexFile = null;
         }
 


### PR DESCRIPTION
I didn't add bigBed support to stuff having to do with structured text viewers, because bigBed is a binary/indexed version of BED rather than the tabular format normal BED is.

Won't be that helpful without https://github.com/cyverse-de/heuristomancer/pull/1 (though I guess it'll allow manually setting it at least).