### PR TITLE
CORE-8599 and CORE-8441

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
@@ -161,7 +161,7 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
     Map<String, List<OntologyHierarchy>> iriToHierarchyMap = new FastMap<>();
     private OntologyHierarchiesViewFactory viewFactory;
     String baseID;
-    List<OntologyHierarchy> unclassifiedHierarchies = Lists.newArrayList();
+    List<OntologyHierarchy> unclassifiedHierarchies;
     List<OntologyHierarchiesView> views;
     boolean desiredHierarchyFound = false;
     Logger LOG = Logger.getLogger("OntologyHierarchiesPresenterImpl");
@@ -183,6 +183,7 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
     @Override
     public void go(final OntologyHierarchy selectedHierarchy, final DETabPanel tabPanel) {
         desiredHierarchyFound = false;
+        unclassifiedHierarchies = Lists.newArrayList();
         views = Lists.newArrayList();
         viewTabPanel = tabPanel;
         serviceFacade.getRootHierarchies(new AppsCallback<List<OntologyHierarchy>>() {

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/hierarchies/OntologyHierarchiesPresenterImpl.java
@@ -91,7 +91,10 @@ public class OntologyHierarchiesPresenterImpl implements OntologyHierarchiesView
             }
 
             List<OntologyHierarchy> hierarchies = appDetails.getHierarchies();
-            if (hierarchies != null && hierarchies.size() == 0) {
+
+            boolean isPublicApp = appDetails.isPublic() != null && appDetails.isPublic();
+            boolean isUnclassified = hierarchies != null && hierarchies.size() == 0;
+            if (isUnclassified && isPublicApp) {
                 hierarchies = unclassifiedHierarchies;
             }
             addHierarchies(hierarchyTreeStore, null, hierarchies);


### PR DESCRIPTION
CORE-8441 - Private apps were listing the Unclassified hierarchies in the App Details view, which incorrectly conveyed that those apps were public.

CORE-8599 - Hitting the Refresh button in the Apps window causes the go() method to be rerun.  The unclassifiedHierarchies list was never reset in the go() method which would cause dupes to get added every time the Refresh button was pressed.  This led to an incorrect number of Unclassified hierarchies listed in the App Details view.