### PR TITLE
CORE-7539 When relaunching an analysis, the Retain Inputs flag does not persist

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/presenter/AppLaunchPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/presenter/AppLaunchPresenterImpl.java
@@ -140,6 +140,7 @@ public class AppLaunchPresenterImpl implements AppLaunchView.Presenter,
         final JobExecution je = getJobExecution();
         je.setSystemId(appTemplate.getSystemId());
         je.setAppTemplateId(appTemplate.getId());
+        je.setRetainInputs(appTemplate.isRetainInputs());
         je.setEmailNotificationEnabled(userSettings.isEnableAnalysisEmailNotification());
         // JDS Replace all Cmd Line restricted chars with underscores
         String regex = getRestrictedCharRegEx();

--- a/de-lib/src/main/java/org/iplantc/de/client/models/apps/integration/AppTemplate.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/apps/integration/AppTemplate.java
@@ -1,11 +1,12 @@
 package org.iplantc.de.client.models.apps.integration;
 
-import com.google.gwt.user.client.ui.HasName;
-import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 import org.iplantc.de.client.models.HasDescription;
 import org.iplantc.de.client.models.HasLabel;
 import org.iplantc.de.client.models.HasQualifiedId;
 import org.iplantc.de.client.models.tool.Tool;
+
+import com.google.gwt.user.client.ui.HasName;
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 
 import java.util.Date;
 import java.util.List;
@@ -64,4 +65,8 @@ public interface AppTemplate extends HasQualifiedId, HasLabel, HasName, HasDescr
     String getAppType();
 
     Boolean isDeleted();
+
+    @PropertyName("debug")
+    Boolean isRetainInputs();
+
 }

--- a/de-lib/src/test/java/org/iplantc/de/apps/widgets/client/presenter/AppLaunchPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/widgets/client/presenter/AppLaunchPresenterImplTest.java
@@ -170,10 +170,12 @@ public class AppLaunchPresenterImplTest {
 
     @Test
     public void createJobExecution() {
+        when(appTemplateMock.isRetainInputs()).thenReturn(true);
         /** CALL METHOD UNDER TEST **/
         uut.createJobExecution();
 
         verify(jeMock).setAppTemplateId(eq("id"));
+        verify(jeMock).setRetainInputs(eq(true));
         verify(jeMock).setEmailNotificationEnabled(eq(userSettingsMock.isEnableAnalysisEmailNotification()));
         verify(jeMock).setName(anyString());
         verify(jeMock).setOutputDirectory(eq("path"));


### PR DESCRIPTION
This PR fixes a bug where the UI was not checking the Retain Inputs flag (debug key) during analysis relaunch. 