### PR TITLE
CORE-8701 Add app ID to App Editor window config to allow multiple ap…

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/window/configs/ConfigFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/window/configs/ConfigFactory.java
@@ -37,12 +37,15 @@ public class ConfigFactory {
     }
 
     public static AppsIntegrationWindowConfig appsIntegrationWindowConfig(HasQualifiedId app) {
-        AppsIntegrationWindowConfig aiwc = applyWindowType(WindowType.APP_INTEGRATION,
-                factory.appsIntegrationWindowConfig()).as();
-        aiwc.setSystemId(app == null ? "" : app.getSystemId());
-        aiwc.setAppId(app == null ? "" : app.getId());
-        aiwc.setOnlyLabelEditMode(false);
-        return aiwc;
+        AutoBean<AppsIntegrationWindowConfig> aiwc = applyWindowType(WindowType.APP_INTEGRATION,
+                factory.appsIntegrationWindowConfig());
+        String systemId = app.getSystemId();
+        String appId = app.getId();
+        aiwc.as().setSystemId(app == null ? "" : systemId);
+        aiwc.as().setAppId(app == null ? "" : appId);
+        applyTag(systemId + ":" + appId, aiwc);
+        aiwc.as().setOnlyLabelEditMode(false);
+        return aiwc.as();
     }
 
     public static AppsWindowConfig appsWindowConfig() {


### PR DESCRIPTION
…p editor windows to be open at the same time.

Previously each App Editor window had a window config of just "APP_INTEGRATION".  So when a user tried to open another App Editor window for a different app, the window configs would be the same, so the desktop manager assumed the user wanted to open a window that was already open.  Now the window config appends the system and app IDs so multiple windows can be open.