### PR TITLE
CORE-8845 Add deprecated tool warning when editing private apps.

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/integration/client/presenter/AppsEditorPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/integration/client/presenter/AppsEditorPresenterImpl.java
@@ -430,10 +430,12 @@ public class AppsEditorPresenterImpl implements AppsEditorView.Presenter,
     public void go(HasOneWidget container) {
         clearRegisteredHandlers();
 
-        if(appTemplate.isPublic()!=null) {
-            setLabelOnlyEditMode(appTemplate.isPublic());
-        } else {
-            setLabelOnlyEditMode(false);
+        boolean isPublic = appTemplate.isPublic() != null ? appTemplate.isPublic() : false;
+
+        setLabelOnlyEditMode(isPublic);
+
+        if (!isPublic) {
+            checkForDeprecatedTools(appTemplate.getTools());
         }
 
         view.getEditorDriver().edit(appTemplate);
@@ -814,4 +816,16 @@ public class AppsEditorPresenterImpl implements AppsEditorView.Presenter,
         }
     }
 
+    private void checkForDeprecatedTools(final List<Tool> tools) {
+        if (tools != null && !tools.isEmpty()) {
+            if (tools.stream().anyMatch(Tool::isDeprecated)) {
+                Scheduler.get().scheduleDeferred(() -> {
+                    IplantInfoBox errorsInfo = new IplantInfoBox(appearance.warning(),
+                                                                 appearance.appUsesDeprecatedTools());
+                    errorsInfo.setIcon(MessageBox.ICONS.warning());
+                    errorsInfo.show();
+                });
+            }
+        }
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/AppsEditorView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/integration/client/view/AppsEditorView.java
@@ -64,6 +64,8 @@ public interface AppsEditorView extends IsWidget,
 
         String done();
 
+        String appUsesDeprecatedTools();
+
         String appContainsErrorsUnableToSave();
 
         String unableToSave();

--- a/de-lib/src/main/java/org/iplantc/de/client/models/tool/Tool.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/tool/Tool.java
@@ -32,6 +32,8 @@ public interface Tool extends HasId, HasDescription, HasName {
     @PropertyName("version")
     String getVersion();
 
+    boolean isDeprecated();
+
     @PropertyName("implementation")
     ToolImplementation getImplementation();
 

--- a/de-lib/src/main/java/org/iplantc/de/resources/client/uiapps/integration/AppIntegrationErrorMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/resources/client/uiapps/integration/AppIntegrationErrorMessages.java
@@ -10,6 +10,8 @@ public interface AppIntegrationErrorMessages {
 
     String appContainsErrorsPromptToContinue();
 
+    String appUsesDeprecatedTools();
+
     SafeHtml cannotDeleteLastArgumentGroup();
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/integration/AppsEditorViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/integration/AppsEditorViewDefaultAppearance.java
@@ -107,6 +107,11 @@ public class AppsEditorViewDefaultAppearance implements AppsEditorView.AppsEdito
     }
 
     @Override
+    public String appUsesDeprecatedTools() {
+        return errorStrings.appUsesDeprecatedTools();
+    }
+
+    @Override
     public String appContainsErrorsUnableToSave() {
         return errorStrings.appContainsErrorsUnableToSave();
     }

--- a/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantErrorStrings.properties
+++ b/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantErrorStrings.properties
@@ -84,6 +84,8 @@ workflowValidationError = A workflow must have a name and description, 2 or more
 markAsSeenFailed = Unable to mark notifications as read!
 # AppIntegrationErrorMessages
 unableToSave = Failed to save app. Please try again later.
+appUsesDeprecatedTools = This app uses a deprecated tool. You can still edit and use this private app, \
+  but you will have to choose a newer version of the tool before it can be made public.
 appContainsErrorsUnableToSave = App Editor contains errors and cannot be saved.
 appContainsErrorsPromptToContinue = App Editor contains errors and cannot be saved. Do you wish to abandon all changes and continue?
 cannotDeleteLastArgumentGroup = Cannot delete section. App must contain at least one section.


### PR DESCRIPTION
If the user opens (or copies) an app for editing, and that app uses a tool that has been marked as `deprecated`, then the following warning message will display in a dialog pop-up:

> This app uses a deprecated tool. You can still edit and use this private app, but you will have to choose a newer version of the tool before it can be made public.

This message will not display when a user opens a public app to edit its labels.