### PR TITLE
CORE-8723 Enable notifications for tool sharing messages

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/notifications/NotificationCategory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/notifications/NotificationCategory.java
@@ -17,6 +17,8 @@ public enum NotificationCategory {
     ANALYSIS("Analysis"),
     /** tool rquest status update notification */
     TOOLREQUEST("Tool Request"),
+    /** Tool sharing/unsharing notifications **/
+    TOOLS("Tools"),
     /** apps notification */
     APPS("Apps"),
 

--- a/de-lib/src/main/java/org/iplantc/de/client/models/notifications/payload/PayloadTool.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/notifications/payload/PayloadTool.java
@@ -1,0 +1,17 @@
+package org.iplantc.de.client.models.notifications.payload;
+
+import com.google.web.bindery.autobean.shared.AutoBean;
+
+/**
+ * An AutoBean interface containing a tool's information provided within a notification
+ *
+ * @author aramsey
+ */
+public interface PayloadTool {
+
+    @AutoBean.PropertyName("tool_id")
+    String getToolId();
+
+    @AutoBean.PropertyName("tool_name")
+    String getToolName();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/notifications/payload/PayloadToolMsg.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/notifications/payload/PayloadToolMsg.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.client.models.notifications.payload;
+
+import com.google.web.bindery.autobean.shared.AutoBean;
+
+import java.util.List;
+
+/**
+ * An AutoBean interface for a notification regarding tool sharing
+ *
+ * @author aramsey
+ */
+public interface PayloadToolMsg {
+
+    String getAction();
+
+    @AutoBean.PropertyName("tools")
+    List<PayloadTool> getTools();
+}

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/util/NotificationUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/util/NotificationUtil.java
@@ -96,6 +96,10 @@ public class NotificationUtil {
                 GWT.log("TOOLREQUEST  category");
                 msg.setContext(payload.getPayload());
                 break;
+            case TOOLS:
+                GWT.log("TOOL category");
+                msg.setContext(payload.getPayload());
+                break;
 
             default:
                 break;


### PR DESCRIPTION
I was thinking we don't currently have anything to show the user if they click on the notification, but if there are ideas for that, do let me know.  I'm thinking once the UI changes are implemented, this would open up the new [Tools window](https://docs.google.com/document/d/1SEnFQtBirQVoLAaStq1oF3KroK7i6i6YR21grx2qCSE/edit?usp=sharing).