### PR TITLE
CORE-8833 Make app tile view selection more visible

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppsTile.gss
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/cells/AppsTile.gss
@@ -23,12 +23,12 @@
 
 .tileCell:hover {
     background-color: rgb(238,238,238);
-    outline: rgb(208,208,208) solid 2px;
+    outline: rgb(0,0,0) solid 1px;
 }
 
 .tileCellSelect {
     background-color: rgb(238,238,238);
-    outline: rgb(208,208,208) solid 2px;
+    outline: rgb(0, 0, 0) solid 1px;
 }
 
 .statusMod {


### PR DESCRIPTION
Blake asked for this change this morning. The light gray border against a white background didn’t stand out enough.  Switching to black.

Before:
![image](https://cloud.githubusercontent.com/assets/8909156/26008428/9e34445c-36f9-11e7-9eef-56e101cc15f9.png)

After:
![image](https://cloud.githubusercontent.com/assets/8909156/26008465/b8e6b208-36f9-11e7-82b8-e5c9acaca763.png)
