### PR TITLE
CORE-8597 Fix issue where private apps do not show lock icon

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppStatusCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppStatusCellDefaultAppearance.java
@@ -72,7 +72,10 @@ public class AppStatusCellDefaultAppearance implements AppStatusCell.AppStatusCe
     public void render(Cell.Context context, App value, SafeHtmlBuilder sb, String debugId) {
         String tooltip;
         final SafeUri safeUri;
-        if (value.isDisabled()) {
+        if (value.isPublic() != null && !value.isPublic()) {
+            safeUri = iplantResources.lock().getSafeUri();
+            tooltip = appsMessages.privateToolTip();
+        } else if (value.isDisabled()) {
             safeUri = iplantResources.xred().getSafeUri();
             tooltip = iplantDisplayStrings.appUnavailable();
         } else if (value.isBeta() != null && value.isBeta()) {


### PR DESCRIPTION
I accidentally removed this code to fix a bug in Belphegor where this was causing NPE, not realizing this also affected the DE.  Now there's a null check so Belphegor can do its thing and the DE will show the lock.