### PR TITLE
CORE-4232 Rename Copy Link button in Data Link window for clarity

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/DataLinkView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/DataLinkView.java
@@ -17,7 +17,7 @@ import java.util.List;
 public interface DataLinkView extends IsWidget {
     interface Appearance {
 
-        String copy();
+        String dataLinkTitle();
 
         String copyDataLinkDlgHeight();
 
@@ -41,7 +41,7 @@ public interface DataLinkView extends IsWidget {
 
         ImageResource treeCollapseIcon();
 
-        String copyLink();
+        String showLink();
 
         ImageResource pasteIcon();
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/GridView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/GridView.java
@@ -125,7 +125,7 @@ public interface GridView extends IsWidget,
 
             String comments();
 
-            String copy();
+            String dataLinkTitle();
 
             String copyPasteInstructions();
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/DataLinkViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/DataLinkViewImpl.java
@@ -27,6 +27,7 @@ import com.sencha.gxt.core.client.IdentityValueProvider;
 import com.sencha.gxt.core.client.ValueProvider;
 import com.sencha.gxt.data.shared.ModelKeyProvider;
 import com.sencha.gxt.data.shared.TreeStore;
+import com.sencha.gxt.widget.core.client.Dialog;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
@@ -89,7 +90,7 @@ public class DataLinkViewImpl implements DataLinkView,
 
     @UiField TextButton advancedDataLinkButton;
     @UiField TextButton collapseAll;
-    @UiField TextButton copyDataLinkButton;
+    @UiField TextButton showDataLinkButton;
     @UiField TextButton createDataLinksBtn;
     @UiField TextButton expandAll;
     @UiField TreeStore<DiskResource> store;
@@ -115,7 +116,7 @@ public class DataLinkViewImpl implements DataLinkView,
         tree.getStyle().setNodeOpenIcon(emptyImgResource);
 
         tree.getSelectionModel().addSelectionHandler(new TreeSelectionHandler(createDataLinksBtn,
-                                                                              copyDataLinkButton,
+                                                                              showDataLinkButton,
                                                                               advancedDataLinkButton,
                                                                               tree));
         DataLinkPanelCell dataLinkPanelCell = new DataLinkPanelCell();
@@ -128,7 +129,7 @@ public class DataLinkViewImpl implements DataLinkView,
 
     @Override
     public void onDeleteDataLinkSelected(DeleteDataLinkSelected event) {
-        copyDataLinkButton.setEnabled(false);
+        showDataLinkButton.setEnabled(false);
     }
 
     //<editor-fold desc="UI Handlers">
@@ -142,13 +143,14 @@ public class DataLinkViewImpl implements DataLinkView,
         tree.collapseAll();
     }
 
-    @UiHandler("copyDataLinkButton")
+    @UiHandler("showDataLinkButton")
     void onCopyDataLinkButtonSelected(SelectEvent event) {
         // Open dialog window with text selected.
         IPlantDialog dlg = new IPlantDialog();
-        dlg.setHeadingText(appearance.copy());
+        dlg.setHeadingText(appearance.dataLinkTitle());
         dlg.setHideOnButtonClick(true);
         dlg.setResizable(false);
+        dlg.setPredefinedButtons(Dialog.PredefinedButton.OK);
         dlg.setSize(appearance.copyDataLinkDlgWidth(), appearance.copyDataLinkDlgHeight());
         TextField textBox = new TextField();
         textBox.setWidth(appearance.copyDataLinkDlgTextBoxWidth());

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/DataLinkViewImpl.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dataLink/DataLinkViewImpl.ui.xml
@@ -40,8 +40,8 @@
                 <button:TextButton ui:field="collapseAll"
                                    text="{appearance.collapseAll}"
                                    icon="{appearance.treeCollapseIcon}"/>
-                <button:TextButton ui:field="copyDataLinkButton"
-                                   text="{appearance.copyLink}"
+                <button:TextButton ui:field="showDataLinkButton"
+                                   text="{appearance.showLink}"
                                    icon="{appearance.pasteIcon}"
                                    enabled="false"/>
                 <button:TextButton ui:field="advancedDataLinkButton"

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/ShareResourceLinkDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/ShareResourceLinkDialog.java
@@ -18,7 +18,7 @@ public class ShareResourceLinkDialog extends IPlantDialog {
 
     @Inject
     ShareResourceLinkDialog(final GridView.Presenter.Appearance appearance) {
-        setHeadingText(appearance.copy());
+        setHeadingText(appearance.dataLinkTitle());
         setPredefinedButtons(PredefinedButton.OK);
         setHideOnButtonClick(true);
         setResizable(false);

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/dataLink/DataLinkMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/dataLink/DataLinkMessages.java
@@ -9,11 +9,13 @@ import com.google.gwt.i18n.client.Messages;
 public interface DataLinkMessages extends Messages{
     String advancedSharing();
 
-    String copyLink();
+    String showLink();
 
     String dataLinkWarning();
 
     String deleteDataLinkToolTip();
 
     String expandAll();
+
+    String dataLinkTitle();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/dataLink/DataLinkMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/dataLink/DataLinkMessages.properties
@@ -1,6 +1,6 @@
 dataLinkWarning = All links created are public until deactivated.
 advancedSharing = Advanced Sharing
-copyLink = Copy Link
+showLink = Show Link
 expandAll = Expand All
 deleteDataLinkToolTip = Click to delete Data Link
-
+dataLinkTitle = Public Data Link

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/dataLink/DataLinkViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/dataLink/DataLinkViewDefaultAppearance.java
@@ -86,8 +86,8 @@ public class DataLinkViewDefaultAppearance implements DataLinkView.Appearance {
     }
 
     @Override
-    public String copy() {
-        return iplantDisplayStrings.copy();
+    public String dataLinkTitle() {
+        return displayMessages.dataLinkTitle();
     }
 
     @Override
@@ -106,8 +106,8 @@ public class DataLinkViewDefaultAppearance implements DataLinkView.Appearance {
     }
 
     @Override
-    public String copyLink() {
-        return displayMessages.copyLink();
+    public String showLink() {
+        return displayMessages.showLink();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.java
@@ -77,4 +77,5 @@ public interface GridViewDisplayStrings extends Messages {
 
     String metadataSaveError();
 
+    String dataLinkTitle();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.properties
@@ -25,4 +25,4 @@ copyMetadataFailure = Unable to copy metadata. Please try again or contact suppo
 md5Checksum = Md5 Checksum
 checksum = Checksum
 metadataSaveError = Please fix all error(s) before saving. Attribute(s) cannot be empty!
-
+dataLinkTitle = Public Data Link

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/presenter/GridViewPresenterDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/presenter/GridViewPresenterDefaultAppearance.java
@@ -40,8 +40,8 @@ public class GridViewPresenterDefaultAppearance implements GridView.Presenter.Ap
     }
 
     @Override
-    public String copy() {
-        return iplantDisplayStrings.copy();
+    public String dataLinkTitle() {
+        return displayStrings.dataLinkTitle();
     }
 
     @Override


### PR DESCRIPTION
When creating public data links, users thought the verbiage and buttons were trying to convey that opening the data link window automatically copied the data link into the user's clipboard.  This is changing the wording so that it's clearer that users still have to manually copy the link.

From "Copy Link" to "Show Link"
![image](https://cloud.githubusercontent.com/assets/8909156/23079954/46ad8a9c-f50c-11e6-9361-398e932c5a95.png)

From "Copy" title to "Public Data Link" title.  Cancel button has been removed so as to not indicate there is an action to cancel.
![image](https://cloud.githubusercontent.com/assets/8909156/23079984/60c35880-f50c-11e6-9ec5-8e2691e13042.png)
