### PR TITLE
CORE-8751 Allow users to create Collaborator Lists

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/gin/BelphegorAppsGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/gin/BelphegorAppsGinModule.java
@@ -34,6 +34,7 @@ import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.gin.ServicesInjector;
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.UserSettings;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.services.FileSystemMetadataServiceFacade;
 import org.iplantc.de.client.services.SearchServiceFacade;
@@ -91,6 +92,11 @@ public class BelphegorAppsGinModule extends AbstractGinModule {
     @Provides
     public FileSystemMetadataServiceFacade createFileSystemMetadataServiceFacade() {
         return ServicesInjector.INSTANCE.getFileSysteMetadataServiceFacade();
+    }
+
+    @Provides
+    public CollaboratorsServiceFacade createCollaboratorServices() {
+        return ServicesInjector.INSTANCE.getCollaboratorsServiceFacade();
     }
 
     @Provides

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/AnalysesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/AnalysesPresenterImpl.java
@@ -40,8 +40,6 @@ import org.iplantc.de.client.models.analysis.support.AnalysisSupportRequestField
 import org.iplantc.de.client.models.diskResources.PermissionValue;
 import org.iplantc.de.client.services.AnalysisServiceFacade;
 import org.iplantc.de.client.services.DEUserSupportServiceFacade;
-import org.iplantc.de.client.util.JsonUtil;
-import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
@@ -225,10 +223,6 @@ public class AnalysesPresenterImpl implements AnalysesView.Presenter,
     AsyncProviderWrapper<AnalysisUserSupportDialog> aSupportDialogProvider;
     @Inject AsyncProviderWrapper<AnalysisStepsInfoDialog> stepsInfoDialogProvider;
 
-    @Inject
-    CollaboratorsUtil collaboratorsUtil;
-    @Inject
-    JsonUtil jsonUtil;
     @Inject
     AnalysisUserSupportDialog.AnalysisUserSupportAppearance userSupportAppearance;
     @Inject

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/sharing/AnalysisSharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/sharing/AnalysisSharingPresenter.java
@@ -21,6 +21,7 @@ import org.iplantc.de.client.models.sharing.SharedResource;
 import org.iplantc.de.client.models.sharing.Sharing;
 import org.iplantc.de.client.models.sharing.UserPermission;
 import org.iplantc.de.client.services.AnalysisServiceFacade;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.sharing.SharingPermissionView;
 import org.iplantc.de.client.sharing.SharingPresenter;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
@@ -107,7 +108,7 @@ public class AnalysisSharingPresenter implements SharingPresenter {
                     usernames.add(userPerm.getUser());
                 }
             }
-            collaboratorsUtil.getUserInfo(usernames, new GetUserInfoCallback(analysisPermsList));
+            collaboratorsServiceFacade.getUserInfo(usernames, new GetUserInfoCallback(analysisPermsList));
         }
 
     }
@@ -115,6 +116,7 @@ public class AnalysisSharingPresenter implements SharingPresenter {
     final AnalysisSharingView sharingView;
     private final SharingPermissionView permissionsPanel;
     private final List<Analysis> selectedAnalysis;
+    private CollaboratorsServiceFacade collaboratorsServiceFacade;
     private Appearance appearance;
     private final CollaboratorsUtil collaboratorsUtil;
     private final AnalysisServiceFacade aService;
@@ -125,6 +127,7 @@ public class AnalysisSharingPresenter implements SharingPresenter {
                                     @Assisted final List<Analysis> selectedAnalysis,
                                     final AnalysisSharingView view,
                                     final CollaboratorsUtil collaboratorsUtil,
+                                    CollaboratorsServiceFacade collaboratorsServiceFacade,
                                     SharingPermissionViewFactory sharingViewFactory,
                                     Appearance appearance) {
 
@@ -132,6 +135,7 @@ public class AnalysisSharingPresenter implements SharingPresenter {
         this.aService = aService;
         this.collaboratorsUtil = collaboratorsUtil;
         this.selectedAnalysis = selectedAnalysis;
+        this.collaboratorsServiceFacade = collaboratorsServiceFacade;
         this.appearance = appearance;
         this.permissionsPanel = sharingViewFactory.create(this, getSelectedResourcesAsMap(this.selectedAnalysis));
         permissionsPanel.hidePermissionColumn();

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/views/dialogs/AnalysisSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/views/dialogs/AnalysisSharingDialog.java
@@ -3,8 +3,6 @@ package org.iplantc.de.analysis.client.views.dialogs;
 import org.iplantc.de.analysis.client.gin.factory.AnalysisSharingPresenterFactory;
 import org.iplantc.de.client.models.analysis.Analysis;
 import org.iplantc.de.client.sharing.SharingPresenter;
-import org.iplantc.de.client.util.JsonUtil;
-import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
 import com.google.common.base.Preconditions;
@@ -18,11 +16,6 @@ import java.util.List;
 public class AnalysisSharingDialog extends IPlantDialog implements SelectHandler {
 
     private SharingPresenter sharingPresenter;
-
-    @Inject
-    CollaboratorsUtil collaboratorsUtil;
-    @Inject
-    JsonUtil jsonUtil;
     private AnalysisSharingPresenterFactory factory;
 
     @Inject

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/sharing/AppSharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/sharing/AppSharingPresenter.java
@@ -21,6 +21,7 @@ import org.iplantc.de.client.models.sharing.SharedResource;
 import org.iplantc.de.client.models.sharing.Sharing;
 import org.iplantc.de.client.models.sharing.UserPermission;
 import org.iplantc.de.client.services.AppUserServiceFacade;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.sharing.SharingPermissionView;
 import org.iplantc.de.client.sharing.SharingPresenter;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
@@ -105,7 +106,7 @@ public class AppSharingPresenter implements SharingPresenter {
                 }
             }
 
-            collaboratorsUtil.getUserInfo(usernames, new GetUserInfoCallback(appPermsList));
+            collaboratorsServiceFacade.getUserInfo(usernames, new GetUserInfoCallback(appPermsList));
         }
 
     }
@@ -114,6 +115,7 @@ public class AppSharingPresenter implements SharingPresenter {
     private final SharingPermissionView permissionsPanel;
     private final List<App> selectedApps;
     private final AppUserServiceFacade appService;
+    private CollaboratorsServiceFacade collaboratorsServiceFacade;
     private Appearance appearance;
     private final CollaboratorsUtil collaboratorsUtil;
     @Inject AppAutoBeanFactory appFactory;
@@ -125,10 +127,12 @@ public class AppSharingPresenter implements SharingPresenter {
                                @Assisted final List<App> selectedApps,
                                final AppSharingView view,
                                final CollaboratorsUtil collaboratorsUtil,
+                               CollaboratorsServiceFacade collaboratorsServiceFacade,
                                SharingPresenter.Appearance appearance,
                                SharingPermissionViewFactory sharingViewFactory) {
 
         this.view = view;
+        this.collaboratorsServiceFacade = collaboratorsServiceFacade;
         this.appearance = appearance;
         this.appService = appService;
         this.collaboratorsUtil = collaboratorsUtil;

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/sharing/dialog/AppSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/sharing/dialog/AppSharingDialog.java
@@ -7,7 +7,6 @@ package org.iplantc.de.apps.client.views.sharing.dialog;
 import org.iplantc.de.apps.client.gin.factory.AppSharingPresenterFactory;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.sharing.SharingPresenter;
-import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
 import com.google.common.base.Preconditions;
@@ -22,9 +21,6 @@ public class AppSharingDialog extends IPlantDialog implements SelectHandler {
 
     private AppSharingPresenterFactory factory;
     private SharingPresenter sharingPresenter;
-
-    @Inject
-    CollaboratorsUtil collaboratorsUtil;
 
     @Inject
     AppSharingDialog(AppSharingPresenterFactory factory) {

--- a/de-lib/src/main/java/org/iplantc/de/client/services/CollaboratorsServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/CollaboratorsServiceFacade.java
@@ -3,8 +3,11 @@
  */
 package org.iplantc.de.client.services;
 
-import com.google.gwt.json.client.JSONObject;
+import org.iplantc.de.client.models.collaborators.Collaborator;
+
 import com.google.gwt.user.client.rpc.AsyncCallback;
+
+import com.sencha.gxt.core.shared.FastMap;
 
 import java.util.List;
 /**
@@ -12,14 +15,14 @@ import java.util.List;
  *
  */
 public interface CollaboratorsServiceFacade {
-    public void searchCollaborators(String term, AsyncCallback<String> callback) ;
+    public void searchCollaborators(String term, AsyncCallback<List<Collaborator>> callback) ;
       
-    public void getCollaborators(AsyncCallback<String> callback);
+    public void getCollaborators(AsyncCallback<List<Collaborator>> callback);
 
-    public void addCollaborators(JSONObject users, AsyncCallback<String> callback);
+    public void addCollaborators(List<Collaborator> collaborators, AsyncCallback<Void> callback);
 
-    public void removeCollaborators(JSONObject users, AsyncCallback<String> callback);
+    public void removeCollaborators(List<Collaborator> users, AsyncCallback<Void> callback);
 
-    public void getUserInfo(List<String> usernames, AsyncCallback<String> callback);
+    public void getUserInfo(List<String> usernames, AsyncCallback<FastMap<Collaborator>> callback);
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/GroupServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/GroupServiceFacade.java
@@ -12,4 +12,7 @@ import java.util.List;
 public interface GroupServiceFacade {
 
     void getGroups(String searchTerm, AsyncCallback<List<Group>> callback);
+
+    void addGroup(Group group, AsyncCallback<Group> callback);
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/CollaboratorListCallbackConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/CollaboratorListCallbackConverter.java
@@ -1,0 +1,30 @@
+package org.iplantc.de.client.services.converters;
+
+import org.iplantc.de.client.models.collaborators.Collaborator;
+import org.iplantc.de.client.models.collaborators.CollaboratorAutoBeanFactory;
+import org.iplantc.de.client.models.collaborators.CollaboratorsList;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.web.bindery.autobean.shared.AutoBean;
+import com.google.web.bindery.autobean.shared.AutoBeanCodex;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public class CollaboratorListCallbackConverter extends AsyncCallbackConverter<String, List<Collaborator>> {
+
+    private CollaboratorAutoBeanFactory factory;
+
+    public CollaboratorListCallbackConverter(AsyncCallback<List<Collaborator>> callback, CollaboratorAutoBeanFactory factory) {
+        super(callback);
+        this.factory = factory;
+    }
+
+    @Override
+    protected List<Collaborator> convertFrom(String object) {
+        AutoBean<CollaboratorsList> decode = AutoBeanCodex.decode(factory, CollaboratorsList.class, object);
+        return decode.as().getCollaborators();
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/FastMapCollaboratorCallbackConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/FastMapCollaboratorCallbackConverter.java
@@ -1,0 +1,44 @@
+package org.iplantc.de.client.services.converters;
+
+import org.iplantc.de.client.models.collaborators.Collaborator;
+import org.iplantc.de.client.models.collaborators.CollaboratorAutoBeanFactory;
+import org.iplantc.de.client.util.JsonUtil;
+
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.web.bindery.autobean.shared.AutoBean;
+import com.google.web.bindery.autobean.shared.AutoBeanCodex;
+
+import com.sencha.gxt.core.shared.FastMap;
+
+/**
+ * @author aramsey
+ */
+public class FastMapCollaboratorCallbackConverter extends AsyncCallbackConverter<String, FastMap<Collaborator>> {
+
+    CollaboratorAutoBeanFactory factory;
+    JsonUtil jsonUtil = JsonUtil.getInstance();
+
+    public FastMapCollaboratorCallbackConverter(AsyncCallback<FastMap<Collaborator>> callback, CollaboratorAutoBeanFactory factory) {
+        super(callback);
+        this.factory = factory;
+    }
+
+    @Override
+    protected FastMap<Collaborator> convertFrom(String object) {
+        FastMap<Collaborator> userResults = new FastMap<>();
+
+        JSONObject users = jsonUtil.getObject(object);
+        if (object != null) {
+
+            for (String username : users.keySet()) {
+                JSONObject userJson = jsonUtil.getObject(users, username);
+                AutoBean<Collaborator> bean = AutoBeanCodex.decode(factory, Collaborator.class,
+                                                                   userJson.toString());
+                userResults.put(username, bean.as());
+            }
+
+        }
+        return userResults;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/GroupCallbackConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/GroupCallbackConverter.java
@@ -1,0 +1,27 @@
+package org.iplantc.de.client.services.converters;
+
+import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.web.bindery.autobean.shared.AutoBean;
+import com.google.web.bindery.autobean.shared.AutoBeanCodex;
+
+/**
+ * @author aramsey
+ */
+public class GroupCallbackConverter extends AsyncCallbackConverter<String, Group> {
+
+    private final GroupAutoBeanFactory factory;
+
+    public GroupCallbackConverter(AsyncCallback<Group> callback, GroupAutoBeanFactory factory) {
+        super(callback);
+        this.factory = factory;
+    }
+
+    @Override
+    protected Group convertFrom(String object) {
+        final AutoBean<Group> decode = AutoBeanCodex.decode(factory, Group.class, object);
+        return decode.as();
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/GroupServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/GroupServiceFacadeImpl.java
@@ -1,12 +1,14 @@
 package org.iplantc.de.client.services.impl;
 
 import static org.iplantc.de.shared.services.BaseServiceCallWrapper.Type.GET;
+import static org.iplantc.de.shared.services.BaseServiceCallWrapper.Type.POST;
 
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
 import org.iplantc.de.client.models.groups.GroupList;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
+import org.iplantc.de.client.services.converters.GroupCallbackConverter;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.shared.services.ServiceCallWrapper;
 
@@ -14,6 +16,8 @@ import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
+import com.google.web.bindery.autobean.shared.AutoBeanUtils;
+import com.google.web.bindery.autobean.shared.Splittable;
 
 import java.util.List;
 import javax.inject.Inject;
@@ -48,4 +52,15 @@ public class GroupServiceFacadeImpl implements GroupServiceFacade {
             }
         });
     }
+
+    @Override
+    public void addGroup(Group group, AsyncCallback<Group> callback) {
+        String address = GROUPS;
+
+        final Splittable encode = AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(group));
+
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, encode.getPayload());
+        deService.getServiceData(wrapper, new GroupCallbackConverter(callback, factory));
+    }
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/sharing/SharingPermissionsPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/sharing/SharingPermissionsPanel.java
@@ -8,7 +8,7 @@ import org.iplantc.de.client.models.sharing.SharedResource;
 import org.iplantc.de.client.models.sharing.Sharing;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
-import org.iplantc.de.collaborators.client.views.ManageCollaboratorsDialog;
+import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.diskResource.client.model.DataSharingKeyProvider;

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -13,8 +13,7 @@ import java.util.List;
  * @author aramsey
  */
 public interface GroupView extends IsWidget,
-                                   GroupNameSelected.GroupNameSelectedHandler,
-                                   GroupNameSelected.HasGroupNameSelectedHandlers {
+                                   GroupNameSelected.GroupNameSelectedHandler {
 
     interface GroupViewAppearance {
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 
 import com.google.gwt.resources.client.ImageResource;
@@ -13,7 +14,8 @@ import java.util.List;
  * @author aramsey
  */
 public interface GroupView extends IsWidget,
-                                   GroupNameSelected.GroupNameSelectedHandler {
+                                   GroupNameSelected.GroupNameSelectedHandler,
+                                   AddGroupSelected.HasAddGroupSelectedHandlers {
 
     interface GroupViewAppearance {
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -50,6 +50,8 @@ public interface GroupView extends IsWidget,
         int groupDetailsHeight();
 
         String groupDetailsHeading(Group group);
+
+        String completeRequiredFieldsError();
     }
 
     void addCollabLists(List<Group> result);

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -4,6 +4,7 @@ import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.client.ui.IsWidget;
 
 import java.util.List;
@@ -35,7 +36,7 @@ public interface GroupView extends IsWidget,
 
         String noCollabLists();
 
-        String groupNameLabel();
+        SafeHtml groupNameLabel();
 
         String groupDescriptionLabel();
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -11,7 +12,9 @@ import java.util.List;
 /**
  * @author aramsey
  */
-public interface GroupView extends IsWidget {
+public interface GroupView extends IsWidget,
+                                   GroupNameSelected.GroupNameSelectedHandler,
+                                   GroupNameSelected.HasGroupNameSelectedHandlers {
 
     interface GroupViewAppearance {
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -4,7 +4,6 @@ import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 
 import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.gwt.user.client.ui.IsWidget;
 
 import java.util.List;
@@ -34,20 +33,21 @@ public interface GroupView extends IsWidget,
 
         String descriptionColumnLabel();
 
-        String groupDialogHeader();
-
-        String groupDialogWidth();
-
-        String groupDialogHeight();
-
         String noCollabLists();
-    }
 
-    interface GroupPresenter {
+        String groupNameLabel();
 
-        void go(HasOneWidget container);
+        String groupDescriptionLabel();
 
-        void setViewDebugId(String baseId);
+        String delete();
+
+        String noCollaborators();
+
+        int groupDetailsWidth();
+
+        int groupDetailsHeight();
+
+        String groupDetailsHeading(Group group);
     }
 
     void addCollabLists(List<Group> result);

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -2,7 +2,6 @@ package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
-import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 
 import com.google.gwt.resources.client.ImageResource;
@@ -17,8 +16,7 @@ import java.util.List;
  * 
  */
 public interface ManageCollaboratorsView extends IsWidget,
-                                                 RemoveCollaboratorSelected.HasRemoveCollaboratorSelectedHandlers,
-                                                 GroupNameSelected.HasGroupNameSelectedHandlers {
+                                                 RemoveCollaboratorSelected.HasRemoveCollaboratorSelectedHandlers {
 
     interface Appearance {
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -91,4 +91,6 @@ public interface ManageCollaboratorsView extends IsWidget,
     MODE getMode();
 
     void addCollaborators(List<Collaborator> models);
+
+    List<Collaborator> getCollaborators();
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 
 import com.google.gwt.resources.client.ImageResource;
@@ -16,7 +17,8 @@ import java.util.List;
  * 
  */
 public interface ManageCollaboratorsView extends IsWidget,
-                                                 RemoveCollaboratorSelected.HasRemoveCollaboratorSelectedHandlers{
+                                                 RemoveCollaboratorSelected.HasRemoveCollaboratorSelectedHandlers,
+                                                 GroupNameSelected.HasGroupNameSelectedHandlers {
 
     interface Appearance {
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 
 import com.google.gwt.resources.client.ImageResource;
@@ -16,7 +17,8 @@ import java.util.List;
  * 
  */
 public interface ManageCollaboratorsView extends IsWidget,
-                                                 RemoveCollaboratorSelected.HasRemoveCollaboratorSelectedHandlers {
+                                                 RemoveCollaboratorSelected.HasRemoveCollaboratorSelectedHandlers,
+                                                 AddGroupSelected.HasAddGroupSelectedHandlers {
 
     interface Appearance {
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/AddGroupSelected.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/AddGroupSelected.java
@@ -1,0 +1,40 @@
+package org.iplantc.de.collaborators.client.events;
+
+import org.iplantc.de.client.models.groups.Group;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class AddGroupSelected extends GwtEvent<AddGroupSelected.AddGroupSelectedHandler> {
+
+    public static interface AddGroupSelectedHandler extends EventHandler {
+        void onAddGroupSelected(AddGroupSelected event);
+    }
+
+    public interface HasAddGroupSelectedHandlers {
+        HandlerRegistration addAddGroupSelectedHandler(AddGroupSelectedHandler handler);
+    }
+
+    public static Type<AddGroupSelectedHandler> TYPE = new Type<AddGroupSelectedHandler>();
+    private Group group;
+
+    public AddGroupSelected(Group group) {
+        this.group = group;
+    }
+
+    public Type<AddGroupSelectedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(AddGroupSelectedHandler handler) {
+        handler.onAddGroupSelected(this);
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/GroupNameSelected.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/GroupNameSelected.java
@@ -1,0 +1,40 @@
+package org.iplantc.de.collaborators.client.events;
+
+import org.iplantc.de.client.models.groups.Group;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class GroupNameSelected extends GwtEvent<GroupNameSelected.GroupNameSelectedHandler> {
+
+    public static interface GroupNameSelectedHandler extends EventHandler {
+        void onGroupNameSelected(GroupNameSelected event);
+    }
+
+    public interface HasGroupNameSelectedHandlers {
+        HandlerRegistration addGroupNameSelectedHandler(GroupNameSelectedHandler handler);
+    }
+
+    public static Type<GroupNameSelectedHandler> TYPE = new Type<GroupNameSelectedHandler>();
+    private Group group;
+
+    public GroupNameSelected(Group group) {
+        this.group = group;
+    }
+
+    public Type<GroupNameSelectedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(GroupNameSelectedHandler handler) {
+        handler.onGroupNameSelected(this);
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/GroupNameSelected.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/GroupNameSelected.java
@@ -4,7 +4,6 @@ import org.iplantc.de.client.models.groups.Group;
 
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
-import com.google.gwt.event.shared.HandlerRegistration;
 
 /**
  * @author aramsey
@@ -13,10 +12,6 @@ public class GroupNameSelected extends GwtEvent<GroupNameSelected.GroupNameSelec
 
     public static interface GroupNameSelectedHandler extends EventHandler {
         void onGroupNameSelected(GroupNameSelected event);
-    }
-
-    public interface HasGroupNameSelectedHandlers {
-        HandlerRegistration addGroupNameSelectedHandler(GroupNameSelectedHandler handler);
     }
 
     public static Type<GroupNameSelectedHandler> TYPE = new Type<GroupNameSelectedHandler>();

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/SaveGroupSelected.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/SaveGroupSelected.java
@@ -1,0 +1,49 @@
+package org.iplantc.de.collaborators.client.events;
+
+import org.iplantc.de.client.models.collaborators.Collaborator;
+import org.iplantc.de.client.models.groups.Group;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public class SaveGroupSelected extends GwtEvent<SaveGroupSelected.SaveGroupSelectedHandler> {
+
+    public static interface SaveGroupSelectedHandler extends EventHandler {
+        void onSaveGroupSelected(SaveGroupSelected event);
+    }
+
+    public interface HasSaveGroupSelectedHandlers {
+        HandlerRegistration addSaveGroupSelectedHandler(SaveGroupSelectedHandler handler);
+    }
+
+    public static Type<SaveGroupSelectedHandler> TYPE = new Type<SaveGroupSelectedHandler>();
+    private Group group;
+    private List<Collaborator> collaboratorList;
+
+    public SaveGroupSelected(Group group, List<Collaborator> collaboratorList) {
+        this.group = group;
+        this.collaboratorList = collaboratorList;
+    }
+
+    public Type<SaveGroupSelectedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(SaveGroupSelectedHandler handler) {
+        handler.onSaveGroupSelected(this);
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public List<Collaborator> getCollaboratorList() {
+        return collaboratorList;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/UserSearchResultSelected.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/UserSearchResultSelected.java
@@ -17,7 +17,7 @@ public class UserSearchResultSelected extends GwtEvent<UserSearchResultSelectedE
 
     public enum USER_SEARCH_EVENT_TAG {
 
-        SHARING, MANAGE, WORKSHOP_ADMIN
+        SHARING, MANAGE, WORKSHOP_ADMIN, GROUP
 
     };
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaboratorsGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaboratorsGinModule.java
@@ -6,7 +6,7 @@ import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.presenter.ManageCollaboratorsPresenter;
 import org.iplantc.de.collaborators.client.views.GroupViewImpl;
-import org.iplantc.de.collaborators.client.views.ManageCollaboratorsDialog;
+import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
 import org.iplantc.de.collaborators.client.views.ManageCollaboratorsViewImpl;
 
 import com.google.gwt.inject.client.AbstractGinModule;

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaboratorsGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaboratorsGinModule.java
@@ -3,10 +3,10 @@ package org.iplantc.de.collaborators.client.gin;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.client.services.impl.GroupServiceFacadeImpl;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.presenter.ManageCollaboratorsPresenter;
 import org.iplantc.de.collaborators.client.views.GroupViewImpl;
 import org.iplantc.de.collaborators.client.views.ManageCollaboratorsDialog;
-import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.views.ManageCollaboratorsViewImpl;
 
 import com.google.gwt.inject.client.AbstractGinModule;

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/models/CollaboratorKeyProvider.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/models/CollaboratorKeyProvider.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package org.iplantc.de.collaborators.client.views;
+package org.iplantc.de.collaborators.client.models;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -11,18 +11,15 @@ import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.CollaboratorsLoadedEvent;
-import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.gin.ManageCollaboratorsViewFactory;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
-import org.iplantc.de.collaborators.client.views.dialogs.GroupDetailsDialog;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.resources.client.messages.I18N;
-import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Joiner;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -40,8 +37,7 @@ import java.util.stream.Stream;
  * 
  */
 public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Presenter,
-                                                     RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler,
-                                                     GroupNameSelected.GroupNameSelectedHandler {
+                                                     RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler {
 
     final class UserSearchResultSelectedEventHandlerImpl implements
                                                                  UserSearchResultSelected.UserSearchResultSelectedEventHandler {
@@ -72,7 +68,6 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     private CollaboratorsServiceFacade collabServiceFacade;
     ManageCollaboratorsView view;
     HandlerRegistration addCollabHandlerRegistration;
-    @Inject AsyncProviderWrapper<GroupDetailsDialog> groupDetailsDialog;
 
     @Inject
     public ManageCollaboratorsPresenter(ManageCollaboratorsViewFactory factory,
@@ -86,7 +81,6 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     void addEventHandlers() {
         addCollabHandlerRegistration = eventBus.addHandler(UserSearchResultSelected.TYPE,
                                                            new UserSearchResultSelectedEventHandlerImpl());
-        view.addGroupNameSelectedHandler(this);
     }
 
     /*
@@ -231,23 +225,5 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
         if (addCollabHandlerRegistration != null) {
             addCollabHandlerRegistration.removeHandler();
         }
-    }
-
-    @Override
-    public void onGroupNameSelected(GroupNameSelected event) {
-        Group group = event.getGroup();
-        showGroupDetailsDialog(group);
-    }
-
-    void showGroupDetailsDialog(Group group) {
-        groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
-            @Override
-            public void onFailure(Throwable caught) {}
-
-            @Override
-            public void onSuccess(GroupDetailsDialog result) {
-                result.show(group);
-            }
-        });
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -11,15 +11,18 @@ import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.CollaboratorsLoadedEvent;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.gin.ManageCollaboratorsViewFactory;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
+import org.iplantc.de.collaborators.client.views.dialogs.GroupDetailsDialog;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.resources.client.messages.I18N;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Joiner;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -37,7 +40,8 @@ import java.util.stream.Stream;
  * 
  */
 public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Presenter,
-                                                     RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler{
+                                                     RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler,
+                                                     GroupNameSelected.GroupNameSelectedHandler {
 
     final class UserSearchResultSelectedEventHandlerImpl implements
                                                                  UserSearchResultSelected.UserSearchResultSelectedEventHandler {
@@ -68,6 +72,7 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     private CollaboratorsServiceFacade collabServiceFacade;
     ManageCollaboratorsView view;
     HandlerRegistration addCollabHandlerRegistration;
+    @Inject AsyncProviderWrapper<GroupDetailsDialog> groupDetailsDialog;
 
     @Inject
     public ManageCollaboratorsPresenter(ManageCollaboratorsViewFactory factory,
@@ -81,6 +86,7 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     void addEventHandlers() {
         addCollabHandlerRegistration = eventBus.addHandler(UserSearchResultSelected.TYPE,
                                                            new UserSearchResultSelectedEventHandlerImpl());
+        view.addGroupNameSelectedHandler(this);
     }
 
     /*
@@ -227,4 +233,21 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
         }
     }
 
+    @Override
+    public void onGroupNameSelected(GroupNameSelected event) {
+        Group group = event.getGroup();
+        showGroupDetailsDialog(group);
+    }
+
+    void showGroupDetailsDialog(Group group) {
+        groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
+            @Override
+            public void onFailure(Throwable caught) {}
+
+            @Override
+            public void onSuccess(GroupDetailsDialog result) {
+                result.show(group);
+            }
+        });
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -10,6 +10,7 @@ import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.CollaboratorsLoadedEvent;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
@@ -22,6 +23,7 @@ import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.resources.client.messages.I18N;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -37,7 +39,8 @@ import java.util.stream.Stream;
  * 
  */
 public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Presenter,
-                                                     RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler {
+                                                     RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler,
+                                                     AddGroupSelected.AddGroupSelectedHandler {
 
     final class UserSearchResultSelectedEventHandlerImpl implements
                                                                  UserSearchResultSelected.UserSearchResultSelectedEventHandler {
@@ -81,6 +84,7 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     void addEventHandlers() {
         addCollabHandlerRegistration = eventBus.addHandler(UserSearchResultSelected.TYPE,
                                                            new UserSearchResultSelectedEventHandlerImpl());
+        view.addAddGroupSelectedHandler(this);
     }
 
     /*
@@ -225,5 +229,24 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
         if (addCollabHandlerRegistration != null) {
             addCollabHandlerRegistration.removeHandler();
         }
+    }
+
+    @Override
+    public void onAddGroupSelected(AddGroupSelected event) {
+        Group group = event.getGroup();
+        if (group == null) {
+            return;
+        }
+        groupServiceFacade.addGroup(group, new AsyncCallback<Group>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                ErrorHandler.post(caught);
+            }
+
+            @Override
+            public void onSuccess(Group result) {
+                view.addCollabLists(Lists.newArrayList(result));
+            }
+        });
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -7,17 +7,21 @@ import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
+import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.collaborators.client.events.CollaboratorsLoadedEvent;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.gin.ManageCollaboratorsViewFactory;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
-import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.resources.client.messages.I18N;
 
+import com.google.common.base.Joiner;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -25,6 +29,8 @@ import com.google.inject.Inject;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author sriram
@@ -44,12 +50,11 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
                    if (!UserInfo.getInstance()
                                 .getUsername()
                                 .equals(collaborator.getUserName())) {
-                       if (!collaboratorsUtil.isCurrentCollaborator(collaborator)) {
+                       if (!collaboratorsUtil.isCurrentCollaborator(collaborator, view.getCollaborators())) {
                            addAsCollaborators(Arrays.asList(collaborator));
                        }
                    } else {
-                       IplantAnnouncer.getInstance()
-                                      .schedule(new ErrorAnnouncementConfig(I18N.DISPLAY.collaboratorSelfAdd()));
+                       announcer.schedule(new ErrorAnnouncementConfig(I18N.DISPLAY.collaboratorSelfAdd()));
                    }
                }
            }
@@ -57,16 +62,20 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
 
     @Inject CollaboratorsUtil collaboratorsUtil;
     @Inject EventBus eventBus;
+    @Inject IplantAnnouncer announcer;
     private ManageCollaboratorsViewFactory factory;
     private GroupServiceFacade groupServiceFacade;
+    private CollaboratorsServiceFacade collabServiceFacade;
     ManageCollaboratorsView view;
     HandlerRegistration addCollabHandlerRegistration;
 
     @Inject
     public ManageCollaboratorsPresenter(ManageCollaboratorsViewFactory factory,
-                                        GroupServiceFacade groupServiceFacade) {
+                                        GroupServiceFacade groupServiceFacade,
+                                        CollaboratorsServiceFacade collabServiceFacade) {
         this.factory = factory;
         this.groupServiceFacade = groupServiceFacade;
+        this.collabServiceFacade = collabServiceFacade;
     }
 
     void addEventHandlers() {
@@ -99,20 +108,32 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
      */
     @Override
     public void addAsCollaborators(final List<Collaborator> models) {
-        collaboratorsUtil.addCollaborators(models, new AsyncCallback<Void>() {
+        collabServiceFacade.addCollaborators(models, new AsyncCallback<Void>() {
 
             @Override
             public void onSuccess(Void result) {
                 // remove added models from search results
                 view.addCollaborators(models);
+                String names = getCollaboratorNames(models);
+
+                announcer.schedule(new SuccessAnnouncementConfig(
+                                       I18N.DISPLAY.collaboratorAddConfirm(names)));
             }
 
             @Override
             public void onFailure(Throwable caught) {
-                ErrorHandler.post(caught);
+                ErrorHandler.post(I18N.ERROR.addCollabErrorMsg(), caught);
             }
         });
 
+    }
+
+    String getCollaboratorNames(List<Collaborator> collaborators) {
+        Stream<Collaborator> stream = collaborators.stream();
+
+        Stream<String> stringStream = stream.map(Collaborator::getUserName);
+        List<String> names = stringStream.collect(Collectors.toList());
+        return Joiner.on(",").join(names);
     }
 
     void updateListView() {
@@ -138,11 +159,13 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     @Override
     public void onRemoveCollaboratorSelected(RemoveCollaboratorSelected event) {
         List<Collaborator> models = event.getCollaborators();
-        collaboratorsUtil.removeCollaborators(models, new AsyncCallback<Void>() {
+        collabServiceFacade.removeCollaborators(models, new AsyncCallback<Void>() {
 
             @Override
             public void onSuccess(Void result) {
                 view.removeCollaborators(models);
+                String names = getCollaboratorNames(models);
+                announcer.schedule(new SuccessAnnouncementConfig(I18N.DISPLAY.collaboratorRemoveConfirm(names)));
 
             }
 
@@ -164,7 +187,7 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     @Override
     public void loadCurrentCollaborators() {
         view.mask(null);
-        collaboratorsUtil.getCollaborators(new AsyncCallback<Void>() {
+        collabServiceFacade.getCollaborators(new AsyncCallback<List<Collaborator>>() {
 
             @Override
             public void onFailure(Throwable caught) {
@@ -172,9 +195,10 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
             }
 
             @Override
-            public void onSuccess(Void result) {
+            public void onSuccess(List<Collaborator> result) {
                 view.unmask();
-                view.loadData(collaboratorsUtil.getCurrentCollaborators());
+                view.loadData(result);
+                eventBus.fireEvent(new CollaboratorsLoadedEvent());
             }
 
         });

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -245,8 +245,12 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
 
             @Override
             public void onSuccess(Group result) {
-                view.addCollabLists(Lists.newArrayList(result));
+                view.addCollabLists(getGroupList(result));
             }
         });
+    }
+
+    List<Group> getGroupList(Group result) {
+        return Lists.newArrayList(result);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/CollaboratorsUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/CollaboratorsUtil.java
@@ -3,170 +3,46 @@
  */
 package org.iplantc.de.collaborators.client.util;
 
-import org.iplantc.de.client.events.EventBus;
-import org.iplantc.de.client.gin.ServicesInjector;
-import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.collaborators.CollaboratorAutoBeanFactory;
-import org.iplantc.de.client.models.collaborators.CollaboratorsList;
-import org.iplantc.de.client.services.CollaboratorsServiceFacade;
-import org.iplantc.de.client.util.JsonUtil;
-import org.iplantc.de.commons.client.ErrorHandler;
-import org.iplantc.de.collaborators.client.events.CollaboratorsLoadedEvent;
-import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
-import org.iplantc.de.commons.client.info.IplantAnnouncer;
-import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
-import org.iplantc.de.resources.client.messages.I18N;
 
 import com.google.gwt.core.shared.GWT;
-import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
-import com.google.gwt.safehtml.shared.SafeHtmlUtils;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
-
-import com.sencha.gxt.core.shared.FastMap;
 
 import java.util.List;
 
 /**
- * FIXME Utility classes shouldn't be calling service facades. Factor this class out.
  * @author sriram
  *
  */
 public class CollaboratorsUtil {
 
-    private List<Collaborator> currentCollaborators;
-    private List<Collaborator> searchResults;
     private final CollaboratorAutoBeanFactory factory = GWT.create(CollaboratorAutoBeanFactory.class);
-    private final CollaboratorsServiceFacade facade = ServicesInjector.INSTANCE.getCollaboratorsServiceFacade();
-    private final JsonUtil jsonUtil = JsonUtil.getInstance();
-
     private static CollaboratorsUtil INSTANCE;
 
     CollaboratorsUtil() {
-
-        currentCollaborators = null;
-        searchResults = null;
     }
 
-    public static CollaboratorsUtil getInstance(){
-        if(INSTANCE == null) {
+    public static CollaboratorsUtil getInstance() {
+        if (INSTANCE == null) {
             INSTANCE = new CollaboratorsUtil();
         }
 
         return INSTANCE;
     }
 
-    private List<Collaborator> parseResults(String result) {
-        AutoBean<CollaboratorsList> bean = AutoBeanCodex
-                .decode(factory, CollaboratorsList.class, result);
-        JSONObject obj = jsonUtil.getObject(result);
-        return bean.as().getCollaborators();
-    }
-
-    /**
-     * @return the currentCollaborators
-     */
-    public List<Collaborator> getCurrentCollaborators() {
-        return currentCollaborators;
-    }
-
-    /**
-     * @param currentCollaborators the currentCollaborators to set
-     */
-    public void setCurrentCollaborators(List<Collaborator> currentCollaborators) {
-        this.currentCollaborators = currentCollaborators;
-    }
-
-    public void getCollaborators(final AsyncCallback<Void> superCallback) {
-        if (getCurrentCollaborators() == null) {
-            facade.getCollaborators(new GetCollaboratorsCallback(superCallback));
-        } else {
-            superCallback.onSuccess(null);
-        }
-    }
-
-    public void search(final String term, final AsyncCallback<Void> superCallback) {
-        facade.searchCollaborators(term, new SearchCallback(superCallback));
-    }
-
-    public boolean checkCurrentUser(Collaborator model) {
-        return model.getUserName().equalsIgnoreCase(UserInfo.getInstance().getUsername());
-
-    }
-
-    /**
-     * @return the searchResults
-     */
-    public List<Collaborator> getSearchResults() {
-        return searchResults;
-    }
-
-    public Collaborator findCollaboratorByUserName(String userName) {
-        List<Collaborator> collabs = getCurrentCollaborators();
-        for (Collaborator c : collabs) {
-            if (c.getUserName().equals(userName)) {
-                return c;
-            }
-        }
-        return getDummyCollaborator(userName);
-    }
-
     public Collaborator getDummyCollaborator(String userName) {
         JSONObject obj = new JSONObject();
         obj.put("username", new JSONString(userName));
-        AutoBean<Collaborator> bean = AutoBeanCodex.decode(factory, Collaborator.class,
-                obj.toString());
+        AutoBean<Collaborator> bean = AutoBeanCodex.decode(factory, Collaborator.class, obj.toString());
         return bean.as();
     }
 
-    public boolean isCollaborator(Collaborator c) {
-        return getCurrentCollaborators().contains(c);
-    }
-
-    public void getUserInfo(List<String> usernames,
-            final AsyncCallback<FastMap<Collaborator>> superCallback) {
-        facade.getUserInfo(usernames, new GetUserInfoCallback(superCallback));
-    }
-
-    /**
-     * @param searchResults the searchResults to set
-     */
-    public void setSearchResults(List<Collaborator> searchResults) {
-        this.searchResults = searchResults;
-    }
-
-    private final class GetCollaboratorsCallback implements AsyncCallback<String> {
-        private final AsyncCallback<Void> callback;
-
-        public GetCollaboratorsCallback(final AsyncCallback<Void> callback) {
-            this.callback = callback;
-        }
-
-        @Override
-        public void onFailure(Throwable caught) {
-            ErrorHandler.post(caught);
-            if (callback != null) {
-                callback.onFailure(caught);
-            }
-        }
-
-        @Override
-        public void onSuccess(String result) {
-            setCurrentCollaborators(parseResults(result));
-            CollaboratorsLoadedEvent event = new CollaboratorsLoadedEvent();
-            EventBus.getInstance().fireEvent(event);
-            if (callback != null) {
-                callback.onSuccess(null);
-            }
-        }
-    }
-
-    public boolean isCurrentCollaborator(Collaborator c) {
-        for (Collaborator current : getCurrentCollaborators()) {
+    public boolean isCurrentCollaborator(Collaborator c, List<Collaborator> collaborators) {
+        for (Collaborator current : collaborators) {
             if (current.getUserName().equals(c.getUserName())) {
                 return true;
             }
@@ -174,175 +50,4 @@ public class CollaboratorsUtil {
 
         return false;
     }
-
-    public void addCollaborators(final List<Collaborator> models,
-            final AsyncCallback<Void> supercallback) {
-        JSONObject obj = buildJSONModel(models);
-        facade.addCollaborators(obj, new AddCollaboratorCallback(models, supercallback));
-    }
-
-    public void removeCollaborators(final List<Collaborator> models,
-            final AsyncCallback<Void> supercallback) {
-        JSONObject obj = buildJSONModel(models);
-        facade.removeCollaborators(obj, new RemoveCollaboratorCallback(models, supercallback));
-    }
-
-    private JSONObject buildJSONModel(final List<Collaborator> models) {
-        JSONArray arr = new JSONArray();
-        int count = 0;
-        for (Collaborator model : models) {
-            JSONObject user = new JSONObject();
-            user.put("username", new JSONString(model.getUserName()));
-            arr.set(count++, user);
-        }
-
-        JSONObject obj = new JSONObject();
-        obj.put("users", arr);
-        return obj;
-    }
-
-    private final class SearchCallback implements AsyncCallback<String> {
-
-        private final AsyncCallback<Void> callback;
-
-        public SearchCallback(final AsyncCallback<Void> callback) {
-            this.callback = callback;
-        }
-
-        @Override
-        public void onFailure(Throwable caught) {
-            ErrorHandler.post(caught);
-            if (callback != null) {
-                callback.onFailure(caught);
-            }
-        }
-
-        @Override
-        public void onSuccess(String result) {
-            setSearchResults(parseResults(result));
-            if (callback != null) {
-                callback.onSuccess(null);
-            }
-        }
-    }
-
-    private final class AddCollaboratorCallback implements AsyncCallback<String> {
-        private final AsyncCallback<Void> callback;
-        private final List<Collaborator> models;
-
-        public AddCollaboratorCallback(final List<Collaborator> models,
-                final AsyncCallback<Void> callback) {
-            this.callback = callback;
-            this.models = models;
-        }
-
-        @Override
-        public void onFailure(Throwable caught) {
-            ErrorHandler.post(I18N.ERROR.addCollabErrorMsg(), caught);
-            if (callback != null) {
-                callback.onFailure(caught);
-            }
-
-        }
-
-        @Override
-        public void onSuccess(String result) {
-            getCurrentCollaborators().addAll(models);
-            StringBuilder builder = new StringBuilder();
-            for (Collaborator c : models) {
-                builder.append(c.getUserName() + ",");
-            }
-
-            if (builder.length() > 0) {
-                builder.deleteCharAt(builder.length() - 1);
-            }
-
-            IplantAnnouncer.getInstance()
-                           .schedule(new SuccessAnnouncementConfig(
-                    I18N.DISPLAY.collaboratorAddConfirm(builder.toString())));
-            if (callback != null) {
-                callback.onSuccess(null);
-            }
-        }
-    }
-
-    private class GetUserInfoCallback implements AsyncCallback<String> {
-
-        private final AsyncCallback<FastMap<Collaborator>> superCallback;
-
-        public GetUserInfoCallback(AsyncCallback<FastMap<Collaborator>> superCallback) {
-            this.superCallback = superCallback;
-        }
-
-        @Override
-        public void onFailure(Throwable caught) {
-            if (superCallback != null) {
-                superCallback.onFailure(caught);
-            }
-        }
-
-        @Override
-        public void onSuccess(String result) {
-            if (superCallback != null) {
-                FastMap<Collaborator> userResults = new FastMap<>();
-
-                JSONObject users = jsonUtil.getObject(result);
-                if (result != null) {
-
-                    for (String username : users.keySet()) {
-                        JSONObject userJson = jsonUtil.getObject(users, username);
-                        AutoBean<Collaborator> bean = AutoBeanCodex.decode(factory, Collaborator.class,
-                                userJson.toString());
-                        userResults.put(username, bean.as());
-                    }
-
-                }
-
-                superCallback.onSuccess(userResults);
-            }
-        }
-
-    }
-
-    private final class RemoveCollaboratorCallback implements AsyncCallback<String> {
-        private final AsyncCallback<Void> callback;
-        private final List<Collaborator> models;
-
-        public RemoveCollaboratorCallback(final List<Collaborator> models,
-                final AsyncCallback<Void> callback) {
-            this.callback = callback;
-            this.models = models;
-        }
-
-        @Override
-        public void onFailure(Throwable caught) {
-            ErrorHandler.post(I18N.ERROR.removeCollabErrorMsg(), caught);
-            if (callback != null) {
-                callback.onFailure(caught);
-            }
-
-        }
-
-        @Override
-        public void onSuccess(String result) {
-            StringBuilder builder = new StringBuilder();
-            for (Collaborator c : models) {
-                builder.append(c.getUserName() + ",");
-                getCurrentCollaborators().remove(c);
-
-            }
-
-            if (builder.length() > 0) {
-                builder.deleteCharAt(builder.length() - 1);
-            }
-
-            IplantAnnouncer.getInstance()
-                           .schedule(new SuccessAnnouncementConfig(I18N.DISPLAY.collaboratorRemoveConfirm(builder.toString())));
-            if (callback != null) {
-                callback.onSuccess(null);
-            }
-
-        }
-    }
-
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/UserSearchRPCProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/UserSearchRPCProxy.java
@@ -3,9 +3,11 @@
  */
 package org.iplantc.de.collaborators.client.util;
 
+import org.iplantc.de.client.gin.ServicesInjector;
 import org.iplantc.de.client.models.collaborators.Collaborator;
-import org.iplantc.de.commons.client.ErrorHandler;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.collaborators.client.util.UserSearchField.UsersLoadConfig;
+import org.iplantc.de.commons.client.ErrorHandler;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
@@ -13,17 +15,19 @@ import com.sencha.gxt.data.client.loader.RpcProxy;
 import com.sencha.gxt.data.shared.loader.PagingLoadResult;
 import com.sencha.gxt.data.shared.loader.PagingLoadResultBean;
 
+import java.util.List;
+
 /**
  * @author sriram
  *
  */
 public class UserSearchRPCProxy extends RpcProxy<UsersLoadConfig, PagingLoadResult<Collaborator>> {
 
-    private final CollaboratorsUtil collaboratorsUtil;
+    CollaboratorsServiceFacade serviceFacade;
     private String lastQueryText = ""; //$NON-NLS-1$
 
     public UserSearchRPCProxy() {
-        this.collaboratorsUtil = CollaboratorsUtil.getInstance();
+        serviceFacade = ServicesInjector.INSTANCE.getCollaboratorsServiceFacade();
     }
 
     public String getLastQueryText() {
@@ -41,11 +45,10 @@ public class UserSearchRPCProxy extends RpcProxy<UsersLoadConfig, PagingLoadResu
             return;
         }
 
-        collaboratorsUtil.search(lastQueryText, new AsyncCallback<Void>() {
+        serviceFacade.searchCollaborators(lastQueryText, new AsyncCallback<List<Collaborator>>() {
             @Override
-            public void onSuccess(Void result) {
-                callback.onSuccess(new PagingLoadResultBean<>(collaboratorsUtil
-                        .getSearchResults(), collaboratorsUtil.getSearchResults().size(), 0));
+            public void onSuccess(List<Collaborator> result) {
+                callback.onSuccess(new PagingLoadResultBean<>(result, result.size(), 0));
             }
 
             @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
@@ -107,6 +107,15 @@ public class GroupDetailsView extends Composite {
     protected void onEnsureDebugId(String baseID) {
         super.onEnsureDebugId(baseID);
         this.baseID = baseID;
+
+        groupNameLabel.ensureDebugId(baseID + CollaboratorsModule.Ids.GROUP_NAME_LABEL);
+        groupDescLabel.ensureDebugId(baseID + CollaboratorsModule.Ids.GROUP_DESC_LABEL);
+        groupName.ensureDebugId(baseID + CollaboratorsModule.Ids.GROUP_NAME);
+        groupDesc.ensureDebugId(baseID + CollaboratorsModule.Ids.GROUP_DESC);
+        searchField.asWidget().ensureDebugId(baseID + CollaboratorsModule.Ids.SEARCH_LIST);
+        toolbar.ensureDebugId(baseID + CollaboratorsModule.Ids.GROUP_TOOLBAR);
+        deleteBtn.ensureDebugId(baseID + CollaboratorsModule.Ids.GROUP_DELETE_BTN);
+        grid.ensureDebugId(baseID + CollaboratorsModule.Ids.GROUP_GRID);
     }
 
     void setGridCheckBoxDebugIds() {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
@@ -164,6 +164,10 @@ public class GroupDetailsView extends Composite implements Editor<Group> {
         return editorDriver.flush();
     }
 
+    public boolean isValid() {
+        return nameEditor.isValid();
+    }
+
     public List<Collaborator> getCollaborators() {
         return listStore.getAll();
     }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
@@ -1,0 +1,104 @@
+package org.iplantc.de.collaborators.client.views;
+
+import org.iplantc.de.client.models.collaborators.Collaborator;
+import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
+import org.iplantc.de.collaborators.client.models.CollaboratorKeyProvider;
+import org.iplantc.de.collaborators.client.util.UserSearchField;
+import org.iplantc.de.collaborators.shared.CollaboratorsModule;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiFactory;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+
+import com.sencha.gxt.core.client.IdentityValueProvider;
+import com.sencha.gxt.core.client.Style;
+import com.sencha.gxt.data.shared.ListStore;
+import com.sencha.gxt.widget.core.client.Composite;
+import com.sencha.gxt.widget.core.client.button.TextButton;
+import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
+import com.sencha.gxt.widget.core.client.form.FieldLabel;
+import com.sencha.gxt.widget.core.client.form.TextArea;
+import com.sencha.gxt.widget.core.client.form.TextField;
+import com.sencha.gxt.widget.core.client.grid.CheckBoxSelectionModel;
+import com.sencha.gxt.widget.core.client.grid.ColumnModel;
+import com.sencha.gxt.widget.core.client.grid.Grid;
+import com.sencha.gxt.widget.core.client.toolbar.ToolBar;
+
+
+/**
+ * @author aramsey
+ */
+public class GroupDetailsView extends Composite {
+
+    interface GroupDetailsViewUiBinder extends UiBinder<Widget, GroupDetailsView> {
+    }
+
+    static GroupDetailsViewUiBinder uiBinder = GWT.create(GroupDetailsViewUiBinder.class);
+
+    @UiField FieldLabel groupNameLabel;
+    @UiField FieldLabel groupDescLabel;
+    @UiField TextField groupName;
+    @UiField TextArea groupDesc;
+    @UiField(provided = true) UserSearchField searchField;
+    @UiField ToolBar toolbar;
+    @UiField TextButton deleteBtn;
+    @UiField ListStore<Collaborator> listStore;
+    @UiField Grid<Collaborator> grid;
+    @UiField ColumnModel<Collaborator> cm;
+    @UiField(provided = true) GroupView.GroupViewAppearance appearance;
+
+    private CheckBoxSelectionModel<Collaborator> checkBoxModel;
+    String baseID;
+
+    @Inject
+    public GroupDetailsView(GroupView.GroupViewAppearance appearance) {
+        this.appearance = appearance;
+        searchField = new UserSearchField(UserSearchResultSelected.USER_SEARCH_EVENT_TAG.GROUP);
+        checkBoxModel = new CheckBoxSelectionModel<>(new IdentityValueProvider<Collaborator>());
+        initWidget(uiBinder.createAndBindUi(this));
+
+        checkBoxModel.setSelectionMode(Style.SelectionMode.MULTI);
+        grid.setSelectionModel(checkBoxModel);
+        grid.getView().setEmptyText(appearance.noCollaborators());
+        grid.addViewReadyHandler(new ViewReadyEvent.ViewReadyHandler() {
+            @Override
+            public void onViewReady(ViewReadyEvent event) {
+                setGridCheckBoxDebugIds();
+            }
+        });
+    }
+
+    @UiFactory
+    ListStore<Collaborator> createListStore() {
+        return new ListStore<Collaborator>(new CollaboratorKeyProvider());
+    }
+
+    @UiFactory
+    ColumnModel<Collaborator> buildColumnModel() {
+        return new CollaboratorsColumnModel(checkBoxModel);
+    }
+
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+        this.baseID = baseID;
+    }
+
+    void setGridCheckBoxDebugIds() {
+        for (int i = 0; i < listStore.size(); i++) {
+            grid.getView().getCell(i, 0).setId(baseID + CollaboratorsModule.Ids.CHECKBOX_ITEM + i);
+        }
+    }
+
+    public void edit(Group group) {
+        if (group != null) {
+            groupName.setText(group.getName());
+            groupDesc.setText(group.getDescription());
+        }
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
@@ -29,6 +29,7 @@ import com.sencha.gxt.widget.core.client.form.TextField;
 import com.sencha.gxt.widget.core.client.grid.CheckBoxSelectionModel;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
+import com.sencha.gxt.widget.core.client.selection.SelectionChangedEvent;
 import com.sencha.gxt.widget.core.client.toolbar.ToolBar;
 
 
@@ -86,6 +87,12 @@ public class GroupDetailsView extends Composite {
             @Override
             public void onViewReady(ViewReadyEvent event) {
                 setGridCheckBoxDebugIds();
+            }
+        });
+        grid.getSelectionModel().addSelectionChangedHandler(new SelectionChangedEvent.SelectionChangedHandler<Collaborator>() {
+            @Override
+            public void onSelectionChanged(SelectionChangedEvent<Collaborator> event) {
+                deleteBtn.setEnabled(!event.getSelection().isEmpty());
             }
         });
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
@@ -3,6 +3,7 @@ package org.iplantc.de.collaborators.client.views;
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.models.CollaboratorKeyProvider;
@@ -69,6 +70,7 @@ public class GroupDetailsView extends Composite {
     @UiField ColumnModel<Collaborator> cm;
     @UiField(provided = true) GroupView.GroupViewAppearance appearance;
 
+    private GroupAutoBeanFactory factory;
     EventBus eventBus;
     HandlerRegistration handlerRegistration;
 
@@ -77,8 +79,10 @@ public class GroupDetailsView extends Composite {
 
     @Inject
     public GroupDetailsView(GroupView.GroupViewAppearance appearance,
+                            GroupAutoBeanFactory factory,
                             EventBus eventBus) {
         this.appearance = appearance;
+        this.factory = factory;
         this.eventBus = eventBus;
         searchField = new UserSearchField(UserSearchResultSelected.USER_SEARCH_EVENT_TAG.GROUP);
         checkBoxModel = new CheckBoxSelectionModel<>(new IdentityValueProvider<Collaborator>());
@@ -154,5 +158,16 @@ public class GroupDetailsView extends Composite {
 
     public void clearHandlers() {
         handlerRegistration.removeHandler();
+    }
+
+    public Group getGroup() {
+        Group group = factory.getGroup().as();
+        group.setName(groupName.getCurrentValue());
+        group.setDescription(groupDesc.getCurrentValue());
+        return group;
+    }
+
+    public List<Collaborator> getCollaborators() {
+        return listStore.getAll();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
@@ -80,6 +80,8 @@ public class GroupDetailsView extends Composite {
         checkBoxModel = new CheckBoxSelectionModel<>(new IdentityValueProvider<Collaborator>());
         initWidget(uiBinder.createAndBindUi(this));
 
+        groupNameLabel.setHTML(appearance.groupNameLabel());
+
         checkBoxModel.setSelectionMode(Style.SelectionMode.MULTI);
         grid.setSelectionModel(checkBoxModel);
         grid.getView().setEmptyText(appearance.noCollaborators());

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.java
@@ -14,6 +14,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -22,6 +23,7 @@ import com.sencha.gxt.core.client.Style;
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.form.FieldLabel;
 import com.sencha.gxt.widget.core.client.form.TextArea;
@@ -31,6 +33,8 @@ import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
 import com.sencha.gxt.widget.core.client.selection.SelectionChangedEvent;
 import com.sencha.gxt.widget.core.client.toolbar.ToolBar;
+
+import java.util.List;
 
 
 /**
@@ -100,6 +104,14 @@ public class GroupDetailsView extends Composite {
 
         handlerRegistration =
                 eventBus.addHandler(UserSearchResultSelected.TYPE, new CollaboratorSelectedHandler());
+    }
+
+    @UiHandler("deleteBtn")
+    void onDeleteButtonSelected(SelectEvent event) {
+        List<Collaborator> selectedCollab = grid.getSelectionModel().getSelectedItems();
+        if (selectedCollab != null && !selectedCollab.isEmpty()) {
+            selectedCollab.forEach(collaborator -> listStore.remove(collaborator));
+        }
     }
 
     @UiFactory

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.ui.xml
@@ -1,0 +1,103 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
+             xmlns:grid="urn:import:com.sencha.gxt.widget.core.client.grid"
+             xmlns:button="urn:import:com.sencha.gxt.widget.core.client.button"
+             xmlns:toolbar="urn:import:com.sencha.gxt.widget.core.client.toolbar"
+             xmlns:form="urn:import:com.sencha.gxt.widget.core.client.form"
+             xmlns:userSearch="urn:import:org.iplantc.de.collaborators.client.util"
+>
+
+    <ui:with field="appearance"
+             type="org.iplantc.de.collaborators.client.GroupView.GroupViewAppearance"/>
+
+    <!-- Main Panel -->
+    <ui:with field="listStore" type="com.sencha.gxt.data.shared.ListStore"/>
+    <ui:with field="cm"
+             type="com.sencha.gxt.widget.core.client.grid.ColumnModel"/>
+    <ui:with field="gridView"
+             type="com.sencha.gxt.widget.core.client.grid.GridView">
+        <ui:attributes forceFit="true" autoFill="true"/>
+    </ui:with>
+
+    <ui:with field="layoutData"
+             type="com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer.VerticalLayoutData">
+        <ui:attributes width="1" height="-1" margins="{margins}"/>
+    </ui:with>
+    <ui:with field="margins"
+             type="com.sencha.gxt.core.client.util.Margins">
+        <ui:attributes top="5" right="5" bottom="5" left="5"/>
+    </ui:with>
+
+    <ui:with field="northData"
+             type="com.sencha.gxt.widget.core.client.container.BorderLayoutContainer.BorderLayoutData">
+        <ui:attributes size="150"
+                       hidden="false" margins="{northMargins}"/>
+    </ui:with>
+    <ui:with field="northMargins" type="com.sencha.gxt.core.client.util.Margins">
+        <ui:attributes top="5" right="0" bottom="0" left="5"/>
+    </ui:with>
+
+    <ui:with field="centerData"
+             type="com.sencha.gxt.widget.core.client.container.MarginData">
+        <ui:attributes margins="{centerMargins}"/>
+    </ui:with>
+    <ui:with field="centerMargins" type="com.sencha.gxt.core.client.util.Margins">
+        <ui:attributes top="0" right="0" bottom="0" left="0"/>
+    </ui:with>
+
+    <ui:with field="middleData"
+             type="com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer.VerticalLayoutData">
+        <ui:attributes width="1" height="1"/>
+    </ui:with>
+
+    <container:BorderLayoutContainer ui:field="con" borders="true">
+        <!-- This is the tool bar -->
+        <container:north layoutData="{northData}">
+            <container:VerticalLayoutContainer>
+                <container:child layoutData="{layoutData}">
+                    <form:FieldLabel ui:field="groupNameLabel"
+                                     text="{appearance.groupNameLabel}">
+                        <form:widget>
+                            <form:TextField ui:field="groupName"/>
+                        </form:widget>
+                    </form:FieldLabel>
+                </container:child>
+                <container:child layoutData="{layoutData}">
+                    <form:FieldLabel ui:field="groupDescLabel"
+                                     text="{appearance.groupDescriptionLabel}">
+                        <form:widget>
+                            <form:TextArea ui:field="groupDesc"/>
+                        </form:widget>
+                    </form:FieldLabel>
+                </container:child>
+                <container:child layoutData="{layoutData}">
+                    <userSearch:UserSearchField ui:field="searchField"/>
+                </container:child>
+            </container:VerticalLayoutContainer>
+        </container:north>
+        <!-- This is the main panel -->
+        <container:center layoutData="{centerData}">
+            <container:VerticalLayoutContainer>
+                <container:child>
+                    <toolbar:ToolBar height="30" ui:field="toolbar">
+                        <button:TextButton ui:field="deleteBtn"
+                                           text="{appearance.delete}"
+                                           icon="{appearance.deleteIcon}"
+                                           enabled="false"/>
+                    </toolbar:ToolBar>
+                </container:child>
+                <container:child layoutData="{middleData}">
+                    <grid:Grid ui:field="grid"
+                               cm="{cm}"
+                               store="{listStore}"
+                               view="{gridView}"
+                               loadMask="true"
+                               columnReordering="true"
+                               borders="false">
+                    </grid:Grid>
+                </container:child>
+            </container:VerticalLayoutContainer>
+        </container:center>
+    </container:BorderLayoutContainer>
+</ui:UiBinder>

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.ui.xml
@@ -58,7 +58,7 @@
                 <container:child layoutData="{layoutData}">
                     <form:FieldLabel ui:field="groupNameLabel">
                         <form:widget>
-                            <form:TextField ui:field="groupName"
+                            <form:TextField ui:field="nameEditor"
                                             allowBlank="false"/>
                         </form:widget>
                     </form:FieldLabel>
@@ -67,7 +67,7 @@
                     <form:FieldLabel ui:field="groupDescLabel"
                                      text="{appearance.groupDescriptionLabel}">
                         <form:widget>
-                            <form:TextArea ui:field="groupDesc"/>
+                            <form:TextArea ui:field="descriptionEditor"/>
                         </form:widget>
                     </form:FieldLabel>
                 </container:child>

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsView.ui.xml
@@ -56,10 +56,10 @@
         <container:north layoutData="{northData}">
             <container:VerticalLayoutContainer>
                 <container:child layoutData="{layoutData}">
-                    <form:FieldLabel ui:field="groupNameLabel"
-                                     text="{appearance.groupNameLabel}">
+                    <form:FieldLabel ui:field="groupNameLabel">
                         <form:widget>
-                            <form:TextField ui:field="groupName"/>
+                            <form:TextField ui:field="groupName"
+                                            allowBlank="false"/>
                         </form:widget>
                     </form:FieldLabel>
                 </container:child>

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -5,16 +5,19 @@ import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.models.GroupProperties;
 import org.iplantc.de.collaborators.client.views.cells.GroupNameCell;
+import org.iplantc.de.collaborators.client.views.dialogs.GroupDetailsDialog;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
 
 import com.sencha.gxt.core.client.IdentityValueProvider;
 import com.sencha.gxt.core.client.Style;
@@ -28,7 +31,6 @@ import com.sencha.gxt.widget.core.client.grid.Grid;
 import com.sencha.gxt.widget.core.client.toolbar.ToolBar;
 
 import java.util.List;
-import javax.inject.Inject;
 
 /**
  * @author aramsey
@@ -46,6 +48,8 @@ public class GroupViewImpl extends Composite implements GroupView {
     @UiField ListStore<Group> listStore;
     @UiField ColumnModel<Group> cm;
     @UiField(provided = true) GroupViewAppearance appearance;
+
+    @Inject AsyncProviderWrapper<GroupDetailsDialog> groupDetailsDialog;
 
     private final GroupProperties props;
 
@@ -97,16 +101,29 @@ public class GroupViewImpl extends Composite implements GroupView {
 
     @UiHandler("addGroup")
     void addGroupSelected(SelectEvent event) {
-        fireEvent(new GroupNameSelected(null));
+        groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
+            @Override
+            public void onFailure(Throwable caught) {}
+
+            @Override
+            public void onSuccess(GroupDetailsDialog result) {
+                result.show(null);
+
+            }
+        });
     }
 
     @Override
     public void onGroupNameSelected(GroupNameSelected event) {
-        fireEvent(new GroupNameSelected(event.getGroup()));
-    }
+        Group group = event.getGroup();
+        groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
+            @Override
+            public void onFailure(Throwable caught) {}
 
-    @Override
-    public HandlerRegistration addGroupNameSelectedHandler(GroupNameSelected.GroupNameSelectedHandler handler) {
-        return addHandler(handler, GroupNameSelected.TYPE);
+            @Override
+            public void onSuccess(GroupDetailsDialog result) {
+                result.show(group);
+            }
+        });
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -110,7 +110,7 @@ public class GroupViewImpl extends Composite implements GroupView {
 
             @Override
             public void onSuccess(GroupDetailsDialog result) {
-                result.show(null);
+                result.show();
                 result.addSaveGroupSelectedHandler(new SaveGroupSelected.SaveGroupSelectedHandler() {
                     @Override
                     public void onSaveGroupSelected(SaveGroupSelected event) {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -2,7 +2,9 @@ package org.iplantc.de.collaborators.client.views;
 
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
+import org.iplantc.de.collaborators.client.events.SaveGroupSelected;
 import org.iplantc.de.collaborators.client.models.GroupProperties;
 import org.iplantc.de.collaborators.client.views.cells.GroupNameCell;
 import org.iplantc.de.collaborators.client.views.dialogs.GroupDetailsDialog;
@@ -11,6 +13,7 @@ import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
@@ -108,7 +111,12 @@ public class GroupViewImpl extends Composite implements GroupView {
             @Override
             public void onSuccess(GroupDetailsDialog result) {
                 result.show(null);
-
+                result.addSaveGroupSelectedHandler(new SaveGroupSelected.SaveGroupSelectedHandler() {
+                    @Override
+                    public void onSaveGroupSelected(SaveGroupSelected event) {
+                        fireEvent(new AddGroupSelected(event.getGroup()));
+                    }
+                });
             }
         });
     }
@@ -125,5 +133,10 @@ public class GroupViewImpl extends Composite implements GroupView {
                 result.show(group);
             }
         });
+    }
+
+    @Override
+    public HandlerRegistration addAddGroupSelectedHandler(AddGroupSelected.AddGroupSelectedHandler handler) {
+        return addHandler(handler, AddGroupSelected.TYPE);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -3,6 +3,7 @@ package org.iplantc.de.collaborators.client.views;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.models.GroupProperties;
+import org.iplantc.de.collaborators.client.views.cells.GroupNameCell;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
 
 import com.google.common.collect.Lists;
@@ -65,6 +66,7 @@ public class GroupViewImpl extends Composite implements GroupView {
         ColumnConfig<Group, String> descriptionCol = new ColumnConfig<>(props.description(),
                                                                         appearance.descriptionColumnWidth(),
                                                                         appearance.descriptionColumnLabel());
+        nameCol.setCell(new GroupNameCell(this));
         columns.add(nameCol);
         columns.add(descriptionCol);
         return new ColumnModel<>(columns);

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -2,15 +2,18 @@ package org.iplantc.de.collaborators.client.views;
 
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.models.GroupProperties;
 import org.iplantc.de.collaborators.client.views.cells.GroupNameCell;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Widget;
 
 import com.sencha.gxt.core.client.IdentityValueProvider;
@@ -18,6 +21,7 @@ import com.sencha.gxt.core.client.Style;
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -89,5 +93,20 @@ public class GroupViewImpl extends Composite implements GroupView {
     @Override
     public void addCollabLists(List<Group> result) {
         listStore.addAll(result);
+    }
+
+    @UiHandler("addGroup")
+    void addGroupSelected(SelectEvent event) {
+        fireEvent(new GroupNameSelected(null));
+    }
+
+    @Override
+    public void onGroupNameSelected(GroupNameSelected event) {
+        fireEvent(new GroupNameSelected(event.getGroup()));
+    }
+
+    @Override
+    public HandlerRegistration addGroupNameSelectedHandler(GroupNameSelected.GroupNameSelectedHandler handler) {
+        return addHandler(handler, GroupNameSelected.TYPE);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -98,6 +98,11 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     }
 
     @Override
+    public List<Collaborator> getCollaborators() {
+        return listStore.getAll();
+    }
+
+    @Override
     public MODE getMode() {
         return mode;
     }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -6,6 +6,7 @@ import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected.USER_SEARCH_EVENT_TAG;
+import org.iplantc.de.collaborators.client.models.CollaboratorKeyProvider;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -226,9 +226,4 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     public HandlerRegistration addRemoveCollaboratorSelectedHandler(RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler handler) {
         return addHandler(handler, RemoveCollaboratorSelected.TYPE);
     }
-
-    @Override
-    public HandlerRegistration addGroupNameSelectedHandler(GroupNameSelected.GroupNameSelectedHandler handler) {
-        return groupView.addGroupNameSelectedHandler(handler);
-    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -4,7 +4,7 @@ import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
-import org.iplantc.de.collaborators.client.events.GroupNameSelected;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected.USER_SEARCH_EVENT_TAG;
 import org.iplantc.de.collaborators.client.models.CollaboratorKeyProvider;
@@ -225,5 +225,10 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     @Override
     public HandlerRegistration addRemoveCollaboratorSelectedHandler(RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler handler) {
         return addHandler(handler, RemoveCollaboratorSelected.TYPE);
+    }
+
+    @Override
+    public HandlerRegistration addAddGroupSelectedHandler(AddGroupSelected.AddGroupSelectedHandler handler) {
+        return groupView.addAddGroupSelectedHandler(handler);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -4,6 +4,7 @@ import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected.USER_SEARCH_EVENT_TAG;
 import org.iplantc.de.collaborators.client.models.CollaboratorKeyProvider;
@@ -224,5 +225,10 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     @Override
     public HandlerRegistration addRemoveCollaboratorSelectedHandler(RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler handler) {
         return addHandler(handler, RemoveCollaboratorSelected.TYPE);
+    }
+
+    @Override
+    public HandlerRegistration addGroupNameSelectedHandler(GroupNameSelected.GroupNameSelectedHandler handler) {
+        return groupView.addGroupNameSelectedHandler(handler);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/cells/GroupNameCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/cells/GroupNameCell.java
@@ -1,0 +1,63 @@
+package org.iplantc.de.collaborators.client.views.cells;
+
+import static com.google.gwt.dom.client.BrowserEvents.CLICK;
+
+import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
+import org.iplantc.de.collaborators.shared.CollaboratorsModule;
+
+import com.google.gwt.cell.client.AbstractCell;
+import com.google.gwt.cell.client.ValueUpdater;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.Event;
+
+/**
+ * @author aramsey
+ */
+public class GroupNameCell extends AbstractCell<Group> {
+
+    public interface GroupNameCellAppearance {
+        String CLICKABLE_ELEMENT_NAME = "groupName";
+
+        void render(SafeHtmlBuilder safeHtmlBuilder, Group group, String debugID);
+    }
+
+    private GroupNameCellAppearance appearance = GWT.create(GroupNameCellAppearance.class);
+    private String baseDebugId;
+    private GroupNameSelected.GroupNameSelectedHandler handler;
+
+    public GroupNameCell(GroupNameSelected.GroupNameSelectedHandler handler) {
+        super(CLICK);
+        this.handler = handler;
+    }
+
+    @Override
+    public void onBrowserEvent(Context context,
+                               Element parent,
+                               Group value,
+                               NativeEvent event,
+                               ValueUpdater<Group> valueUpdater) {
+        if (value == null) {
+            return;
+        }
+
+        Element eventTargetElement = Element.as(event.getEventTarget());
+        if ((Event.as(event).getTypeInt() == Event.ONCLICK)
+            && eventTargetElement.getAttribute("name").equalsIgnoreCase(GroupNameCellAppearance.CLICKABLE_ELEMENT_NAME)) {
+            handler.onGroupNameSelected(new GroupNameSelected(value));
+        }
+    }
+
+    @Override
+    public void render(Context context, Group value, SafeHtmlBuilder sb) {
+        String debugID = baseDebugId + "." + value.getId() + CollaboratorsModule.Ids.GROUP_NAME_CELL;
+        appearance.render(sb, value, debugID);
+    }
+
+    public void setBaseDebugId(String baseDebugId) {
+        this.baseDebugId = baseDebugId;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.collaborators.client.views.dialogs;
 
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.events.SaveGroupSelected;
 import org.iplantc.de.collaborators.client.views.GroupDetailsView;
@@ -20,12 +21,15 @@ public class GroupDetailsDialog extends IPlantDialog implements SaveGroupSelecte
 
     GroupDetailsView view;
     GroupView.GroupViewAppearance appearance;
+    private GroupAutoBeanFactory factory;
 
     @Inject
     public GroupDetailsDialog(GroupDetailsView view,
-                              GroupView.GroupViewAppearance appearance) {
+                              GroupView.GroupViewAppearance appearance,
+                              GroupAutoBeanFactory factory) {
         this.view = view;
         this.appearance = appearance;
+        this.factory = factory;
 
         setResizable(true);
         setPixelSize(appearance.groupDetailsWidth(), appearance.groupDetailsHeight());
@@ -54,6 +58,12 @@ public class GroupDetailsDialog extends IPlantDialog implements SaveGroupSelecte
         super.show();
 
         ensureDebugId(CollaboratorsModule.Ids.GROUP_DETAILS_DLG);
+    }
+
+    @Override
+    public void show() {
+        Group group = factory.getGroup().as();
+        show(group);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
@@ -1,0 +1,39 @@
+package org.iplantc.de.collaborators.client.views.dialogs;
+
+import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.views.GroupDetailsView;
+import org.iplantc.de.collaborators.shared.CollaboratorsModule;
+import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
+
+import com.google.inject.Inject;
+
+/**
+ * @author aramsey
+ */
+public class GroupDetailsDialog extends IPlantDialog {
+
+    GroupDetailsView view;
+    GroupView.GroupViewAppearance appearance;
+
+    @Inject
+    public GroupDetailsDialog(GroupDetailsView view,
+                              GroupView.GroupViewAppearance appearance) {
+        this.view = view;
+        this.appearance = appearance;
+
+        setResizable(true);
+        setPixelSize(appearance.groupDetailsWidth(), appearance.groupDetailsHeight());
+        setOnEsc(false);
+
+        add(view);
+    }
+
+    public void show(Group group) {
+        view.edit(group);
+        setHeading(appearance.groupDetailsHeading(group));
+        super.show();
+
+        ensureDebugId(CollaboratorsModule.Ids.GROUP_DETAILS_DLG);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
@@ -2,18 +2,21 @@ package org.iplantc.de.collaborators.client.views.dialogs;
 
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.events.SaveGroupSelected;
 import org.iplantc.de.collaborators.client.views.GroupDetailsView;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.inject.Inject;
 
 import com.sencha.gxt.widget.core.client.event.HideEvent;
+import com.sencha.gxt.widget.core.client.event.SelectEvent;
 
 /**
  * @author aramsey
  */
-public class GroupDetailsDialog extends IPlantDialog {
+public class GroupDetailsDialog extends IPlantDialog implements SaveGroupSelected.HasSaveGroupSelectedHandlers {
 
     GroupDetailsView view;
     GroupView.GroupViewAppearance appearance;
@@ -30,6 +33,13 @@ public class GroupDetailsDialog extends IPlantDialog {
 
         add(view);
 
+        addOkButtonSelectHandler(new SelectEvent.SelectHandler() {
+            @Override
+            public void onSelect(SelectEvent event) {
+                fireEvent(new SaveGroupSelected(view.getGroup(), view.getCollaborators()));
+            }
+        });
+
         addHideHandler(new HideEvent.HideHandler() {
             @Override
             public void onHide(HideEvent event) {
@@ -44,5 +54,10 @@ public class GroupDetailsDialog extends IPlantDialog {
         super.show();
 
         ensureDebugId(CollaboratorsModule.Ids.GROUP_DETAILS_DLG);
+    }
+
+    @Override
+    public HandlerRegistration addSaveGroupSelectedHandler(SaveGroupSelected.SaveGroupSelectedHandler handler) {
+        return addHandler(handler, SaveGroupSelected.TYPE);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
@@ -8,6 +8,8 @@ import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
 import com.google.inject.Inject;
 
+import com.sencha.gxt.widget.core.client.event.HideEvent;
+
 /**
  * @author aramsey
  */
@@ -27,6 +29,13 @@ public class GroupDetailsDialog extends IPlantDialog {
         setOnEsc(false);
 
         add(view);
+
+        addHideHandler(new HideEvent.HideHandler() {
+            @Override
+            public void onHide(HideEvent event) {
+                view.clearHandlers();
+            }
+        });
     }
 
     public void show(Group group) {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
@@ -11,6 +11,7 @@ import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.inject.Inject;
 
+import com.sencha.gxt.widget.core.client.box.AlertMessageBox;
 import com.sencha.gxt.widget.core.client.event.HideEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 
@@ -34,13 +35,28 @@ public class GroupDetailsDialog extends IPlantDialog implements SaveGroupSelecte
         setResizable(true);
         setPixelSize(appearance.groupDetailsWidth(), appearance.groupDetailsHeight());
         setOnEsc(false);
+        setHideOnButtonClick(false);
 
         add(view);
 
         addOkButtonSelectHandler(new SelectEvent.SelectHandler() {
             @Override
             public void onSelect(SelectEvent event) {
-                fireEvent(new SaveGroupSelected(view.getGroup(), view.getCollaborators()));
+                if (view.isValid()) {
+                    fireEvent(new SaveGroupSelected(view.getGroup(), view.getCollaborators()));
+                    hide();
+                } else {
+                    AlertMessageBox alertMsgBox =
+                            new AlertMessageBox("Warning", appearance.completeRequiredFieldsError());
+                    alertMsgBox.show();
+                }
+            }
+        });
+
+        addCancelButtonSelectHandler(new SelectEvent.SelectHandler() {
+            @Override
+            public void onSelect(SelectEvent event) {
+                hide();
             }
         });
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ManageCollaboratorsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ManageCollaboratorsDialog.java
@@ -1,4 +1,4 @@
-package org.iplantc.de.collaborators.client.views;
+package org.iplantc.de.collaborators.client.views.dialogs;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/shared/CollaboratorsModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/shared/CollaboratorsModule.java
@@ -18,5 +18,14 @@ public interface CollaboratorsModule {
         String DELETE_GROUP = ".deleteCollabList";
         String GRID = ".collabListGrid";
         String GROUPS_VIEW = ".collabListsView";
+        String GROUP_DETAILS_DLG = "collabListDetails";
+        String GROUP_NAME_CELL = ".groupNameCell";
+        String GROUP_NAME_LABEL = "groupNameLabel";
+        String GROUP_DESC_LABEL = "groupDescLabel";
+        String GROUP_NAME = "groupName";
+        String GROUP_DESC = ".groupDesc";
+        String GROUP_TOOLBAR = ".toolbar";
+        String GROUP_DELETE_BTN = ".groupDeleteBtn";
+        String GROUP_GRID = ".grid";
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/gin/DEGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/gin/DEGinModule.java
@@ -9,6 +9,7 @@ import org.iplantc.de.client.services.AppBuilderMetadataServiceFacade;
 import org.iplantc.de.client.services.AppServiceFacade;
 import org.iplantc.de.client.services.AppTemplateServices;
 import org.iplantc.de.client.services.AppUserServiceFacade;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.DEUserSupportServiceFacade;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.services.FileEditorServiceFacade;
@@ -122,6 +123,11 @@ public class DEGinModule extends AbstractGinModule {
     @Provides
     public OauthServiceFacade createOauthServices() {
         return ServicesInjector.INSTANCE.getOauthService();
+    }
+
+    @Provides
+    public CollaboratorsServiceFacade createCollaboratorServices() {
+        return ServicesInjector.INSTANCE.getCollaboratorsServiceFacade();
     }
 
     //</editor-fold>

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -33,7 +33,7 @@ import org.iplantc.de.client.services.UserSessionServiceFacade;
 import org.iplantc.de.client.util.CommonModelUtils;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.client.util.JsonUtil;
-import org.iplantc.de.collaborators.client.views.ManageCollaboratorsDialog;
+import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.commons.client.CommonUiConstants;
 import org.iplantc.de.commons.client.ErrorHandler;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
@@ -6,6 +6,7 @@ import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.PermissionValue;
 import org.iplantc.de.client.models.sharing.SharedResource;
 import org.iplantc.de.client.models.sharing.Sharing;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.sharing.SharingPermissionView;
 import org.iplantc.de.client.sharing.SharingPresenter;
@@ -99,7 +100,7 @@ public class DataSharingPresenterImpl implements SharingPresenter {
 
                 final List<String> usernames = new ArrayList<>();
                 usernames.addAll(sharingList.keySet());
-                collaboratorsUtil.getUserInfo(usernames, new GetUserInfoCallback(usernames));
+                collaboratorsServiceFacade.getUserInfo(usernames, new GetUserInfoCallback(usernames));
             }
         }
     }
@@ -111,6 +112,7 @@ public class DataSharingPresenterImpl implements SharingPresenter {
     private final Appearance appearance;
     private FastMap<List<Sharing>> dataSharingMap;
     private FastMap<List<JSONObject>> sharingList;
+    private CollaboratorsServiceFacade collaboratorsServiceFacade;
     private final JsonUtil jsonUtil;
     private final CollaboratorsUtil collaboratorsUtil;
 
@@ -120,6 +122,7 @@ public class DataSharingPresenterImpl implements SharingPresenter {
                                     @Assisted final List<DiskResource> selectedResources,
                                     final DataSharingView view,
                                     final CollaboratorsUtil collaboratorsUtil,
+                                    CollaboratorsServiceFacade collaboratorsServiceFacade,
                                     final JsonUtil jsonUtil,
                                     SharingPresenter.Appearance appearance,
                                     SharingPermissionViewFactory sharingViewFactory) {
@@ -127,6 +130,7 @@ public class DataSharingPresenterImpl implements SharingPresenter {
         this.view = view;
         this.selectedResources = selectedResources;
         this.collaboratorsUtil = collaboratorsUtil;
+        this.collaboratorsServiceFacade = collaboratorsServiceFacade;
         this.jsonUtil = jsonUtil;
         this.appearance = appearance;
         permissionsPanel = sharingViewFactory.create(this, getSelectedResourcesAsMap(selectedResources));

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/DataSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/DataSharingDialog.java
@@ -7,8 +7,6 @@ package org.iplantc.de.diskResource.client.views.sharing.dialogs;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.sharing.SharingAppearance;
 import org.iplantc.de.client.sharing.SharingPresenter;
-import org.iplantc.de.client.util.JsonUtil;
-import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 import org.iplantc.de.diskResource.client.gin.factory.DataSharingPresenterFactory;
 
@@ -27,9 +25,6 @@ import java.util.List;
 public class DataSharingDialog extends IPlantDialog implements SelectHandler {
 
     private SharingPresenter sharingPresenter;
-
-    @Inject CollaboratorsUtil collaboratorsUtil;
-    @Inject JsonUtil jsonUtil;
     private DataSharingPresenterFactory factory;
 
     @Inject

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/Collaborators.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/Collaborators.gwt.xml
@@ -12,4 +12,8 @@
         <when-type-is class="org.iplantc.de.collaborators.client.GroupView.GroupViewAppearance"/>
     </replace-with>
 
+    <replace-with class="org.iplantc.de.theme.base.client.collaborators.cells.GroupNameCellDefaultAppearance">
+        <when-type-is class="org.iplantc.de.collaborators.client.views.cells.GroupNameCell.GroupNameCellAppearance"/>
+    </replace-with>
+
 </module>

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.java
@@ -6,7 +6,13 @@ import com.google.gwt.i18n.client.Messages;
  * @author aramsey
  */
 public interface GroupDisplayStrings extends Messages {
-    String groupDialogHeader();
-
     String noCollabLists();
+
+    String groupNameLabel();
+
+    String groupDescriptionLabel();
+
+    String newGroupDetailsHeading();
+
+    String editGroupDetailsHeading(String name);
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.properties
@@ -1,2 +1,5 @@
-groupDialogHeader = Groups
+editGroupDetailsHeading=Edit {0}
+groupDescriptionLabel=Description
+groupNameLabel=Collaborator List Name
+newGroupDetailsHeading=Create a Collaborator List
 noCollabLists = Click the Add button to start creating Collaborator Lists

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
@@ -5,6 +5,7 @@ import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.resources.client.IplantResources;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 
+import com.google.common.base.Strings;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -121,7 +122,7 @@ public class GroupViewDefaultAppearance implements GroupView.GroupViewAppearance
 
     @Override
     public String groupDetailsHeading(Group group) {
-        if (group == null) {
+        if (group == null || Strings.isNullOrEmpty(group.getName())) {
             return displayStrings.newGroupDetailsHeading();
         } else {
             return displayStrings.editGroupDetailsHeading(group.getName());

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.theme.base.client.collaborators;
 
+import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.resources.client.IplantResources;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
@@ -72,22 +73,46 @@ public class GroupViewDefaultAppearance implements GroupView.GroupViewAppearance
     }
 
     @Override
-    public String groupDialogHeader() {
-        return displayStrings.groupDialogHeader();
-    }
-
-    @Override
-    public String groupDialogWidth() {
-        return "500";
-    }
-
-    @Override
-    public String groupDialogHeight() {
-        return "400";
-    }
-
-    @Override
     public String noCollabLists() {
         return displayStrings.noCollabLists();
+    }
+
+    @Override
+    public String groupNameLabel() {
+        return displayStrings.groupNameLabel();
+    }
+
+    @Override
+    public String groupDescriptionLabel() {
+        return displayStrings.groupDescriptionLabel();
+    }
+
+    @Override
+    public String delete() {
+        return iplantDisplayStrings.delete();
+    }
+
+    @Override
+    public String noCollaborators() {
+        return iplantDisplayStrings.noCollaborators();
+    }
+
+    @Override
+    public int groupDetailsWidth() {
+        return 500;
+    }
+
+    @Override
+    public int groupDetailsHeight() {
+        return 500;
+    }
+
+    @Override
+    public String groupDetailsHeading(Group group) {
+        if (group == null) {
+            return displayStrings.newGroupDetailsHeading();
+        } else {
+            return displayStrings.editGroupDetailsHeading(group.getName());
+        }
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
@@ -7,29 +7,41 @@ import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtml;
+
+import com.sencha.gxt.core.client.XTemplates;
 
 /**
  * @author aramsey
  */
 public class GroupViewDefaultAppearance implements GroupView.GroupViewAppearance {
 
+    interface Templates extends XTemplates {
+        @XTemplates.XTemplate("<span style='color: red;'>*&nbsp</span>{label}")
+        SafeHtml requiredFieldLabel(String label);
+    }
+
     private IplantDisplayStrings iplantDisplayStrings;
     private IplantResources iplantResources;
     private GroupDisplayStrings displayStrings;
+    private Templates templates;
 
     public GroupViewDefaultAppearance() {
         this(GWT.<IplantDisplayStrings>create(IplantDisplayStrings.class),
              GWT.<IplantResources>create(IplantResources.class),
-             GWT.<GroupDisplayStrings>create(GroupDisplayStrings.class));
+             GWT.<GroupDisplayStrings>create(GroupDisplayStrings.class),
+             GWT.<Templates> create(Templates.class));
     }
 
     public GroupViewDefaultAppearance(IplantDisplayStrings iplantDisplayStrings,
                                       IplantResources iplantResources,
-                                      GroupDisplayStrings displayStrings) {
+                                      GroupDisplayStrings displayStrings,
+                                      Templates templates) {
 
         this.iplantDisplayStrings = iplantDisplayStrings;
         this.iplantResources = iplantResources;
         this.displayStrings = displayStrings;
+        this.templates = templates;
     }
 
     @Override
@@ -78,8 +90,8 @@ public class GroupViewDefaultAppearance implements GroupView.GroupViewAppearance
     }
 
     @Override
-    public String groupNameLabel() {
-        return displayStrings.groupNameLabel();
+    public SafeHtml groupNameLabel() {
+        return templates.requiredFieldLabel(displayStrings.groupNameLabel());
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
@@ -127,4 +127,9 @@ public class GroupViewDefaultAppearance implements GroupView.GroupViewAppearance
             return displayStrings.editGroupDetailsHeading(group.getName());
         }
     }
+
+    @Override
+    public String completeRequiredFieldsError() {
+        return iplantDisplayStrings.completeRequiredFieldsError();
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/cells/GroupNameCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/cells/GroupNameCellDefaultAppearance.java
@@ -1,0 +1,46 @@
+package org.iplantc.de.theme.base.client.collaborators.cells;
+
+import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.views.cells.GroupNameCell;
+import org.iplantc.de.resources.client.DiskResourceNameCellStyle;
+import org.iplantc.de.resources.client.IplantResources;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+
+import com.sencha.gxt.core.client.XTemplates;
+
+/**
+ * @author aramsey
+ */
+public class GroupNameCellDefaultAppearance implements GroupNameCell.GroupNameCellAppearance {
+
+    interface Templates extends XTemplates {
+        @XTemplates.XTemplate("<span name='{elementName}' class='{style.nameStyle}' id='{debugID}'>{group.name}</span>")
+        SafeHtml group(String elementName, DiskResourceNameCellStyle style, Group group, String debugID);
+    }
+
+    private final GroupNameCellDefaultAppearance.Templates templates;
+    private final DiskResourceNameCellStyle defaultStyle;
+
+    public GroupNameCellDefaultAppearance() {
+        this(GWT.<IplantResources>create(IplantResources.class),
+             GWT.<Templates>create(Templates.class));
+    }
+
+    public GroupNameCellDefaultAppearance(IplantResources iplantResources,
+                                          Templates templates) {
+        this.defaultStyle = iplantResources.diskResourceNameCss();
+        this.templates = templates;
+    }
+
+    @Override
+    public void render(SafeHtmlBuilder safeHtmlBuilder, Group group, String debugID) {
+        if (group == null) {
+            return;
+        }
+
+        safeHtmlBuilder.append(templates.group(CLICKABLE_ELEMENT_NAME, defaultStyle, group, debugID));
+    }
+}

--- a/de-lib/src/test/java/org/iplantc/de/analysis/client/presenter/AnalysesPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/analysis/client/presenter/AnalysesPresenterImplTest.java
@@ -37,8 +37,6 @@ import org.iplantc.de.client.models.analysis.support.AnalysisSupportAutoBeanFact
 import org.iplantc.de.client.models.analysis.support.AnalysisSupportRequest;
 import org.iplantc.de.client.models.analysis.support.AnalysisSupportRequestFields;
 import org.iplantc.de.client.services.AnalysisServiceFacade;
-import org.iplantc.de.client.util.JsonUtil;
-import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 import org.iplantc.de.shared.AnalysisCallback;
@@ -94,8 +92,6 @@ public class AnalysesPresenterImplTest {
     @Mock AnalysisStepsView analysisStepsViewMock;
     @Mock AsyncProviderWrapper<AnalysisSharingDialog> aSharingDialogProviderMock;
     @Mock AnalysisSharingDialog analysisSharingDialogMock;
-    @Mock CollaboratorsUtil collaboratorsUtilMock;
-    @Mock JsonUtil jsonUtilMock;
     @Mock AnalysisFilter currentFilterMock;
     @Mock ListStore<Analysis> listStoreMock;
     @Mock AnalysesView viewMock;
@@ -187,7 +183,6 @@ public class AnalysesPresenterImplTest {
         uut.appearance = appearanceMock;
         uut.analysisStepView = analysisStepsViewMock;
         uut.aSharingDialogProvider = aSharingDialogProviderMock;
-        uut.collaboratorsUtil = collaboratorsUtilMock;
         uut.userInfo = userInfoMock;
         uut.supportFactory = supportFactoryMock;
         uut.stepsInfoDialogProvider = stepsInfoDialogMock;


### PR DESCRIPTION
This is just for creating a Collaborator List (a group).  There's a separate endpoint for adding members to a group, so that will be in a separate PR to match.  I also went ahead and gutted the `CollaboratorUtil` class so that presenters are calling the service facade instead of using the util class to do it for them.  There's probably more refactoring that could be done there, but I'll save that for a different PR.

![image](https://cloud.githubusercontent.com/assets/8909156/25458259/17c82978-2a8e-11e7-9851-de80d66dfb07.png)