### PR TITLE
CORE-8613 Log errors from the UI during bootstrap

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/HasSplittableError.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/HasSplittableError.java
@@ -1,0 +1,11 @@
+package org.iplantc.de.client.models;
+
+import com.google.web.bindery.autobean.shared.Splittable;
+
+/**
+ * @author aramsey
+ */
+public interface HasSplittableError {
+
+    Splittable getError();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -78,8 +78,10 @@ public class UserInfo {
         preferences = userBootstrap.getPreferences();
         session = userBootstrap.getSession();
         appsInfo = userBootstrap.getAppsInfo();
-        workspace = appsInfo.getWorkspace();
-        systemIds = appsInfo.getSystemsIds();
+        if (appsInfo != null) {
+            workspace = appsInfo.getWorkspace();
+            systemIds = appsInfo.getSystemsIds();
+        }
     }
 
     public boolean hasErrors() {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/UserInfo.java
@@ -18,6 +18,7 @@ import com.google.web.bindery.autobean.shared.Splittable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * Holds all the information about an user.
@@ -56,6 +57,7 @@ public class UserInfo {
     private AppsInfo appsInfo;
     private List<WindowState> savedOrderedWindowStates;
     private static String AGAVE_AUTH_KEY = "agave";
+    private Logger LOG = Logger.getLogger(UserInfo.class.getName());
 
     /**
      * Constructs a default instance of the object with all fields being set to null.
@@ -82,6 +84,37 @@ public class UserInfo {
             workspace = appsInfo.getWorkspace();
             systemIds = appsInfo.getSystemsIds();
         }
+
+        checkForErrors();
+    }
+
+    private void checkForErrors() {
+        if (userProfile == null || hasUserProfileError()) {
+            logBootstrapError(UserBootstrap.USER_INFO_KEY, null);
+        }
+        if (dataInfo == null || hasDataInfoError()) {
+            logBootstrapError(UserBootstrap.DATA_INFO_KEY, dataInfo);
+        }
+        if (preferences == null || hasPreferencesError()) {
+            logBootstrapError(UserBootstrap.PREFERENCES_KEY, preferences);
+        }
+        if (session == null || hasSessionError()) {
+            logBootstrapError(UserBootstrap.SESSION_KEY, session);
+        }
+        if (appsInfo == null || hasAppsInfoError()) {
+            logBootstrapError(UserBootstrap.APPS_INFO_KEY, appsInfo);
+        }
+    }
+
+    private void logBootstrapError(String key, HasSplittableError obj) {
+        String errorMsg;
+        errorMsg = "Bootstrap error within '" + key + "' key: ";
+        if (obj != null) {
+            errorMsg += obj.getError().getPayload();
+        } else {
+            errorMsg += "null value or key parsing error";
+        }
+        LOG.severe(errorMsg);
     }
 
     public boolean hasErrors() {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/AppsInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/AppsInfo.java
@@ -1,17 +1,16 @@
 package org.iplantc.de.client.models.bootstrap;
 
+import org.iplantc.de.client.models.HasSplittableError;
+
 import com.google.web.bindery.autobean.shared.AutoBean;
-import com.google.web.bindery.autobean.shared.Splittable;
 
 /**
  * Created by sriram on 2/27/17.
  */
-public interface AppsInfo {
+public interface AppsInfo extends HasSplittableError {
 
     @AutoBean.PropertyName("system_ids")
     SystemIds getSystemsIds();
 
     Workspace getWorkspace();
-
-    Splittable getError();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/DataInfo.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/DataInfo.java
@@ -1,14 +1,14 @@
 package org.iplantc.de.client.models.bootstrap;
 
+import org.iplantc.de.client.models.HasSplittableError;
 import org.iplantc.de.client.models.HasStatus;
 
 import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
-import com.google.web.bindery.autobean.shared.Splittable;
 
 /**
  * @author aramsey
  */
-public interface DataInfo extends HasStatus {
+public interface DataInfo extends HasStatus, HasSplittableError {
 
     @PropertyName("user_home_path")
     String getHomePath();
@@ -18,6 +18,4 @@ public interface DataInfo extends HasStatus {
 
     @PropertyName("base_trash_path")
     String getBaseTrashPath();
-
-    Splittable getError();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Preferences.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Preferences.java
@@ -1,16 +1,12 @@
 package org.iplantc.de.client.models.bootstrap;
 
+import org.iplantc.de.client.models.HasSplittableError;
 import org.iplantc.de.client.models.HasStatus;
 import org.iplantc.de.client.models.userSettings.UserSetting;
-
-import com.google.web.bindery.autobean.shared.Splittable;
 
 /**
  *
  * @author aramsey
  */
-public interface Preferences extends HasStatus, UserSetting {
-
-    Splittable getError();
-
+public interface Preferences extends HasStatus, UserSetting, HasSplittableError {
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Session.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Session.java
@@ -1,5 +1,7 @@
 package org.iplantc.de.client.models.bootstrap;
 
+import org.iplantc.de.client.models.HasSplittableError;
+
 import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 import com.google.web.bindery.autobean.shared.Splittable;
 
@@ -8,7 +10,7 @@ import java.util.Map;
 /**
  * @author aramsey
  */
-public interface Session {
+public interface Session extends HasSplittableError {
 
     @PropertyName("login_time")
     Long getLoginTime();
@@ -19,6 +21,5 @@ public interface Session {
     @PropertyName("auth_redirect")
     void setAuthRedirects(Map<String, String> redirects);
 
-    Splittable getError();
     void setError(Splittable error);
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/SystemIds.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/SystemIds.java
@@ -1,20 +1,19 @@
 package org.iplantc.de.client.models.bootstrap;
 
+import org.iplantc.de.client.models.HasSplittableError;
+
 import com.google.web.bindery.autobean.shared.AutoBean;
-import com.google.web.bindery.autobean.shared.Splittable;
 
 import java.util.List;
 
 /**
  * Created by sriram on 2/24/17.
  */
-public interface SystemIds {
+public interface SystemIds extends HasSplittableError {
 
     @AutoBean.PropertyName("de_system_id")
     String getDESytemId();
 
     @AutoBean.PropertyName("all_system_ids")
     List<String> getAllSystemIds();
-
-    Splittable getError();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/UserBootstrap.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/UserBootstrap.java
@@ -11,19 +11,29 @@ import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
  */
 public interface UserBootstrap {
 
-    @PropertyName("user_info")
+    String USER_INFO_KEY = "user_info";
+    String SESSION_KEY = "session";
+    String WORKSPACE_KEY = "workspace";
+    String DATA_INFO_KEY = "data_info";
+    String PREFERENCES_KEY = "preferences";
+    String APPS_INFO_KEY = "apps_info";
+
+    @PropertyName(USER_INFO_KEY)
     UserProfile getUserProfile();
 
+    @PropertyName(SESSION_KEY)
     Session getSession();
 
+    @PropertyName(WORKSPACE_KEY)
     Workspace getWorkspace();
 
-    @PropertyName("data_info")
+    @PropertyName(DATA_INFO_KEY)
     DataInfo getDataInfo();
 
+    @PropertyName(PREFERENCES_KEY)
     Preferences getPreferences();
 
-    @PropertyName("apps_info")
+    @PropertyName(APPS_INFO_KEY)
     AppsInfo getAppsInfo();
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Workspace.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/bootstrap/Workspace.java
@@ -1,20 +1,18 @@
 package org.iplantc.de.client.models.bootstrap;
 
+import org.iplantc.de.client.models.HasSplittableError;
 import org.iplantc.de.client.models.HasStatus;
 
 import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
-import com.google.web.bindery.autobean.shared.Splittable;
 
 /**
  * @author aramsey
  */
-public interface Workspace extends HasStatus {
+public interface Workspace extends HasStatus, HasSplittableError {
 
     @PropertyName("new_workspace")
     Boolean isNewUser();
 
     @PropertyName("workspace_id")
     String getWorkspaceId();
-
-    Splittable getError();
 }


### PR DESCRIPTION
We discovered recently that if there are any kind of errors during bootstrap (for example, if the backend has updated the bootstrap JSON), the UI will use default values as expected, but will hide the cause of the use of defaults.

This change will log the bootstrap errors that occur within the UI prior to using defaults for more transparency. 