### PR TITLE
CORE-8792 Allow users to add members to a Collaborator List

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Collaborator.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Collaborator.java
@@ -3,13 +3,15 @@
  */
 package org.iplantc.de.client.models.collaborators;
 
+import org.iplantc.de.client.models.HasId;
+
 import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 
 /**
  * @author sriram
  * 
  */
-public interface Collaborator {
+public interface Collaborator extends HasId {
 
     @PropertyName("username")
     void setUserName(String username);

--- a/de-lib/src/main/java/org/iplantc/de/client/models/groups/GroupAutoBeanFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/groups/GroupAutoBeanFactory.java
@@ -19,4 +19,10 @@ public interface GroupAutoBeanFactory extends AutoBeanFactory {
     AutoBean<Group> getGroup();
 
     AutoBean<GroupList> getGroupList();
+
+    AutoBean<UpdateMemberRequest> getUpdateMemberRequest();
+
+    AutoBean<UpdateMemberResult> getUpdateMemberResult();
+
+    AutoBean<UpdateMemberResultList> getUpdateMemberResultList();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberRequest.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberRequest.java
@@ -3,6 +3,7 @@ package org.iplantc.de.client.models.groups;
 import java.util.List;
 
 /**
+ * The AutoBean representation of the request sent to update a list of members in a Group
  * @author aramsey
  */
 public interface UpdateMemberRequest {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberRequest.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberRequest.java
@@ -1,0 +1,12 @@
+package org.iplantc.de.client.models.groups;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public interface UpdateMemberRequest {
+    List<String> getMembers();
+
+    void setMembers(List<String> ids);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberResult.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberResult.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.client.models.groups;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+/**
+ * @author aramsey
+ */
+public interface UpdateMemberResult {
+
+    Boolean isSuccess();
+
+    @PropertyName("subject_id")
+    String getSubjectId();
+
+    @PropertyName("subject_name")
+    String getSubjectName();
+
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberResult.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberResult.java
@@ -3,6 +3,8 @@ package org.iplantc.de.client.models.groups;
 import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 
 /**
+ * The AutoBean representation of the response that is returned from updating the
+ * list of members in a Group
  * @author aramsey
  */
 public interface UpdateMemberResult {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberResultList.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberResultList.java
@@ -1,0 +1,11 @@
+package org.iplantc.de.client.models.groups;
+
+import java.util.List;
+
+/**
+ * @author aramsey
+ */
+public interface UpdateMemberResultList {
+
+    List<UpdateMemberResult> getResults();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberResultList.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/groups/UpdateMemberResultList.java
@@ -3,6 +3,7 @@ package org.iplantc.de.client.models.groups;
 import java.util.List;
 
 /**
+ * The AutoBean representation of a List of UpdateMemberResult
  * @author aramsey
  */
 public interface UpdateMemberResultList {

--- a/de-lib/src/main/java/org/iplantc/de/client/services/GroupServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/GroupServiceFacade.java
@@ -40,4 +40,11 @@ public interface GroupServiceFacade {
      */
     void getMembers(Group group, AsyncCallback<List<Collaborator>> callback);
 
+    /**
+     * Add members to a Collaborator List
+     * @param group
+     * @param callback
+     */
+    void addMembers(Group group, Collaborator member, AsyncCallback<Void> callback);
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/GroupServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/GroupServiceFacade.java
@@ -2,6 +2,7 @@ package org.iplantc.de.client.services;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.models.groups.UpdateMemberResult;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
@@ -46,5 +47,12 @@ public interface GroupServiceFacade {
      * @param callback
      */
     void addMember(Group group, Collaborator member, AsyncCallback<Void> callback);
+
+    /**
+     * Replaces all members in the Collaborator List with the specified list instead
+     * @param group
+     * @param collaborators
+     */
+    void updateMembers(Group group, List<Collaborator> collaborators, AsyncCallback<List<UpdateMemberResult>> callback);
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/GroupServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/GroupServiceFacade.java
@@ -41,10 +41,10 @@ public interface GroupServiceFacade {
     void getMembers(Group group, AsyncCallback<List<Collaborator>> callback);
 
     /**
-     * Add members to a Collaborator List
+     * Add a single member to a Collaborator List
      * @param group
      * @param callback
      */
-    void addMembers(Group group, Collaborator member, AsyncCallback<Void> callback);
+    void addMember(Group group, Collaborator member, AsyncCallback<Void> callback);
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/GroupServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/GroupServiceFacadeImpl.java
@@ -91,7 +91,7 @@ public class GroupServiceFacadeImpl implements GroupServiceFacade {
     }
 
     @Override
-    public void addMembers(Group group, Collaborator member, AsyncCallback<Void> callback) {
+    public void addMember(Group group, Collaborator member, AsyncCallback<Void> callback) {
         String groupName = group.getName();
         String subjectId = member.getId();
 

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/GroupServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/GroupServiceFacadeImpl.java
@@ -3,6 +3,7 @@ package org.iplantc.de.client.services.impl;
 import static org.iplantc.de.shared.services.BaseServiceCallWrapper.Type.DELETE;
 import static org.iplantc.de.shared.services.BaseServiceCallWrapper.Type.GET;
 import static org.iplantc.de.shared.services.BaseServiceCallWrapper.Type.POST;
+import static org.iplantc.de.shared.services.BaseServiceCallWrapper.Type.PUT;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.collaborators.CollaboratorAutoBeanFactory;
@@ -13,6 +14,7 @@ import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
 import org.iplantc.de.client.services.converters.CollaboratorListCallbackConverter;
 import org.iplantc.de.client.services.converters.GroupCallbackConverter;
+import org.iplantc.de.client.services.converters.StringToVoidCallbackConverter;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.shared.services.ServiceCallWrapper;
 
@@ -86,6 +88,17 @@ public class GroupServiceFacadeImpl implements GroupServiceFacade {
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
         deService.getServiceData(wrapper, new CollaboratorListCallbackConverter(callback, collabFactory));
+    }
+
+    @Override
+    public void addMembers(Group group, Collaborator member, AsyncCallback<Void> callback) {
+        String groupName = group.getName();
+        String subjectId = member.getId();
+
+        String address = GROUPS + "/" + groupName + "/members/" + subjectId;
+
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(PUT, address);
+        deService.getServiceData(wrapper, new StringToVoidCallbackConverter(callback));
     }
 
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupDetailsView.java
@@ -17,12 +17,16 @@ import java.util.List;
 public interface GroupDetailsView extends IsWidget {
 
     interface Presenter extends GroupSaved.HasGroupSavedHandlers {
+    enum MODE {
+        ADD,
+        EDIT
+    }
 
         /**
          * Initialize the presenter and add the GroupDetailsView to the specified container
          * @param container
          */
-        void go(HasOneWidget container, Group group);
+        void go(HasOneWidget container, Group group, MODE mode);
 
         /**
          * Check whether the GroupDetailsView is valid
@@ -45,7 +49,7 @@ public interface GroupDetailsView extends IsWidget {
      * Edit the specified Collaborator List
      * @param group
      */
-    void edit(Group group);
+    void edit(Group group, MODE mode);
 
     /**
      * Clear any EventBus handlers that can now be removed

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupDetailsView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.events.AddGroupMemberSelected;
 import org.iplantc.de.collaborators.client.events.GroupSaved;
 
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -16,11 +17,13 @@ import java.util.List;
  */
 public interface GroupDetailsView extends IsWidget {
 
-    interface Presenter extends GroupSaved.HasGroupSavedHandlers {
     enum MODE {
         ADD,
         EDIT
     }
+
+    interface Presenter extends GroupSaved.HasGroupSavedHandlers,
+                                AddGroupMemberSelected.AddGroupMemberSelectedHandler {
 
         /**
          * Initialize the presenter and add the GroupDetailsView to the specified container

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupDetailsView.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.collaborators.client;
 
+import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.events.AddGroupMemberSelected;
@@ -15,7 +16,8 @@ import java.util.List;
  * edit/create Collaborator Lists and add members to those lists.
  * @author aramsey
  */
-public interface GroupDetailsView extends IsWidget {
+public interface GroupDetailsView extends IsWidget,
+                                          IsMaskable {
 
     enum MODE {
         ADD,

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupDetailsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupDetailsView.java
@@ -17,7 +17,8 @@ import java.util.List;
  * @author aramsey
  */
 public interface GroupDetailsView extends IsWidget,
-                                          IsMaskable {
+                                          IsMaskable,
+                                          AddGroupMemberSelected.HasAddGroupMemberSelectedHandlers {
 
     enum MODE {
         ADD,

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -1,6 +1,5 @@
 package org.iplantc.de.collaborators.client;
 
-import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.models.groups.UpdateMemberResult;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
@@ -97,11 +96,4 @@ public interface GroupView extends IsWidget,
      * @param result
      */
     void removeCollabList(Group result);
-
-    /**
-     * Edit the specified Collaborator List and/or its members
-     * @param group
-     * @param members
-     */
-    void editCollabList(Group group, List<Collaborator> members);
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -69,6 +69,10 @@ public interface GroupView extends IsWidget,
         String groupDeleteSuccess(Group group);
 
         String unableToAddMembers(List<UpdateMemberResult> failures);
+
+        String loadingMask();
+
+        String groupCreatedSuccess(Group group);
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.models.groups.UpdateMemberResult;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 
@@ -66,6 +67,8 @@ public interface GroupView extends IsWidget,
         String deleteGroupConfirm(Group group);
 
         String groupDeleteSuccess(Group group);
+
+        String unableToAddMembers(List<UpdateMemberResult> failures);
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -20,9 +20,9 @@ import java.util.List;
  * @author aramsey
  */
 public interface GroupView extends IsWidget,
-                                   GroupNameSelected.GroupNameSelectedHandler,
                                    DeleteGroupSelected.HasDeleteGroupSelectedHandlers,
-                                   AddGroupSelected.HasAddGroupSelectedHandlers {
+                                   AddGroupSelected.HasAddGroupSelectedHandlers,
+                                   GroupNameSelected.HasGroupNameSelectedHandlers {
 
     /**
      * Appearance related items for the GroupView

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.models.groups.UpdateMemberResult;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 
@@ -20,7 +21,8 @@ import java.util.List;
  */
 public interface GroupView extends IsWidget,
                                    GroupNameSelected.GroupNameSelectedHandler,
-                                   DeleteGroupSelected.HasDeleteGroupSelectedHandlers {
+                                   DeleteGroupSelected.HasDeleteGroupSelectedHandlers,
+                                   AddGroupSelected.HasAddGroupSelectedHandlers {
 
     /**
      * Appearance related items for the GroupView

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -183,11 +183,4 @@ public interface ManageCollaboratorsView extends IsWidget,
      * @return
      */
     List<Collaborator> getCollaborators();
-
-    /**
-     * Show the view for editing the specified Collaborator List and/or its members
-     * @param group
-     * @param members
-     */
-    void editCollabList(Group group, List<Collaborator> members);
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 
@@ -21,7 +22,8 @@ import java.util.List;
  */
 public interface ManageCollaboratorsView extends IsWidget,
                                                  RemoveCollaboratorSelected.HasRemoveCollaboratorSelectedHandlers,
-                                                 DeleteGroupSelected.HasDeleteGroupSelectedHandlers {
+                                                 DeleteGroupSelected.HasDeleteGroupSelectedHandlers,
+                                                 AddGroupSelected.HasAddGroupSelectedHandlers {
 
     /**
      * Appearance related items for the ManageCollaboratorsView

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -4,6 +4,7 @@ import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 
 import com.google.gwt.resources.client.ImageResource;
@@ -23,7 +24,8 @@ import java.util.List;
 public interface ManageCollaboratorsView extends IsWidget,
                                                  RemoveCollaboratorSelected.HasRemoveCollaboratorSelectedHandlers,
                                                  DeleteGroupSelected.HasDeleteGroupSelectedHandlers,
-                                                 AddGroupSelected.HasAddGroupSelectedHandlers {
+                                                 AddGroupSelected.HasAddGroupSelectedHandlers,
+                                                 GroupNameSelected.HasGroupNameSelectedHandlers {
 
     /**
      * Appearance related items for the ManageCollaboratorsView

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/AddGroupMemberSelected.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/AddGroupMemberSelected.java
@@ -1,0 +1,48 @@
+package org.iplantc.de.collaborators.client.events;
+
+import org.iplantc.de.client.models.collaborators.Collaborator;
+import org.iplantc.de.client.models.groups.Group;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class AddGroupMemberSelected
+        extends GwtEvent<AddGroupMemberSelected.AddGroupMemberSelectedHandler> {
+
+    public static interface AddGroupMemberSelectedHandler extends EventHandler {
+        void onAddGroupMemberSelected(AddGroupMemberSelected event);
+    }
+
+    public interface HasAddGroupMemberSelectedHandlers {
+        HandlerRegistration addAddGroupMemberSelectedHandler(AddGroupMemberSelectedHandler handler);
+    }
+
+    public static Type<AddGroupMemberSelectedHandler> TYPE = new Type<AddGroupMemberSelectedHandler>();
+    private Group group;
+    private Collaborator subject;
+
+    public AddGroupMemberSelected(Group group, Collaborator subject) {
+        this.group = group;
+        this.subject = subject;
+    }
+
+    public Type<AddGroupMemberSelectedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(AddGroupMemberSelectedHandler handler) {
+        handler.onAddGroupMemberSelected(this);
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public Collaborator getSubject() {
+        return subject;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/AddGroupSelected.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/AddGroupSelected.java
@@ -1,0 +1,29 @@
+package org.iplantc.de.collaborators.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * @author aramsey
+ */
+public class AddGroupSelected extends GwtEvent<AddGroupSelected.AddGroupSelectedHandler> {
+
+    public static interface AddGroupSelectedHandler extends EventHandler {
+        void onAddGroupSelected(AddGroupSelected event);
+    }
+
+    public interface HasAddGroupSelectedHandlers {
+        HandlerRegistration addAddGroupSelectedHandler(AddGroupSelectedHandler handler);
+    }
+
+    public static Type<AddGroupSelectedHandler> TYPE = new Type<AddGroupSelectedHandler>();
+
+    public Type<AddGroupSelectedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    protected void dispatch(AddGroupSelectedHandler handler) {
+        handler.onAddGroupSelected(this);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/GroupSaved.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/events/GroupSaved.java
@@ -6,8 +6,6 @@ import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
 
-import java.util.List;
-
 /**
  * @author aramsey
  */
@@ -22,10 +20,10 @@ public class GroupSaved extends GwtEvent<GroupSaved.GroupSavedHandler> {
     }
 
     public static Type<GroupSavedHandler> TYPE = new Type<GroupSavedHandler>();
-    private List<Group> groups;
+    private Group group;
 
-    public GroupSaved(List<Group> groups) {
-        this.groups = groups;
+    public GroupSaved(Group group) {
+        this.group = group;
     }
 
     public Type<GroupSavedHandler> getAssociatedType() {
@@ -36,7 +34,7 @@ public class GroupSaved extends GwtEvent<GroupSaved.GroupSavedHandler> {
         handler.onGroupSaved(this);
     }
 
-    public List<Group> getGroups() {
-        return groups;
+    public Group getGroup() {
+        return group;
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -10,6 +10,7 @@ import org.iplantc.de.collaborators.client.events.AddGroupMemberSelected;
 import org.iplantc.de.collaborators.client.events.GroupSaved;
 import org.iplantc.de.commons.client.ErrorHandler;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -96,6 +97,10 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
             @Override
             public void onSuccess(Group result) {
                 ensureHandlers().fireEvent(new GroupSaved(getGroupList(result)));
+                List<Collaborator> subjects = view.getCollaborators();
+                if (subjects != null && subjects.size() > 0) {
+                    subjects.forEach(collaborator -> addGroupMember(group, collaborator));
+                }
             }
         });
     }
@@ -105,17 +110,23 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
         Group group = event.getGroup();
         Collaborator subject = event.getSubject();
 
-        serviceFacade.addMembers(group, subject, new AsyncCallback<Void>() {
-            @Override
-            public void onFailure(Throwable caught) {
-                ErrorHandler.post(caught);
-            }
+        addGroupMember(group, subject);
+    }
 
-            @Override
-            public void onSuccess(Void result) {
-                view.addMembers(Lists.newArrayList(subject));
-            }
-        });
+    void addGroupMember(Group group, Collaborator subject) {
+        if (group != null && !Strings.isNullOrEmpty(group.getName()) && subject != null) {
+            serviceFacade.addMembers(group, subject, new AsyncCallback<Void>() {
+                @Override
+                public void onFailure(Throwable caught) {
+                    ErrorHandler.post(caught);
+                }
+
+                @Override
+                public void onSuccess(Void result) {
+                    view.addMembers(Lists.newArrayList(subject));
+                }
+            });
+        }
     }
 
     List<Group> getGroupList(Group result) {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -101,11 +101,12 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);
+                view.unmask();
             }
 
             @Override
             public void onSuccess(Group result) {
-                ensureHandlers().fireEvent(new GroupSaved(getGroupList(result)));
+                ensureHandlers().fireEvent(new GroupSaved(result));
                 List<Collaborator> subjects = view.getCollaborators();
                 updateGroupMembers(group, subjects);
             }
@@ -118,6 +119,7 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
                 @Override
                 public void onFailure(Throwable caught) {
                     ErrorHandler.post(caught);
+                    view.unmask();
                 }
 
                 @Override
@@ -154,10 +156,6 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
                 }
             });
         }
-    }
-
-    List<Group> getGroupList(Group result) {
-        return Lists.newArrayList(result);
     }
 
     HandlerManager createHandlerManager() {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -12,6 +12,7 @@ import org.iplantc.de.collaborators.client.events.GroupSaved;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
+import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -84,8 +85,10 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
 
     @Override
     public void saveGroupSelected() {
+        view.mask(appearance.loadingMask());
         Group group = view.getGroup();
         if (group == null) {
+            view.unmask();
             return;
         }
         if (GroupDetailsView.MODE.ADD == mode) {
@@ -124,7 +127,10 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
                                                              .collect(Collectors.toList());
                     if (failures == null || !failures.isEmpty()) {
                         announcer.schedule(new ErrorAnnouncementConfig(appearance.unableToAddMembers(failures)));
+                    } else {
+                        announcer.schedule(new SuccessAnnouncementConfig(appearance.groupCreatedSuccess(group)));
                     }
+                    view.unmask();
                 }
             });
         }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -30,7 +30,7 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
     private GroupAutoBeanFactory factory;
     private GroupView.GroupViewAppearance appearance;
     private HandlerManager handlerManager;
-    private GroupDetailsView.MODE mode;
+    GroupDetailsView.MODE mode;
 
     @Inject
     public GroupDetailsPresenterImpl(GroupDetailsView view,
@@ -115,7 +115,7 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
 
     void addGroupMember(Group group, Collaborator subject) {
         if (group != null && !Strings.isNullOrEmpty(group.getName()) && subject != null) {
-            serviceFacade.addMembers(group, subject, new AsyncCallback<Void>() {
+            serviceFacade.addMember(group, subject, new AsyncCallback<Void>() {
                 @Override
                 public void onFailure(Throwable caught) {
                     ErrorHandler.post(caught);

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -27,8 +27,8 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
     private GroupServiceFacade serviceFacade;
     private GroupAutoBeanFactory factory;
     private GroupView.GroupViewAppearance appearance;
-    boolean isNewGroup;
     private HandlerManager handlerManager;
+    private GroupDetailsView.MODE mode;
 
     @Inject
     public GroupDetailsPresenterImpl(GroupDetailsView view,
@@ -42,10 +42,11 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
     }
 
     @Override
-    public void go(HasOneWidget container, Group group) {
+    public void go(HasOneWidget container, Group group, GroupDetailsView.MODE mode) {
+        this.mode = mode;
         container.setWidget(view);
 
-        if (group != null) {
+        if (GroupDetailsView.MODE.EDIT == mode) {
             serviceFacade.getMembers(group, new AsyncCallback<List<Collaborator>>() {
                 @Override
                 public void onFailure(Throwable caught) {
@@ -58,10 +59,9 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
                 }
             });
         } else {
-            isNewGroup = true;
             group = factory.getGroup().as();
         }
-        view.edit(group);
+        view.edit(group, mode);
     }
 
     @Override
@@ -80,7 +80,7 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
         if (group == null) {
             return;
         }
-        if (isNewGroup) {
+        if (GroupDetailsView.MODE.ADD == mode) {
             addGroup(group);
         }
     }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -55,6 +55,10 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
         this.mode = mode;
         container.setWidget(view);
 
+        getGroupMembers(group);
+    }
+
+    void getGroupMembers(Group group) {
         if (GroupDetailsView.MODE.EDIT == mode) {
             serviceFacade.getMembers(group, new AsyncCallback<List<Collaborator>>() {
                 @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -48,6 +48,8 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
         this.serviceFacade = serviceFacade;
         this.factory = factory;
         this.appearance = appearance;
+
+        view.addAddGroupMemberSelectedHandler(this);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -113,7 +113,7 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
     }
 
     void updateGroupMembers(Group group, List<Collaborator> subjects) {
-        if (subjects != null && subjects.size() > 0) {
+        if (subjects != null && !subjects.isEmpty()) {
             serviceFacade.updateMembers(group, subjects, new AsyncCallback<List<UpdateMemberResult>>() {
                 @Override
                 public void onFailure(Throwable caught) {
@@ -141,10 +141,6 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
         Group group = event.getGroup();
         Collaborator subject = event.getSubject();
 
-        addGroupMember(group, subject);
-    }
-
-    void addGroupMember(Group group, Collaborator subject) {
         if (group != null && !Strings.isNullOrEmpty(group.getName()) && subject != null) {
             serviceFacade.addMember(group, subject, new AsyncCallback<Void>() {
                 @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImpl.java
@@ -6,6 +6,7 @@ import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.collaborators.client.GroupDetailsView;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.events.AddGroupMemberSelected;
 import org.iplantc.de.collaborators.client.events.GroupSaved;
 import org.iplantc.de.commons.client.ErrorHandler;
 
@@ -95,6 +96,24 @@ public class GroupDetailsPresenterImpl implements GroupDetailsView.Presenter {
             @Override
             public void onSuccess(Group result) {
                 ensureHandlers().fireEvent(new GroupSaved(getGroupList(result)));
+            }
+        });
+    }
+
+    @Override
+    public void onAddGroupMemberSelected(AddGroupMemberSelected event) {
+        Group group = event.getGroup();
+        Collaborator subject = event.getSubject();
+
+        serviceFacade.addMembers(group, subject, new AsyncCallback<Void>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                ErrorHandler.post(caught);
+            }
+
+            @Override
+            public void onSuccess(Void result) {
+                view.addMembers(Lists.newArrayList(subject));
             }
         });
     }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -35,6 +35,10 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.inject.Inject;
 
+import com.sencha.gxt.widget.core.client.Dialog;
+import com.sencha.gxt.widget.core.client.box.ConfirmMessageBox;
+import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -249,6 +253,23 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     @Override
     public void onDeleteGroupSelected(DeleteGroupSelected event) {
         Group group = event.getGroup();
+        if (group == null) {
+            return;
+        }
+        ConfirmMessageBox deleteAlert = new ConfirmMessageBox(groupAppearance.deleteGroupConfirmHeading(group),
+                                                              groupAppearance.deleteGroupConfirm(group));
+        deleteAlert.show();
+        deleteAlert.addDialogHideHandler(new DialogHideEvent.DialogHideHandler() {
+            @Override
+            public void onDialogHide(DialogHideEvent event) {
+                if (event.getHideButton().equals(Dialog.PredefinedButton.YES)) {
+                    deleteGroup(group);
+                }
+            }
+        });
+    }
+
+    void deleteGroup(Group group) {
         groupServiceFacade.deleteGroup(group.getName(), new AsyncCallback<Group>() {
             @Override
             public void onFailure(Throwable caught) {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -14,6 +14,7 @@ import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.CollaboratorsLoadedEvent;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.events.GroupSaved;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
@@ -46,7 +47,8 @@ import java.util.stream.Stream;
 public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Presenter,
                                                      RemoveCollaboratorSelected.RemoveCollaboratorSelectedHandler,
                                                      DeleteGroupSelected.DeleteGroupSelectedHandler,
-                                                     AddGroupSelected.AddGroupSelectedHandler {
+                                                     AddGroupSelected.AddGroupSelectedHandler,
+                                                     GroupNameSelected.GroupNameSelectedHandler {
 
     final class UserSearchResultSelectedEventHandlerImpl implements
                                                                  UserSearchResultSelected.UserSearchResultSelectedEventHandler {
@@ -97,6 +99,7 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
                                                            new UserSearchResultSelectedEventHandlerImpl());
         view.addDeleteGroupSelectedHandler(this);
         view.addAddGroupSelectedHandler(this);
+        view.addGroupNameSelectedHandler(this);
     }
 
     /*
@@ -276,6 +279,20 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
                         view.addCollabLists(Lists.newArrayList(group));
                     }
                 });
+            }
+        });
+    }
+
+    @Override
+    public void onGroupNameSelected(GroupNameSelected event) {
+        Group group = event.getGroup();
+        groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
+            @Override
+            public void onFailure(Throwable caught) {}
+
+            @Override
+            public void onSuccess(GroupDetailsDialog result) {
+                result.show(group);
             }
         });
     }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
@@ -45,8 +45,7 @@ import java.util.List;
  * @author aramsey
  */
 public class GroupDetailsViewImpl extends Composite implements GroupDetailsView,
-                                                               Editor<Group>,
-                                                               AddGroupMemberSelected.HasAddGroupMemberSelectedHandlers {
+                                                               Editor<Group> {
 
     interface GroupDetailsViewImplUiBinder extends UiBinder<Widget, GroupDetailsViewImpl> {
     }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
@@ -60,6 +60,7 @@ public class GroupDetailsViewImpl extends Composite implements GroupDetailsView,
             if (UserSearchResultSelected.USER_SEARCH_EVENT_TAG.GROUP.toString().equals(userSearchResultSelected.getTag())) {
                 Collaborator collaborator = userSearchResultSelected.getCollaborator();
                 if (MODE.EDIT == mode) {
+                    mask();
                     fireEvent(new AddGroupMemberSelected(getGroup(), collaborator));
                 } else {
                     listStore.add(collaborator);

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
@@ -5,6 +5,7 @@ import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupDetailsView;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.events.AddGroupMemberSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.models.CollaboratorKeyProvider;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
@@ -44,7 +45,8 @@ import java.util.List;
  * @author aramsey
  */
 public class GroupDetailsViewImpl extends Composite implements GroupDetailsView,
-                                                               Editor<Group> {
+                                                               Editor<Group>,
+                                                               AddGroupMemberSelected.HasAddGroupMemberSelectedHandlers {
 
     interface GroupDetailsViewImplUiBinder extends UiBinder<Widget, GroupDetailsViewImpl> {
     }
@@ -56,7 +58,9 @@ public class GroupDetailsViewImpl extends Composite implements GroupDetailsView,
         @Override
         public void onUserSearchResultSelected(UserSearchResultSelected userSearchResultSelected) {
             if (UserSearchResultSelected.USER_SEARCH_EVENT_TAG.GROUP.toString().equals(userSearchResultSelected.getTag())) {
-                listStore.add(userSearchResultSelected.getCollaborator());
+                if (MODE.EDIT == mode) {
+                    fireEvent(new AddGroupMemberSelected(getGroup(), userSearchResultSelected.getCollaborator()));
+                }
             }
         }
     }
@@ -186,5 +190,10 @@ public class GroupDetailsViewImpl extends Composite implements GroupDetailsView,
         if (members != null) {
             listStore.addAll(members);
         }
+    }
+
+    @Override
+    public HandlerRegistration addAddGroupMemberSelectedHandler(AddGroupMemberSelected.AddGroupMemberSelectedHandler handler) {
+        return addHandler(handler, AddGroupMemberSelected.TYPE);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
@@ -58,8 +58,11 @@ public class GroupDetailsViewImpl extends Composite implements GroupDetailsView,
         @Override
         public void onUserSearchResultSelected(UserSearchResultSelected userSearchResultSelected) {
             if (UserSearchResultSelected.USER_SEARCH_EVENT_TAG.GROUP.toString().equals(userSearchResultSelected.getTag())) {
+                Collaborator collaborator = userSearchResultSelected.getCollaborator();
                 if (MODE.EDIT == mode) {
-                    fireEvent(new AddGroupMemberSelected(getGroup(), userSearchResultSelected.getCollaborator()));
+                    fireEvent(new AddGroupMemberSelected(getGroup(), collaborator));
+                } else {
+                    listStore.add(collaborator);
                 }
             }
         }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupDetailsViewImpl.java
@@ -81,6 +81,7 @@ public class GroupDetailsViewImpl extends Composite implements GroupDetailsView,
 
     private CheckBoxSelectionModel<Collaborator> checkBoxModel;
     String baseID;
+    private MODE mode;
 
     @Inject
     public GroupDetailsViewImpl(GroupView.GroupViewAppearance appearance,
@@ -155,7 +156,8 @@ public class GroupDetailsViewImpl extends Composite implements GroupDetailsView,
     }
 
     @Override
-    public void edit(Group group) {
+    public void edit(Group group, MODE mode) {
+        this.mode = mode;
         editorDriver.edit(group);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -25,10 +25,7 @@ import com.sencha.gxt.core.client.IdentityValueProvider;
 import com.sencha.gxt.core.client.Style;
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.Composite;
-import com.sencha.gxt.widget.core.client.Dialog;
-import com.sencha.gxt.widget.core.client.box.ConfirmMessageBox;
 import com.sencha.gxt.widget.core.client.button.TextButton;
-import com.sencha.gxt.widget.core.client.event.DialogHideEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
@@ -117,21 +114,7 @@ public class GroupViewImpl extends Composite implements GroupView {
 
     @UiHandler("deleteGroup")
     void deleteGroupSelected(SelectEvent event) {
-        Group group = grid.getSelectionModel().getSelectedItem();
-        if (group == null) {
-            return;
-        }
-        ConfirmMessageBox deleteAlert = new ConfirmMessageBox(appearance.deleteGroupConfirmHeading(group),
-                                                            appearance.deleteGroupConfirm(group));
-        deleteAlert.show();
-        deleteAlert.addDialogHideHandler(new DialogHideEvent.DialogHideHandler() {
-            @Override
-            public void onDialogHide(DialogHideEvent event) {
-                if (event.getHideButton().equals(Dialog.PredefinedButton.YES)) {
-                    fireEvent(new DeleteGroupSelected(group));
-                }
-            }
-        });
+        fireEvent(new DeleteGroupSelected(grid.getSelectionModel().getSelectedItem()));
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -18,7 +18,6 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -55,6 +54,7 @@ public class GroupViewImpl extends Composite implements GroupView {
     @UiField ColumnModel<Group> cm;
     @UiField(provided = true) GroupViewAppearance appearance;
 
+    @Inject GroupNameCell nameCell;
     @Inject AsyncProviderWrapper<GroupDetailsDialog> groupDetailsDialog;
 
     private final GroupProperties props;
@@ -80,8 +80,6 @@ public class GroupViewImpl extends Composite implements GroupView {
         ColumnConfig<Group, String> descriptionCol = new ColumnConfig<>(props.description(),
                                                                         appearance.descriptionColumnWidth(),
                                                                         appearance.descriptionColumnLabel());
-        GroupNameCell nameCell = new GroupNameCell();
-        nameCell.addGroupNameSelectedHandler(this);
         nameCol.setCell(nameCell);
         columns.add(nameCol);
         columns.add(descriptionCol);
@@ -137,20 +135,6 @@ public class GroupViewImpl extends Composite implements GroupView {
     }
 
     @Override
-    public void onGroupNameSelected(GroupNameSelected event) {
-        Group group = event.getGroup();
-        groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
-            @Override
-            public void onFailure(Throwable caught) {}
-
-            @Override
-            public void onSuccess(GroupDetailsDialog result) {
-                result.show(group);
-            }
-        });
-    }
-
-    @Override
     public HandlerRegistration addDeleteGroupSelectedHandler(DeleteGroupSelected.DeleteGroupSelectedHandler handler) {
         return addHandler(handler, DeleteGroupSelected.TYPE);
     }
@@ -158,5 +142,10 @@ public class GroupViewImpl extends Composite implements GroupView {
     @Override
     public HandlerRegistration addAddGroupSelectedHandler(AddGroupSelected.AddGroupSelectedHandler handler) {
         return addHandler(handler, AddGroupSelected.TYPE);
+    }
+
+    @Override
+    public HandlerRegistration addGroupNameSelectedHandler(GroupNameSelected.GroupNameSelectedHandler handler) {
+        return nameCell.addGroupNameSelectedHandler(handler);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -1,6 +1,5 @@
 package org.iplantc.de.collaborators.client.views;
 
-import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
@@ -113,11 +112,6 @@ public class GroupViewImpl extends Composite implements GroupView {
         listStore.remove(result);
     }
 
-    @Override
-    public void editCollabList(Group group, List<Collaborator> members) {
-
-    }
-
     @UiHandler("addGroup")
     void addGroupSelected(SelectEvent event) {
         groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
@@ -130,8 +124,8 @@ public class GroupViewImpl extends Composite implements GroupView {
                 result.addGroupSavedHandler(new GroupSaved.GroupSavedHandler() {
                     @Override
                     public void onGroupSaved(GroupSaved event) {
-                        List<Group> groups = event.getGroups();
-                        listStore.addAll(groups);
+                        Group group = event.getGroup();
+                        listStore.add(group);
                     }
                 });
             }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -2,9 +2,9 @@ package org.iplantc.de.collaborators.client.views;
 
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
-import org.iplantc.de.collaborators.client.events.GroupSaved;
 import org.iplantc.de.collaborators.client.models.GroupProperties;
 import org.iplantc.de.collaborators.client.views.cells.GroupNameCell;
 import org.iplantc.de.collaborators.client.views.dialogs.GroupDetailsDialog;
@@ -114,22 +114,7 @@ public class GroupViewImpl extends Composite implements GroupView {
 
     @UiHandler("addGroup")
     void addGroupSelected(SelectEvent event) {
-        groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
-            @Override
-            public void onFailure(Throwable caught) {}
-
-            @Override
-            public void onSuccess(GroupDetailsDialog result) {
-                result.show();
-                result.addGroupSavedHandler(new GroupSaved.GroupSavedHandler() {
-                    @Override
-                    public void onGroupSaved(GroupSaved event) {
-                        Group group = event.getGroup();
-                        listStore.add(group);
-                    }
-                });
-            }
-        });
+        fireEvent(new AddGroupSelected());
     }
 
     @UiHandler("deleteGroup")
@@ -168,5 +153,10 @@ public class GroupViewImpl extends Composite implements GroupView {
     @Override
     public HandlerRegistration addDeleteGroupSelectedHandler(DeleteGroupSelected.DeleteGroupSelectedHandler handler) {
         return addHandler(handler, DeleteGroupSelected.TYPE);
+    }
+
+    @Override
+    public HandlerRegistration addAddGroupSelectedHandler(AddGroupSelected.AddGroupSelectedHandler handler) {
+        return addHandler(handler, AddGroupSelected.TYPE);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -105,11 +105,6 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     }
 
     @Override
-    public void editCollabList(Group group, List<Collaborator> members) {
-        groupView.editCollabList(group, members);
-    }
-
-    @Override
     public MODE getMode() {
         return mode;
     }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -6,6 +6,7 @@ import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
+import org.iplantc.de.collaborators.client.events.GroupNameSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected.USER_SEARCH_EVENT_TAG;
 import org.iplantc.de.collaborators.client.models.CollaboratorKeyProvider;
@@ -241,5 +242,10 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     @Override
     public HandlerRegistration addAddGroupSelectedHandler(AddGroupSelected.AddGroupSelectedHandler handler) {
         return groupView.addAddGroupSelectedHandler(handler);
+    }
+
+    @Override
+    public HandlerRegistration addGroupNameSelectedHandler(GroupNameSelected.GroupNameSelectedHandler handler) {
+        return groupView.addGroupNameSelectedHandler(handler);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -4,6 +4,7 @@ import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
 import org.iplantc.de.collaborators.client.events.RemoveCollaboratorSelected;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected.USER_SEARCH_EVENT_TAG;
@@ -235,5 +236,10 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     @Override
     public HandlerRegistration addDeleteGroupSelectedHandler(DeleteGroupSelected.DeleteGroupSelectedHandler handler) {
         return groupView.addDeleteGroupSelectedHandler(handler);
+    }
+
+    @Override
+    public HandlerRegistration addAddGroupSelectedHandler(AddGroupSelected.AddGroupSelectedHandler handler) {
+        return groupView.addAddGroupSelectedHandler(handler);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
@@ -23,7 +23,7 @@ public class GroupDetailsDialog extends IPlantDialog implements GroupSaved.HasGr
 
     GroupDetailsView.Presenter presenter;
     GroupView.GroupViewAppearance appearance;
-    boolean isNewGroup = false;
+    GroupDetailsView.MODE mode = GroupDetailsView.MODE.EDIT;
 
     @Inject
     public GroupDetailsDialog(GroupDetailsView.Presenter presenter,
@@ -70,7 +70,7 @@ public class GroupDetailsDialog extends IPlantDialog implements GroupSaved.HasGr
      * @param group
      */
     public void show(Group group) {
-        presenter.go(this, group);
+        presenter.go(this, group, mode);
         setHeading(appearance.groupDetailsHeading(group));
         super.show();
 
@@ -81,6 +81,7 @@ public class GroupDetailsDialog extends IPlantDialog implements GroupSaved.HasGr
      * Used for displaying GroupDetailsView with a new Group
      */
     public void show() {
+        mode = GroupDetailsView.MODE.ADD;
         show(null);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.java
@@ -25,4 +25,6 @@ public interface GroupDisplayStrings extends Messages {
     String groupDeleteSuccess(String name);
 
     String unableToAddMembers(@PluralCount List<String> memberString);
+
+    String groupCreatedSuccess(String name);
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.java
@@ -2,6 +2,8 @@ package org.iplantc.de.theme.base.client.collaborators;
 
 import com.google.gwt.i18n.client.Messages;
 
+import java.util.List;
+
 /**
  * @author aramsey
  */
@@ -21,4 +23,6 @@ public interface GroupDisplayStrings extends Messages {
     String deleteGroupConfirm(String name);
 
     String groupDeleteSuccess(String name);
+
+    String unableToAddMembers(@PluralCount List<String> memberString);
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.properties
@@ -1,6 +1,7 @@
 deleteGroupConfirm=By deleting the collaborator list {0}, any data that has been shared with this list will immediately be un-shared.  Do you wish to continue deleting the collaborator list?
 deleteGroupConfirmHeading=Delete {0} Collaborator List?
 editGroupDetailsHeading=Edit {0}
+groupCreatedSuccess=Successfully created {0} Collaborator List
 groupDeleteSuccess=Successfully deleted {0} Collaborator List
 groupDescriptionLabel=Description
 groupNameLabel=Collaborator List Name

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupDisplayStrings.properties
@@ -6,3 +6,4 @@ groupDescriptionLabel=Description
 groupNameLabel=Collaborator List Name
 newGroupDetailsHeading=Create a Collaborator List
 noCollabLists = Click the Add button to start creating Collaborator Lists
+unableToAddMembers=Unable to add the following members to your Collaborator List: {0,list}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
@@ -6,7 +6,6 @@ import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.resources.client.IplantResources;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ImageResource;
@@ -159,5 +158,15 @@ public class GroupViewDefaultAppearance implements GroupView.GroupViewAppearance
         List<String> memberNames = failures.stream().map(UpdateMemberResult::getSubjectName).collect(
                 Collectors.toList());
         return displayStrings.unableToAddMembers(memberNames);
+    }
+
+    @Override
+    public String loadingMask() {
+        return iplantDisplayStrings.loadingMask();
+    }
+
+    @Override
+    public String groupCreatedSuccess(Group group) {
+        return displayStrings.groupCreatedSuccess(group.getName());
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/GroupViewDefaultAppearance.java
@@ -1,16 +1,21 @@
 package org.iplantc.de.theme.base.client.collaborators;
 
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.models.groups.UpdateMemberResult;
 import org.iplantc.de.collaborators.client.GroupView;
 import org.iplantc.de.resources.client.IplantResources;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
 
 import com.sencha.gxt.core.client.XTemplates;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author aramsey
@@ -147,5 +152,12 @@ public class GroupViewDefaultAppearance implements GroupView.GroupViewAppearance
     @Override
     public String groupDeleteSuccess(Group group) {
         return displayStrings.groupDeleteSuccess(group.getName());
+    }
+
+    @Override
+    public String unableToAddMembers(List<UpdateMemberResult> failures) {
+        List<String> memberNames = failures.stream().map(UpdateMemberResult::getSubjectName).collect(
+                Collectors.toList());
+        return displayStrings.unableToAddMembers(memberNames);
     }
 }

--- a/de-lib/src/test/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/collaborators/client/presenter/GroupDetailsPresenterImplTest.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.collaborators.client.presenter;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
@@ -9,10 +10,14 @@ import static org.mockito.Mockito.when;
 import org.iplantc.de.client.models.collaborators.Collaborator;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
+import org.iplantc.de.client.models.groups.UpdateMemberResult;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.collaborators.client.GroupDetailsView;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.events.AddGroupMemberSelected;
 import org.iplantc.de.collaborators.client.events.GroupSaved;
+import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
+import org.iplantc.de.commons.client.info.IplantAnnouncer;
 
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -28,7 +33,9 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * @author aramsey
@@ -45,9 +52,19 @@ public class GroupDetailsPresenterImplTest {
     @Mock AutoBean<Group> groupAutoBeanMock;
     @Mock List<Collaborator> collaboratorListMock;
     @Mock HandlerManager handlerManagerMock;
+    @Mock UpdateMemberResult updateResultMock;
+    @Mock List<UpdateMemberResult> updateMemberResultsMock;
+    @Mock List<UpdateMemberResult> failedUpdateResultsMock;
+    @Mock Stream<UpdateMemberResult> updateMemberResultStreamMock;
+    @Mock IplantAnnouncer announcerMock;
+    @Mock Collaborator subjectMock;
+    @Mock Iterator<Collaborator> collaboratorIteratorMock;
+    @Mock Iterator<UpdateMemberResult> resultIteratorMock;
 
     @Captor ArgumentCaptor<AsyncCallback<List<Collaborator>>> collabListCallbackCaptor;
     @Captor ArgumentCaptor<AsyncCallback<Group>> groupCallbackCaptor;
+    @Captor ArgumentCaptor<AsyncCallback<List<UpdateMemberResult>>> updateMembersCallbackCaptor;
+    @Captor ArgumentCaptor<AsyncCallback<Void>> voidCallbackCaptor;
 
     private GroupDetailsPresenterImpl uut;
 
@@ -56,6 +73,14 @@ public class GroupDetailsPresenterImplTest {
 
         when(factoryMock.getGroup()).thenReturn(groupAutoBeanMock);
         when(groupAutoBeanMock.as()).thenReturn(newGroupMock);
+        when(collaboratorListMock.size()).thenReturn(2);
+        when(collaboratorListMock.iterator()).thenReturn(collaboratorIteratorMock);
+        when(collaboratorIteratorMock.hasNext()).thenReturn(true, true, false);
+        when(collaboratorIteratorMock.next()).thenReturn(subjectMock, subjectMock);
+        when(failedUpdateResultsMock.size()).thenReturn(2);
+        when(failedUpdateResultsMock.iterator()).thenReturn(resultIteratorMock);
+        when(resultIteratorMock.hasNext()).thenReturn(true, true, false);
+        when(resultIteratorMock.next()).thenReturn(updateResultMock, updateResultMock);
 
         uut = new GroupDetailsPresenterImpl(viewMock,
                                             serviceFacadeMock,
@@ -66,7 +91,7 @@ public class GroupDetailsPresenterImplTest {
                 return handlerManagerMock;
             }
         };
-
+        uut.announcer = announcerMock;
     }
 
     @Test
@@ -74,14 +99,14 @@ public class GroupDetailsPresenterImplTest {
         HasOneWidget containerMock = mock(HasOneWidget.class);
 
         /** CALL METHOD UNDER TEST **/
-        uut.go(containerMock, groupMock);
+        uut.go(containerMock, groupMock, GroupDetailsView.MODE.EDIT);
 
         verify(containerMock).setWidget(eq(viewMock));
         verify(serviceFacadeMock).getMembers(eq(groupMock), collabListCallbackCaptor.capture());
 
         collabListCallbackCaptor.getValue().onSuccess(collaboratorListMock);
         verify(viewMock).addMembers(eq(collaboratorListMock));
-        verify(viewMock).edit(eq(groupMock));
+        verify(viewMock).edit(eq(groupMock), eq(GroupDetailsView.MODE.EDIT));
     }
 
     @Test
@@ -89,17 +114,17 @@ public class GroupDetailsPresenterImplTest {
         HasOneWidget containerMock = mock(HasOneWidget.class);
 
         /** CALL METHOD UNDER TEST **/
-        uut.go(containerMock, null);
+        uut.go(containerMock, null, GroupDetailsView.MODE.ADD);
 
         verify(containerMock).setWidget(eq(viewMock));
-        verify(viewMock).edit(eq(newGroupMock));
+        verify(viewMock).edit(eq(newGroupMock), eq(GroupDetailsView.MODE.ADD));
     }
 
     @Test
     public void saveGroupSelected_newGroup() {
         when(viewMock.getGroup()).thenReturn(groupMock);
+        uut.mode = GroupDetailsView.MODE.ADD;
         GroupDetailsPresenterImpl spy = Mockito.spy(uut);
-        spy.isNewGroup = true;
 
         /** CALL METHOD UNDER TEST **/
         spy.saveGroupSelected();
@@ -117,5 +142,43 @@ public class GroupDetailsPresenterImplTest {
 
         verify(handlerManagerMock).fireEvent(isA(GroupSaved.class));
 
+    }
+
+    @Test
+    public void updateGroupMembers_withFailures() {
+        when(collaboratorListMock.isEmpty()).thenReturn(false);
+        when(updateMemberResultsMock.stream()).thenReturn(updateMemberResultStreamMock);
+        when(updateMemberResultStreamMock.filter(any())).thenReturn(updateMemberResultStreamMock);
+        when(updateMemberResultStreamMock.collect(any())).thenReturn(failedUpdateResultsMock);
+        when(appearanceMock.unableToAddMembers(any())).thenReturn("announcement");
+        /** CALL METHOD UNDER TEST **/
+        uut.updateGroupMembers(groupMock, collaboratorListMock);
+
+        verify(serviceFacadeMock).updateMembers(eq(groupMock),
+                                                eq(collaboratorListMock),
+                                                updateMembersCallbackCaptor.capture());
+
+        updateMembersCallbackCaptor.getValue().onSuccess(updateMemberResultsMock);
+        verify(appearanceMock).unableToAddMembers(eq(failedUpdateResultsMock));
+        verify(announcerMock).schedule(isA(ErrorAnnouncementConfig.class));
+        verify(viewMock).unmask();
+    }
+
+    @Test
+    public void onAddGroupMemberSelected() {
+        AddGroupMemberSelected eventMock = mock(AddGroupMemberSelected.class);
+        when(eventMock.getGroup()).thenReturn(groupMock);
+        when(eventMock.getSubject()).thenReturn(subjectMock);
+        when(groupMock.getName()).thenReturn("name");
+
+        /** CALL METHOD UNDER TEST **/
+        uut.onAddGroupMemberSelected(eventMock);
+
+        verify(serviceFacadeMock).addMember(eq(groupMock),
+                                            eq(subjectMock),
+                                            voidCallbackCaptor.capture());
+
+        voidCallbackCaptor.getValue().onSuccess(null);
+        verify(viewMock).addMembers(any());
     }
 }


### PR DESCRIPTION
NOTE: This is rebased on top of CORE-8794 PR #121.  You only need to view the commits starting from `CORE-8792 Add endpoint for adding group members`

I had to add the concept of a mode to the GroupDetailsView for this to work - basically if you're creating a brand new Collaborator List, you're in the `ADD` mode which makes sure that the list and any members you add aren't saved until you complete the form - first the list gets saved, then the members get added.  If you're editing a list, you're in the `EDIT` mode and members get immediately added as you select them.