### PR TITLE
CORE-8709 Better error message handling when a user tries to save metadata

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/commons/client/ErrorHandler.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/ErrorHandler.java
@@ -5,6 +5,7 @@ import org.iplantc.de.client.util.JsonUtil;
 import org.iplantc.de.commons.client.views.dialogs.ErrorDialog;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -14,6 +15,7 @@ import com.google.gwt.user.client.Window;
 import com.sencha.gxt.core.client.GXT;
 
 import java.util.Date;
+import java.util.List;
 
 /**
  * Provides a uniform manner for posting errors to the user.
@@ -52,6 +54,19 @@ public class ErrorHandler {
     }
 
     private static final String NEWLINE = "<br>"; //$NON-NLS-1$
+
+    private static JsonUtil jsonUtil = JsonUtil.getInstance();
+
+    private static final List<String> errorStrings =
+            Lists.newArrayList("error_code",
+                               "status");
+
+    private static final List<String> messageStrings =
+            Lists.newArrayList("message",
+                               "msg",
+                               "reason");
+
+
 
     /**
      * Post a message box with error styles with the argument error message.
@@ -162,8 +177,8 @@ public class ErrorHandler {
         }
 
         if (jsonError != null) {
-            String error_code = JsonUtil.getInstance().getString(jsonError, "error_code") + NEWLINE; //$NON-NLS-1$
-            String message = JsonUtil.getInstance().getString(jsonError, "reason") + NEWLINE; //$NON-NLS-1$
+            String error_code = getErrorCode(jsonError) + NEWLINE; //$NON-NLS-1$
+            String message = getErrorMessage(jsonError) + NEWLINE; //$NON-NLS-1$
 
             if (!message.isEmpty() || !error_code.isEmpty()) {
                 exceptionMessage = appearance.errorReport(error_code, message);
@@ -171,6 +186,26 @@ public class ErrorHandler {
         }
 
         return exceptionMessage;
+    }
+
+    private static String getErrorCode(JSONObject jsonError) {
+        for (String s : errorStrings) {
+            String error = jsonUtil.getString(jsonError, s);
+            if (!Strings.isNullOrEmpty(error)) {
+                return error;
+            }
+        }
+        return "";
+    }
+
+    private static String getErrorMessage(JSONObject jsonError) {
+        for (String s : messageStrings) {
+            String error = jsonUtil.getString(jsonError, s);
+            if (!Strings.isNullOrEmpty(error)) {
+                return error;
+            }
+        }
+        return "";
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/info/ErrorAnnouncementConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/info/ErrorAnnouncementConfig.java
@@ -14,7 +14,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 public class ErrorAnnouncementConfig extends IplantAnnouncementConfig {
 
     public ErrorAnnouncementConfig(final String message) {
-        this(SafeHtmlUtils.fromString(message));
+        this(SafeHtmlUtils.fromTrustedString(message));
     }
 
     public ErrorAnnouncementConfig(final SafeHtml message) {

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/info/IplantAnnouncementConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/info/IplantAnnouncementConfig.java
@@ -53,7 +53,7 @@ public class IplantAnnouncementConfig {
      * @param message
      */
     public IplantAnnouncementConfig(final String message) {
-        this(SafeHtmlUtils.fromString(message));
+        this(SafeHtmlUtils.fromTrustedString(message));
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/GridView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/GridView.java
@@ -187,7 +187,9 @@ public interface GridView extends IsWidget,
 
             String copyMetadataPrompt();
 
-            String fileExistsError();
+            String fileExistsError(String fileName);
+
+            String fileSaveError(String fileName);
         }
 
         void deSelectDiskResources();

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/GridView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/GridView.java
@@ -186,6 +186,8 @@ public interface GridView extends IsWidget,
             String error();
 
             String copyMetadataPrompt();
+
+            String fileExistsError();
         }
 
         void deSelectDiskResources();

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/ToolbarView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/ToolbarView.java
@@ -18,6 +18,7 @@ import org.iplantc.de.diskResource.client.events.selection.MoveDiskResourcesSele
 import org.iplantc.de.diskResource.client.events.selection.RefreshFolderSelected.HasRefreshFolderSelectedHandlers;
 import org.iplantc.de.diskResource.client.events.selection.RenameDiskResourceSelected.HasRenameDiskResourceSelectedHandlers;
 import org.iplantc.de.diskResource.client.events.selection.RestoreDiskResourcesSelected.HasRestoreDiskResourceSelectedHandlers;
+import org.iplantc.de.diskResource.client.events.selection.SaveMetadataSelected;
 import org.iplantc.de.diskResource.client.events.selection.SendToCogeSelected.HasSendToCogeSelectedHandlers;
 import org.iplantc.de.diskResource.client.events.selection.SendToEnsemblSelected.HasSendToEnsemblSelectedHandlers;
 import org.iplantc.de.diskResource.client.events.selection.SendToTreeViewerSelected.HasSendToTreeViewerSelectedHandlers;
@@ -59,7 +60,8 @@ public interface ToolbarView extends IsWidget,
                                      HasImportFromUrlSelectedHandlers,
                                      DownloadTemplateSelectedEvent.HasDownloadTemplateSelectedEventHandlers,
                                      FolderSelectionEventHandler,
-                                     DiskResourceSelectionChangedEventHandler {
+                                     DiskResourceSelectionChangedEventHandler,
+                                     SaveMetadataSelected.HasSaveMetadataSelectedEventHandlers{
     interface Appearance {
 
         SafeHtml bulkDownloadInfoBoxHeading();

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
@@ -331,6 +331,7 @@ public class DiskResourcePresenterImpl implements
         toolbarPresenter.getView().addSendToTreeViewerSelectedHandler(this);
         toolbarPresenter.getView().addSimpleUploadSelectedHandler(this.navigationPresenter);
         toolbarPresenter.getView().addImportFromUrlSelectedHandler(this.navigationPresenter);
+        toolbarPresenter.getView().addSaveMetadataSelectedEventHandler(this.gridViewPresenter);
 
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -111,8 +111,13 @@ public class GridViewPresenterImpl implements
 
         @Override
          public void onFailure(Throwable caught) {
-             save_dialog.hide();
-             announcer.schedule(new ErrorAnnouncementConfig("Unable to save your file. Please try again or contact support."));
+            save_dialog.unmask();
+             if (caught.getMessage().contains("ERR_EXISTS")) {
+                 announcer.schedule(new ErrorAnnouncementConfig(appearance.fileExistsError()));
+             } else {
+                 ErrorHandler.post("Unable to save your file. Please try again or contact support.",
+                                   caught);
+             }
          }
 
         @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -687,7 +687,7 @@ public class GridViewPresenterImpl implements
         saveAsDialogProvider.get(new AsyncCallback<SaveAsDialog>() {
             @Override
             public void onFailure(Throwable caught) {
-                announcer.schedule(new ErrorAnnouncementConfig("Unable to save your file. Please try again or contact support."));
+                ErrorHandler.post(caught);
             }
 
             @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -103,15 +103,15 @@ public class GridViewPresenterImpl implements
                                   {
 
     private final class SaveMetadataCallback implements AsyncCallback<String> {
-        private final SaveAsDialog save_dialog;
+        private final SaveAsDialog saveDialog;
 
-        private SaveMetadataCallback(SaveAsDialog save_dialog) {
-            this.save_dialog = save_dialog;
+        private SaveMetadataCallback(SaveAsDialog saveDialog) {
+            this.saveDialog = saveDialog;
         }
 
         @Override
         public void onFailure(Throwable caught) {
-            save_dialog.unmask();
+            saveDialog.unmask();
             String fileName = saveDialog.getFileName();
             if (caught.getMessage().contains("ERR_EXISTS")) {
                 announcer.schedule(new ErrorAnnouncementConfig(appearance.fileExistsError(fileName)));
@@ -123,7 +123,7 @@ public class GridViewPresenterImpl implements
 
         @Override
         public void onSuccess(String result) {
-            save_dialog.hide();
+            saveDialog.hide();
             IplantAnnouncer.getInstance()
                            .schedule(new SuccessAnnouncementConfig("Metadata saved!", true, 3000));
 
@@ -691,32 +691,32 @@ public class GridViewPresenterImpl implements
             }
 
             @Override
-            public void onSuccess(final SaveAsDialog save_dialog) {
+            public void onSuccess(final SaveAsDialog saveDialog) {
 
-                save_dialog.addOkButtonSelectHandler(new SelectHandler() {
+                saveDialog.addOkButtonSelectHandler(new SelectHandler() {
 
                     @Override
                     public void onSelect(SelectEvent select_event) {
-                        save_dialog.mask("Saving");
-                        String destination = save_dialog.getSelectedFolder().getPath() + "/"
-                                + save_dialog.getFileName();
+                        saveDialog.mask("Saving");
+                        String destination = saveDialog.getSelectedFolder().getPath() + "/"
+                                + saveDialog.getFileName();
                         diskResourceService.saveMetadata(event.getDiskResource().getId(),
                                                          destination,
                                                          true,
-                                                         new SaveMetadataCallback(save_dialog));
+                                                         new SaveMetadataCallback(saveDialog));
 
                     }
                 });
-                save_dialog.addCancelButtonSelectHandler(new SelectHandler() {
+                saveDialog.addCancelButtonSelectHandler(new SelectHandler() {
 
                     @Override
                     public void onSelect(SelectEvent event) {
-                        save_dialog.hide();
+                        saveDialog.hide();
 
                     }
                 });
-                save_dialog.show(null);
-                save_dialog.toFront();
+                saveDialog.show(null);
+                saveDialog.toFront();
             }
         });
     }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -112,10 +112,11 @@ public class GridViewPresenterImpl implements
         @Override
         public void onFailure(Throwable caught) {
             save_dialog.unmask();
+            String fileName = saveDialog.getFileName();
             if (caught.getMessage().contains("ERR_EXISTS")) {
-                announcer.schedule(new ErrorAnnouncementConfig(appearance.fileExistsError()));
+                announcer.schedule(new ErrorAnnouncementConfig(appearance.fileExistsError(fileName)));
             } else {
-                ErrorHandler.post("Unable to save your file. Please try again or contact support.",
+                ErrorHandler.post(appearance.fileSaveError(fileName),
                                   caught);
             }
         }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/GridViewPresenterImpl.java
@@ -110,25 +110,23 @@ public class GridViewPresenterImpl implements
         }
 
         @Override
-         public void onFailure(Throwable caught) {
+        public void onFailure(Throwable caught) {
             save_dialog.unmask();
-             if (caught.getMessage().contains("ERR_EXISTS")) {
-                 announcer.schedule(new ErrorAnnouncementConfig(appearance.fileExistsError()));
-             } else {
-                 ErrorHandler.post("Unable to save your file. Please try again or contact support.",
-                                   caught);
-             }
-         }
+            if (caught.getMessage().contains("ERR_EXISTS")) {
+                announcer.schedule(new ErrorAnnouncementConfig(appearance.fileExistsError()));
+            } else {
+                ErrorHandler.post("Unable to save your file. Please try again or contact support.",
+                                  caught);
+            }
+        }
 
         @Override
-         public void onSuccess(String result) {
-             save_dialog.hide();
-             IplantAnnouncer.getInstance()
-                            .schedule(new SuccessAnnouncementConfig("Metadata saved!",
-                                                                    true,
-                                                                    3000));
+        public void onSuccess(String result) {
+            save_dialog.hide();
+            IplantAnnouncer.getInstance()
+                           .schedule(new SuccessAnnouncementConfig("Metadata saved!", true, 3000));
 
-         }
+        }
     }
 
     private final class CopyMetadataCallback implements AsyncCallback<String> {

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbarImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbarImpl.java
@@ -1,6 +1,5 @@
 package org.iplantc.de.diskResource.client.views.toolbar;
 
-import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.File;
@@ -25,7 +24,6 @@ import org.iplantc.de.diskResource.client.events.selection.RefreshFolderSelected
 import org.iplantc.de.diskResource.client.events.selection.RenameDiskResourceSelected;
 import org.iplantc.de.diskResource.client.events.selection.RestoreDiskResourcesSelected;
 import org.iplantc.de.diskResource.client.events.selection.SaveMetadataSelected;
-import org.iplantc.de.diskResource.client.events.selection.SaveMetadataSelected.SaveMetadataSelectedEventHandler;
 import org.iplantc.de.diskResource.client.events.selection.SendToCogeSelected;
 import org.iplantc.de.diskResource.client.events.selection.SendToEnsemblSelected;
 import org.iplantc.de.diskResource.client.events.selection.SendToTreeViewerSelected;
@@ -252,6 +250,11 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
         return addHandler(handler, DownloadTemplateSelectedEvent.TYPE);
     }
 
+    @Override
+    public HandlerRegistration addSaveMetadataSelectedEventHandler(SaveMetadataSelected.SaveMetadataSelectedEventHandler handler) {
+        return addHandler(handler, SaveMetadataSelected.TYPE);
+    }
+
 
     // </editor-fold>
 
@@ -465,7 +468,7 @@ public class DiskResourceViewToolbarImpl extends Composite implements ToolbarVie
     @UiHandler("savemetadataMi")
     void onSaveMetadataClicked(SelectionEvent<Item> event) {
         Preconditions.checkState(selectedDiskResources != null && selectedDiskResources.size() == 1);
-        EventBus.getInstance().fireEvent(new SaveMetadataSelected(selectedDiskResources.iterator().next()));
+        fireEvent(new SaveMetadataSelected(selectedDiskResources.iterator().next()));
     }
 
     @UiHandler("downloadtemplateMi")

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.java
@@ -81,5 +81,5 @@ public interface GridViewDisplayStrings extends Messages {
 
     String copyMetadataPrompt();
 
-    String fileExistsError();
+    String fileSaveError(String fileName);
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.java
@@ -80,4 +80,6 @@ public interface GridViewDisplayStrings extends Messages {
     String dataLinkTitle();
 
     String copyMetadataPrompt();
+
+    String fileExistsError();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.properties
@@ -27,3 +27,4 @@ checksum = Checksum
 metadataSaveError = Please fix all error(s) before saving. Attribute(s) cannot be empty!
 dataLinkTitle = Public Data Link
 copyMetadataPrompt = Select file(s) and folder(s) to which metadata will be copied.
+fileExistsError=A file with that name already exists.  Please choose a different name for your file.

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/GridViewDisplayStrings.properties
@@ -27,4 +27,4 @@ checksum = Checksum
 metadataSaveError = Please fix all error(s) before saving. Attribute(s) cannot be empty!
 dataLinkTitle = Public Data Link
 copyMetadataPrompt = Select file(s) and folder(s) to which metadata will be copied.
-fileExistsError=A file with that name already exists.  Please choose a different name for your file.
+fileSaveError = Unable to save your file: {0}. Please try again or contact support.

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/presenter/GridViewPresenterDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/presenter/GridViewPresenterDefaultAppearance.java
@@ -186,4 +186,9 @@ public class GridViewPresenterDefaultAppearance implements GridView.Presenter.Ap
     public String copyMetadataPrompt() {
         return displayStrings.copyMetadataPrompt();
     }
+
+    @Override
+    public String fileExistsError() {
+        return displayStrings.fileExistsError();
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/presenter/GridViewPresenterDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/grid/presenter/GridViewPresenterDefaultAppearance.java
@@ -188,7 +188,12 @@ public class GridViewPresenterDefaultAppearance implements GridView.Presenter.Ap
     }
 
     @Override
-    public String fileExistsError() {
-        return displayStrings.fileExistsError();
+    public String fileExistsError(String fileName) {
+        return iplantErrorStrings.fileExists(fileName);
+    }
+
+    @Override
+    public String fileSaveError(String fileName) {
+        return displayStrings.fileSaveError(fileName);
     }
 }


### PR DESCRIPTION
When a user tried to save a metadata file with a name that already existed, the user was only informed that they should try again with no details as to why. Now if the file already exists, the user will be better informed, for any other errors they'll get the standard error handler message.  I also thought it would be better to unmask the Save dialog instead of hiding it so users don't have to type the file names in again.

I also added more key strings to the ErrorHandler class to parse for in the error JSON from what I've seen Agave use and examples in other tickets.