### PR TITLE
Migrate PreferencesDialog and DEFeedbackDialog to using AsyncProviderWrapper

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -228,6 +228,8 @@ public interface DesktopView extends IsWidget {
 
         void onCollaboratorsClick();
 
+        void onPreferencesClick();
+
         void onContactSupportClick();
 
         void onDocumentationClick();

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -53,11 +53,13 @@ import org.iplantc.de.desktop.client.presenter.util.NotificationUtil;
 import org.iplantc.de.desktop.client.presenter.util.NotificationWebSocketManager;
 import org.iplantc.de.desktop.client.presenter.util.SystemMessageWebSocketManager;
 import org.iplantc.de.desktop.client.views.windows.IPlantWindowInterface;
+import org.iplantc.de.desktop.client.views.widgets.PreferencesDialog;
 import org.iplantc.de.desktop.shared.DeModule;
 import org.iplantc.de.fileViewers.client.callbacks.LoadGenomeInCoGeCallback;
 import org.iplantc.de.notifications.client.events.WindowShowRequestEvent;
 import org.iplantc.de.notifications.client.utils.NotifyInfo;
 import org.iplantc.de.notifications.client.views.dialogs.RequestHistoryDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 import org.iplantc.de.shared.DEProperties;
 import org.iplantc.de.shared.NotificationCallback;
 import org.iplantc.de.shared.events.ServiceDown;
@@ -160,6 +162,7 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
     @Inject UserSettings userSettings;
     @Inject NotifyInfo notifyInfo;
     @Inject DiskResourceUtil diskResourceUtil;
+    @Inject AsyncProviderWrapper<PreferencesDialog> preferencesDialogProvider;
     private DesktopPresenterAppearance appearance;
 
     private final EventBus eventBus;
@@ -453,6 +456,22 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
     @Override
     public void onCollaboratorsClick() {
         new ManageCollaboratorsDialog(ManageCollaboratorsView.MODE.MANAGE).show();
+    }
+
+    @Override
+    public void onPreferencesClick() {
+	final DesktopView.Presenter presenter = this;
+        preferencesDialogProvider.get(new AsyncCallback<PreferencesDialog>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                ErrorHandler.post(caught);
+            }
+
+            @Override
+            public void onSuccess(final PreferencesDialog dialog) {
+                dialog.show(presenter, userSettings);
+            }
+	});
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -460,7 +460,6 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
 
     @Override
     public void onPreferencesClick() {
-	final DesktopView.Presenter presenter = this;
         preferencesDialogProvider.get(new AsyncCallback<PreferencesDialog>() {
             @Override
             public void onFailure(Throwable caught) {
@@ -469,7 +468,7 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
 
             @Override
             public void onSuccess(final PreferencesDialog dialog) {
-                dialog.show(presenter, userSettings);
+                dialog.show(DesktopPresenterImpl.this, userSettings);
             }
 	});
     }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
@@ -3,6 +3,7 @@ package org.iplantc.de.desktop.client.views;
 import org.iplantc.de.client.models.UserSettings;
 import org.iplantc.de.client.models.notifications.NotificationMessage;
 import org.iplantc.de.commons.client.widgets.IPlantAnchor;
+import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.desktop.client.DesktopView;
 import org.iplantc.de.desktop.client.views.widgets.DEFeedbackDialog;
 import org.iplantc.de.desktop.client.views.widgets.DesktopIconButton;
@@ -13,6 +14,7 @@ import org.iplantc.de.desktop.client.views.widgets.UnseenNotificationsView;
 import org.iplantc.de.desktop.client.views.windows.IPlantWindowInterface;
 import org.iplantc.de.desktop.shared.DeModule;
 import org.iplantc.de.resources.client.messages.IplantNewUserTourStrings;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Preconditions;
 import com.google.gwt.core.client.GWT;
@@ -27,9 +29,9 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.Dialog.PredefinedButton;
@@ -70,8 +72,8 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
     @UiField IPlantAnchor forumsLink;
     @UiField IPlantAnchor feedbackLink;
 
-    @Inject Provider<PreferencesDialog> preferencesDialogProvider;
-    @Inject Provider<DEFeedbackDialog> deFeedbackDialogProvider;
+    @Inject AsyncProviderWrapper<PreferencesDialog> preferencesDialogProvider;
+    @Inject AsyncProviderWrapper<DEFeedbackDialog> deFeedbackDialogProvider;
     @Inject UserSettings userSettings;
 
     private static DesktopViewImplUiBinder ourUiBinder = GWT.create(DesktopViewImplUiBinder.class);
@@ -306,26 +308,35 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
 
     void onFeedbackBtnSelect() {
         helpBtn.hideMenu();
-        final DEFeedbackDialog feedbackDialog = deFeedbackDialogProvider.get();
-        feedbackDialog.show();
-        feedbackDialog.getButton(PredefinedButton.OK).addSelectHandler(new SelectEvent.SelectHandler() {
+        deFeedbackDialogProvider.get(new AsyncCallback<DEFeedbackDialog>() {
             @Override
-            public void onSelect(SelectEvent event) {
-                if(feedbackDialog.validate()){
-                    presenter.submitUserFeedback(feedbackDialog.toJson(), feedbackDialog);
-                } else {
-                    AlertMessageBox amb = new AlertMessageBox(appearance.feedbackAlertValidationWarning(),
-                                                              appearance.completeRequiredFieldsError());
-                    amb.setModal(true);
-                    amb.show();
-                }
+            public void onFailure(Throwable caught) {
+                ErrorHandler.post(caught);
             }
-        });
 
-        feedbackDialog.getButton(PredefinedButton.CANCEL).addSelectHandler(new SelectEvent.SelectHandler() {
             @Override
-            public void onSelect(SelectEvent event) {
-                feedbackDialog.hide();
+            public void onSuccess(final DEFeedbackDialog feedbackDialog) {
+                feedbackDialog.show();
+                feedbackDialog.getButton(PredefinedButton.OK).addSelectHandler(new SelectEvent.SelectHandler() {
+                    @Override
+                    public void onSelect(SelectEvent event) {
+                        if(feedbackDialog.validate()){
+                            presenter.submitUserFeedback(feedbackDialog.toJson(), feedbackDialog);
+                        } else {
+                            AlertMessageBox amb = new AlertMessageBox(appearance.feedbackAlertValidationWarning(),
+                                                                      appearance.completeRequiredFieldsError());
+                            amb.setModal(true);
+                            amb.show();
+                        }
+                    }
+                });
+
+                feedbackDialog.getButton(PredefinedButton.CANCEL).addSelectHandler(new SelectEvent.SelectHandler() {
+                    @Override
+                    public void onSelect(SelectEvent event) {
+                        feedbackDialog.hide();
+                    }
+                });
             }
         });
    }
@@ -349,8 +360,17 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
 
     @UiHandler("preferencesLink")
     void onPreferencesClick(ClickEvent event){
-        PreferencesDialog dialog = preferencesDialogProvider.get();
-        dialog.show(presenter, userSettings);
+        preferencesDialogProvider.get(new AsyncCallback<PreferencesDialog>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                ErrorHandler.post(caught);
+            }
+
+            @Override
+            public void onSuccess(final PreferencesDialog dialog) {
+                dialog.show(presenter, userSettings);
+            }
+	});
     }
 
     @UiHandler("collaboratorsLink")

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
@@ -72,7 +72,6 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
     @UiField IPlantAnchor forumsLink;
     @UiField IPlantAnchor feedbackLink;
 
-    @Inject AsyncProviderWrapper<PreferencesDialog> preferencesDialogProvider;
     @Inject AsyncProviderWrapper<DEFeedbackDialog> deFeedbackDialogProvider;
     @Inject UserSettings userSettings;
 
@@ -360,17 +359,7 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
 
     @UiHandler("preferencesLink")
     void onPreferencesClick(ClickEvent event){
-        preferencesDialogProvider.get(new AsyncCallback<PreferencesDialog>() {
-            @Override
-            public void onFailure(Throwable caught) {
-                ErrorHandler.post(caught);
-            }
-
-            @Override
-            public void onSuccess(final PreferencesDialog dialog) {
-                dialog.show(presenter, userSettings);
-            }
-	});
+        presenter.onPreferencesClick();
     }
 
     @UiHandler("collaboratorsLink")


### PR DESCRIPTION
It works!

I have the feeling I'm supposed to be using the presenter here (no other views seem to import ErrorHandler, particularly, but the presenter which corresponds to this does seem to use it via a provider), but I would need advising on how to move this stuff around. This does successfully reduce the size of the initial download, while increasing the leftovers fragment a little bit and creating one extra split (at least in my testing, it bundled the PreferencesDialog with the preexisting AppLaunchWindow split, but DEFeedbackDialog got its own).