### PR TITLE
CORE-8795 Allow users to share resources with a Group

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/gin/AnalysisGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/gin/AnalysisGinModule.java
@@ -20,7 +20,7 @@ import org.iplantc.de.analysis.client.views.parameters.AnalysisParametersViewImp
 import org.iplantc.de.analysis.client.views.sharing.AnalysisSharingView;
 import org.iplantc.de.analysis.client.views.sharing.AnalysisSharingViewImpl;
 import org.iplantc.de.client.models.analysis.Analysis;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/gin/factory/AnalysisSharingPresenterFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/gin/factory/AnalysisSharingPresenterFactory.java
@@ -1,7 +1,7 @@
 package org.iplantc.de.analysis.client.gin.factory;
 
 import org.iplantc.de.client.models.analysis.Analysis;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 
 import java.util.List;
 

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/sharing/AnalysisSharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/sharing/AnalysisSharingPresenter.java
@@ -5,6 +5,7 @@
 package org.iplantc.de.analysis.client.presenter.sharing;
 
 import org.iplantc.de.analysis.client.views.sharing.AnalysisSharingView;
+import org.iplantc.de.analysis.shared.AnalysisModule;
 import org.iplantc.de.commons.client.gin.factory.SharingPermissionViewFactory;
 import org.iplantc.de.client.models.analysis.Analysis;
 import org.iplantc.de.client.models.analysis.sharing.AnalysisPermission;
@@ -194,6 +195,12 @@ public class AnalysisSharingPresenter implements SharingPresenter {
         }
 
 
+    }
+
+    @Override
+    public void setViewDebugId(String debugId) {
+        sharingView.asWidget().ensureDebugId(debugId + AnalysisModule.Ids.SHARING_VIEW);
+        permissionsPanel.asWidget().ensureDebugId(debugId + AnalysisModule.Ids.SHARING_VIEW + AnalysisModule.Ids.SHARING_PERMS);
     }
 
     private AnalysisSharingRequestList buildSharingRequest() {

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/sharing/AnalysisSharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/sharing/AnalysisSharingPresenter.java
@@ -207,9 +207,9 @@ public class AnalysisSharingPresenter implements SharingPresenter {
             for (String userName : sharingMap.keySet()) {
                 AnalysisSharingRequest sharingRequest = shareFactory.AnalysisSharingRequest().as();
                 SharingSubject sharingSubject = shareFactory.getSharingSubject().as();
-                sharingSubject.setSourceId("ldap");
-                sharingSubject.setId(userName);
                 List<Sharing> shareList = sharingMap.get(userName);
+                sharingSubject.setSourceId(getSourceId(shareList));
+                sharingSubject.setId(userName);
                 sharingRequest.setSubject(sharingSubject);
                 sharingRequest.setAnalysisPermissions(buildAnalysisPermissions(shareList));
                 requests.add(sharingRequest);
@@ -219,6 +219,11 @@ public class AnalysisSharingPresenter implements SharingPresenter {
             sharingRequestList.setAnalysisSharingRequestList(requests);
         }
         return sharingRequestList;
+    }
+
+    String getSourceId(List<Sharing> shareList) {
+        Sharing share = shareList.get(0);
+        return share.getSourceId();
     }
 
     private List<AnalysisPermission> buildAnalysisPermissions(List<Sharing> shareList) {
@@ -245,7 +250,7 @@ public class AnalysisSharingPresenter implements SharingPresenter {
 
                 AnalysisUnsharingRequest unsharingRequest = shareFactory.AnalysisUnsharingRequest().as();
                 SharingSubject sharingSubject = shareFactory.getSharingSubject().as();
-                sharingSubject.setSourceId("ldap");
+                sharingSubject.setSourceId(getSourceId(shareList));
                 sharingSubject.setId(userName);
                 unsharingRequest.setSubject(sharingSubject);
                 unsharingRequest.setAnalyses(buildUnshareAnalysisPermissionList(shareList));

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/sharing/AnalysisSharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/sharing/AnalysisSharingPresenter.java
@@ -5,7 +5,7 @@
 package org.iplantc.de.analysis.client.presenter.sharing;
 
 import org.iplantc.de.analysis.client.views.sharing.AnalysisSharingView;
-import org.iplantc.de.client.gin.factory.SharingPermissionViewFactory;
+import org.iplantc.de.commons.client.gin.factory.SharingPermissionViewFactory;
 import org.iplantc.de.client.models.analysis.Analysis;
 import org.iplantc.de.client.models.analysis.sharing.AnalysisPermission;
 import org.iplantc.de.client.models.analysis.sharing.AnalysisSharingAutoBeanFactory;
@@ -23,8 +23,8 @@ import org.iplantc.de.client.models.sharing.SharingSubject;
 import org.iplantc.de.client.models.sharing.UserPermission;
 import org.iplantc.de.client.services.AnalysisServiceFacade;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
-import org.iplantc.de.client.sharing.SharingPermissionView;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.views.sharing.SharingPermissionView;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/views/dialogs/AnalysisSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/views/dialogs/AnalysisSharingDialog.java
@@ -2,7 +2,7 @@ package org.iplantc.de.analysis.client.views.dialogs;
 
 import org.iplantc.de.analysis.client.gin.factory.AnalysisSharingPresenterFactory;
 import org.iplantc.de.client.models.analysis.Analysis;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
 import com.google.common.base.Preconditions;

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/views/dialogs/AnalysisSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/views/dialogs/AnalysisSharingDialog.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.analysis.client.views.dialogs;
 
 import org.iplantc.de.analysis.client.gin.factory.AnalysisSharingPresenterFactory;
+import org.iplantc.de.analysis.shared.AnalysisModule;
 import org.iplantc.de.client.models.analysis.Analysis;
 import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
@@ -33,6 +34,13 @@ public class AnalysisSharingDialog extends IPlantDialog implements SelectHandler
     }
 
     @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        sharingPresenter.setViewDebugId(baseID);
+    }
+
+    @Override
     public void onSelect(SelectEvent event) {
         Preconditions.checkNotNull(sharingPresenter);
         sharingPresenter.processRequest();
@@ -42,6 +50,8 @@ public class AnalysisSharingDialog extends IPlantDialog implements SelectHandler
         sharingPresenter = factory.create(analyses);
         sharingPresenter.go(this);
         super.show();
+
+        ensureDebugId(AnalysisModule.Ids.SHARING_DLG);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/analysis/shared/AnalysisModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/shared/AnalysisModule.java
@@ -29,5 +29,8 @@ public interface AnalysisModule {
         String SHARE_MENU =".share";
         String SHARE_COLLAB = ".sharecollab";
         String SHARE_SUPPORT =".sharesupport";
+        String SHARING_DLG = "analysisSharingDlg";
+        String SHARING_VIEW = ".view";
+        String SHARING_PERMS = ".permPanel";
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/gin/AppsGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/gin/AppsGinModule.java
@@ -43,7 +43,7 @@ import org.iplantc.de.client.services.AppMetadataServiceFacade;
 import org.iplantc.de.client.services.OntologyServiceFacade;
 import org.iplantc.de.client.services.impl.AppMetadataServiceFacadeImpl;
 import org.iplantc.de.client.services.impl.OntologyServiceFacadeImpl;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/gin/factory/AppSharingPresenterFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/gin/factory/AppSharingPresenterFactory.java
@@ -1,7 +1,7 @@
 package org.iplantc.de.apps.client.gin.factory;
 
 import org.iplantc.de.client.models.apps.App;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 
 import java.util.List;
 

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/sharing/AppSharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/sharing/AppSharingPresenter.java
@@ -4,6 +4,7 @@
 package org.iplantc.de.apps.client.presenter.sharing;
 
 import org.iplantc.de.apps.client.views.sharing.AppSharingView;
+import org.iplantc.de.apps.shared.AppsModule;
 import org.iplantc.de.commons.client.gin.factory.SharingPermissionViewFactory;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppAutoBeanFactory;
@@ -191,6 +192,12 @@ public class AppSharingPresenter implements SharingPresenter {
             IplantAnnouncer.getInstance().schedule(appearance.sharingCompleteMsg());
         }
 
+    }
+
+    @Override
+    public void setViewDebugId(String debugId) {
+        view.asWidget().ensureDebugId(debugId + AppsModule.Ids.SHARING_VIEW);
+        permissionsPanel.asWidget().ensureDebugId(debugId + AppsModule.Ids.SHARING_VIEW + AppsModule.Ids.SHARING_PERMS);
     }
 
     private AppSharingRequestList buildSharingRequest() {

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/sharing/AppSharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/sharing/AppSharingPresenter.java
@@ -204,9 +204,9 @@ public class AppSharingPresenter implements SharingPresenter {
             for (String userName : sharingMap.keySet()) {
                 AppSharingRequest sharingRequest = appFactory.appSharingRequest().as();
                 SharingSubject sharingSubject = shareFactory.getSharingSubject().as();
-                sharingSubject.setSourceId("ldap");
-                sharingSubject.setId(userName);
                 List<Sharing> shareList = sharingMap.get(userName);
+                sharingSubject.setSourceId(getSourceId(shareList));
+                sharingSubject.setId(userName);
                 sharingRequest.setSubject(sharingSubject);
                 sharingRequest.setAppPermissions(buildShareAppPermissionList(shareList));
                 requests.add(sharingRequest);
@@ -217,6 +217,11 @@ public class AppSharingPresenter implements SharingPresenter {
         }
 
         return sharingRequestList;
+    }
+
+    String getSourceId(List<Sharing> shareList) {
+        Sharing share = shareList.get(0);
+        return share.getSourceId();
     }
 
     private AppUnSharingRequestList buildUnSharingRequest() {
@@ -233,7 +238,7 @@ public class AppSharingPresenter implements SharingPresenter {
                 AppSharingRequest unsharingRequest = appFactory.appSharingRequest().as();
                 SharingSubject sharingSubject = shareFactory.getSharingSubject().as();
                 sharingSubject.setId(userName);
-                sharingSubject.setSourceId("ldap");
+                sharingSubject.setSourceId(getSourceId(shareList));
                 unsharingRequest.setSubject(sharingSubject);
                 unsharingRequest.setAppPermissions(buildUnshareAppPermissionList(shareList));
                 requests.add(unsharingRequest);

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/sharing/AppSharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/sharing/AppSharingPresenter.java
@@ -4,7 +4,7 @@
 package org.iplantc.de.apps.client.presenter.sharing;
 
 import org.iplantc.de.apps.client.views.sharing.AppSharingView;
-import org.iplantc.de.client.gin.factory.SharingPermissionViewFactory;
+import org.iplantc.de.commons.client.gin.factory.SharingPermissionViewFactory;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppAutoBeanFactory;
 import org.iplantc.de.client.models.apps.sharing.AppPermission;
@@ -22,8 +22,8 @@ import org.iplantc.de.client.models.sharing.SharingSubject;
 import org.iplantc.de.client.models.sharing.UserPermission;
 import org.iplantc.de.client.services.AppUserServiceFacade;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
-import org.iplantc.de.client.sharing.SharingPermissionView;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.views.sharing.SharingPermissionView;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/sharing/AppSharingViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/sharing/AppSharingViewImpl.java
@@ -5,7 +5,6 @@
 package org.iplantc.de.apps.client.views.sharing;
 
 import org.iplantc.de.client.models.apps.App;
-import org.iplantc.de.client.sharing.SharingPresenter;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/sharing/dialog/AppSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/sharing/dialog/AppSharingDialog.java
@@ -6,7 +6,7 @@ package org.iplantc.de.apps.client.views.sharing.dialog;
 
 import org.iplantc.de.apps.client.gin.factory.AppSharingPresenterFactory;
 import org.iplantc.de.client.models.apps.App;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
 import com.google.common.base.Preconditions;

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/sharing/dialog/AppSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/sharing/dialog/AppSharingDialog.java
@@ -5,6 +5,7 @@
 package org.iplantc.de.apps.client.views.sharing.dialog;
 
 import org.iplantc.de.apps.client.gin.factory.AppSharingPresenterFactory;
+import org.iplantc.de.apps.shared.AppsModule;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
@@ -49,6 +50,8 @@ public class AppSharingDialog extends IPlantDialog implements SelectHandler {
         sharingPresenter = factory.create(resourcesToShare);
         sharingPresenter.go(this);
         super.show();
+
+        ensureDebugId(AppsModule.Ids.SHARING_DLG);
     }
 
     @Override
@@ -56,4 +59,10 @@ public class AppSharingDialog extends IPlantDialog implements SelectHandler {
         throw new UnsupportedOperationException("This method is not supported for this class. ");
     }
 
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        sharingPresenter.setViewDebugId(baseID);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/shared/AppsModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/shared/AppsModule.java
@@ -48,6 +48,9 @@ public interface AppsModule {
         String SWAP_VIEW_BTN = ".swapBtn";
         String APP_STATUS_CELL = ".status";
         String MENU_ITEM_REFRESH = ".refresh";
+        String SHARING_DLG = "appSharingDlg";
+        String SHARING_VIEW = ".view";
+        String SHARING_PERMS = ".permPanel";
     }
 }
 

--- a/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Subject.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Subject.java
@@ -2,6 +2,8 @@ package org.iplantc.de.client.models.collaborators;
 
 import org.iplantc.de.client.models.HasSettableId;
 
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.user.client.ui.HasName;
 import com.google.web.bindery.autobean.shared.AutoBean;
 
@@ -9,9 +11,14 @@ import java.util.List;
 
 /**
  * The autobean representation of a Grouper subject
+ * Also some helper methods to determine if the subject is a collaborator list and how
+ * to get the display name
  * @author aramsey
  */
 public interface Subject extends HasSettableId, HasName {
+
+    String GROUP_IDENTIFIER = "g:gsa";
+    String GROUP_LONG_NAME_REGEX = ".*collaborator-lists:(.+)";
 
     @AutoBean.PropertyName("first_name")
     String getFirstName();
@@ -48,4 +55,36 @@ public interface Subject extends HasSettableId, HasName {
 
     @AutoBean.PropertyName("source_id")
     void setSourceId(String sourceId);
+
+    default boolean isCollaboratorList() {
+        return getSourceId().equals(GROUP_IDENTIFIER);
+    }
+
+    default String getSubjectDisplayName() {
+        String subjectName = getName();
+        if (!isCollaboratorList() || !hasCollaboratorListLongName(subjectName)) {
+            return subjectName;
+        } else {
+            return getCollaboratorListDisplayName(subjectName);
+        }
+    }
+
+    default boolean hasCollaboratorListLongName(String name) {
+        RegExp regex = RegExp.compile(GROUP_LONG_NAME_REGEX);
+        return regex.test(name);
+    }
+
+    /**
+     * Currently subject.getName from the GET /subjects endpoints returns the full name, for example
+     * iplant:de:de-2:users:aramsey:collaborator-lists:test
+     *
+     * Instead, we want to return the part that comes after "collaborator-lists:"
+     * @param name
+     * @return
+     */
+    default String getCollaboratorListDisplayName(String name) {
+        RegExp regex = RegExp.compile(GROUP_LONG_NAME_REGEX);
+        MatchResult match = regex.exec(name);
+        return match.getGroup(1);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Subject.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Subject.java
@@ -2,6 +2,7 @@ package org.iplantc.de.client.models.collaborators;
 
 import org.iplantc.de.client.models.HasSettableId;
 
+import com.google.common.base.Strings;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.user.client.ui.HasName;
@@ -62,6 +63,9 @@ public interface Subject extends HasSettableId, HasName {
 
     default String getSubjectDisplayName() {
         String subjectName = getName();
+        if (Strings.isNullOrEmpty(subjectName)) {
+            subjectName = getFirstName() + " " + getLastName();
+        }
         if (!isCollaboratorList() || !hasCollaboratorListLongName(subjectName)) {
             return subjectName;
         } else {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataPermission.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataPermission.java
@@ -1,0 +1,16 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import org.iplantc.de.client.models.HasPath;
+
+/**
+ * The autobean representation of a disk resource and permission being applied
+ * to that resource
+ * @author aramsey
+ */
+public interface DataPermission extends HasPath {
+
+    void setPath(String path);
+
+    String getPermission();
+    void setPermission(String permission);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataPermissionList.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataPermissionList.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import static com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+import java.util.List;
+
+/**
+ * The autobean representation of a list of DataPermission objects
+ *
+ * @author aramsey
+ */
+public interface DataPermissionList {
+    @PropertyName("paths")
+    List<DataPermission> getDataPermissions();
+
+    @PropertyName("paths")
+    void setDataPermissions(List<DataPermission> dataPermissions);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataSharingAutoBeanFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataSharingAutoBeanFactory.java
@@ -1,0 +1,28 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import com.google.web.bindery.autobean.shared.AutoBean;
+import com.google.web.bindery.autobean.shared.AutoBeanFactory;
+
+/**
+ * The autobean factory for all the sharing autobeans for disk resources
+ * @author aramsey
+ */
+public interface DataSharingAutoBeanFactory extends AutoBeanFactory {
+
+    AutoBean<DataPermission> getDataPermission();
+
+    AutoBean<DataPermissionList> getDataPermissionList();
+
+    AutoBean<DataSharingRequest> getDataSharingRequest();
+
+    AutoBean<DataUserPermission> getDataUserPermission();
+
+    AutoBean<DataUserPermissionList> getDataUserPermissionList();
+
+    AutoBean<DataSharingRequestList> getDataSharingRequestList();
+
+    AutoBean<DataUnsharingRequest> getDataUnsharingRequest();
+
+    AutoBean<DataUnsharingRequestList> getDataUnsharingRequestList();
+
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataSharingRequest.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataSharingRequest.java
@@ -1,0 +1,24 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import static com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+import java.util.List;
+
+/**
+ * The autobean representation of the JSON object expected when sharing
+ * a file or folder
+ *
+ * @author aramsey
+ */
+public interface DataSharingRequest {
+
+    String getUser();
+
+    void setUser(String user);
+
+    @PropertyName("paths")
+    List<DataPermission> getDataPermissions();
+
+    @PropertyName("paths")
+    void setDataPermissions(List<DataPermission> dataPermissions);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataSharingRequestList.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataSharingRequestList.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+import java.util.List;
+
+/**
+ * The autobean representation of a list of DataSharingRequest objects
+ *
+ * @author aramsey
+ */
+public interface DataSharingRequestList {
+    @PropertyName("sharing")
+    List<DataSharingRequest> getDataSharingRequestList();
+
+    @PropertyName("sharing")
+    void setDataSharingRequestList(List<DataSharingRequest> dataSharingRequests);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUnsharingRequest.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUnsharingRequest.java
@@ -1,0 +1,16 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import java.util.List;
+
+/**
+ * The autobean representation of the request to unshare a file or folder
+ * @author aramsey
+ */
+public interface DataUnsharingRequest {
+
+    String getUser();
+    void setUser(String user);
+
+    List<String> getPaths();
+    void setPaths(List<String> paths);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUnsharingRequestList.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUnsharingRequestList.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+import java.util.List;
+
+/**
+ * The autobean representation of a list of DataUnsharingRequest objects
+ * @author aramsey
+ */
+public interface DataUnsharingRequestList {
+
+    @PropertyName("unshare")
+    List<DataUnsharingRequest> getDataUnsharingRequests();
+
+    @PropertyName("unshare")
+    void setDataUnsharingRequests(List<DataUnsharingRequest> dataUnsharingRequests);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUserPermission.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUserPermission.java
@@ -3,7 +3,7 @@ package org.iplantc.de.client.models.diskResources.sharing;
 import static com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 
 import org.iplantc.de.client.models.HasPath;
-import org.iplantc.de.client.models.sharing.UserPermission;
+import org.iplantc.de.client.models.sharing.OldUserPermission;
 
 import java.util.List;
 
@@ -16,9 +16,9 @@ import java.util.List;
 public interface DataUserPermission extends HasPath {
 
     @PropertyName("user-permissions")
-    List<UserPermission> getUserPermissions();
+    List<OldUserPermission> getUserPermissions();
 
     @PropertyName("user-permissions")
-    void setUserPermissions(List<UserPermission> userPermissions);
+    void setUserPermissions(List<OldUserPermission> userPermissions);
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUserPermission.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUserPermission.java
@@ -1,0 +1,24 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import static com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+import org.iplantc.de.client.models.HasPath;
+import org.iplantc.de.client.models.sharing.UserPermission;
+
+import java.util.List;
+
+/**
+ * The autobean representation of a disk resource path and the associated
+ * permissions on that path
+ *
+ * @author aramsey
+ */
+public interface DataUserPermission extends HasPath {
+
+    @PropertyName("user-permissions")
+    List<UserPermission> getUserPermissions();
+
+    @PropertyName("user-permissions")
+    void setUserPermissions(List<UserPermission> userPermissions);
+
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUserPermissionList.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/sharing/DataUserPermissionList.java
@@ -1,0 +1,19 @@
+package org.iplantc.de.client.models.diskResources.sharing;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+import java.util.List;
+
+/**
+ * The autobean representation of a list of DataUserPermission objects
+ *
+ * @author aramsey
+ */
+public interface DataUserPermissionList {
+
+    @PropertyName("paths")
+    List<DataUserPermission> getDataUserPermissions();
+
+    @PropertyName("paths")
+    void setDataUserPermissions(List<DataUserPermission> dataUserPermissions);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/groups/Group.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/groups/Group.java
@@ -20,4 +20,13 @@ public interface Group extends Subject, HasDescription {
 
     String getExtension();
 
+    default String getSubjectDisplayName() {
+        String groupName = getName();
+        if (!hasCollaboratorListLongName(groupName)) {
+            return groupName;
+        } else {
+            return getCollaboratorListDisplayName(groupName);
+        }
+    }
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/sharing/OldUserPermission.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/sharing/OldUserPermission.java
@@ -1,0 +1,21 @@
+package org.iplantc.de.client.models.sharing;
+
+/**
+ * The autobean representation of the user and the permissions being applied
+ * to a disk resource object - eventually this should migrate over to UserPermission
+ * like the other resources
+ * @author aramsey
+ */
+public interface OldUserPermission {
+
+    String getUser();
+    void setUser(String user);
+
+    /**
+     * @return permission for the user
+     */
+    String getPermission();
+
+    void setPermission(String permission);
+
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
@@ -117,19 +117,7 @@ public class Sharing {
         return subject;
     }
 
-
-    public String getCollaboratorName() {
-        StringBuilder builder = new StringBuilder();
-        if (getSubject().getFirstName() != null && !getSubject().getFirstName().isEmpty()) {
-            builder.append(getSubject().getFirstName());
-            if (getSubject().getLastName() != null && !getSubject().getLastName().isEmpty()) {
-                builder.append(" ");
-                builder.append(getSubject().getLastName());
-            }
-            return builder.toString();
-        } else {
-            return getSubject().getId();
-        }
+    public String getSubjectName() {
+        return subject.getSubjectDisplayName();
     }
-
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
@@ -20,18 +20,18 @@ public class Sharing {
     private String name;
 
 
-    public Sharing(final Subject c, final PermissionValue p, final String id, final String name) {
-        this(c, p, null, id, name);
+    public Sharing(final Subject subject, final PermissionValue permission, final String id, final String name) {
+        this(subject, permission, null, id, name);
     }
 
-    public Sharing(final Subject c, final PermissionValue p, final String systemId, final String id, final String name) {
-        this.subject = c;
+    public Sharing(final Subject subject, final PermissionValue permission, final String systemId, final String id, final String name) {
+        this.subject = subject;
         this.systemId = systemId;
         setId(id);
         setName(name);
-        if (p != null) {
-            permission = p;
-            displayPermission = permission;
+        if (permission != null) {
+            this.permission = permission;
+            displayPermission = this.permission;
         }
 
     }
@@ -74,7 +74,7 @@ public class Sharing {
     }
 
     public String getKey() {
-        return getSubject().getId() + getSystemId() + getId();
+        return getSubject().getId();
     }
 
     public void setPermission(PermissionValue perm) {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
@@ -68,9 +68,8 @@ public class Sharing {
         this.systemId = systemId;
     }
 
-    //TODO REMOVE ME, I'M TEMPORARY
     public String getSourceId() {
-        return "ldap";
+        return subject.getSourceId();
     }
 
     public String getKey() {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
@@ -6,6 +6,7 @@ package org.iplantc.de.client.models.sharing;
 
 import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.diskResources.PermissionValue;
+import org.iplantc.de.client.models.groups.Group;
 
 /**
  * @author sriram
@@ -69,6 +70,9 @@ public class Sharing {
     }
 
     public String getSourceId() {
+        if (subject instanceof Group) {
+            return Subject.GROUP_IDENTIFIER;
+        }
         return subject.getSourceId();
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
@@ -12,11 +12,12 @@ import org.iplantc.de.client.models.diskResources.MetadataTemplate;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
 import org.iplantc.de.client.models.diskResources.RootFolders;
 import org.iplantc.de.client.models.diskResources.TYPE;
+import org.iplantc.de.client.models.diskResources.sharing.DataSharingRequestList;
+import org.iplantc.de.client.models.diskResources.sharing.DataUnsharingRequestList;
 import org.iplantc.de.client.models.services.DiskResourceMove;
 import org.iplantc.de.client.models.viewer.InfoType;
 import org.iplantc.de.shared.DECallback;
 
-import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.web.bindery.autobean.shared.Splittable;
 
@@ -184,27 +185,24 @@ public interface DiskResourceServiceFacade {
      * 
      * Share a resource with give user with permission
      * 
-     * 
-     * @param body - Post body in JSONObject format
+     *  @param requestList - Post body in JSONObject format
      * @param callback callback object
      */
-    void shareDiskResource(JSONObject body, AsyncCallback<String> callback);
+    void shareDiskResource(DataSharingRequestList requestList, AsyncCallback<String> callback);
 
     /**
      * UnShare a resource with give user with permission
-     * 
-     * @param body - Post body in JSONObject format
+     *  @param unsharingRequestList - Post body in JSONObject format
      * @param callback callback object
      */
-    void unshareDiskResource(JSONObject body, AsyncCallback<String> callback);
+    void unshareDiskResource(DataUnsharingRequestList unsharingRequestList, AsyncCallback<String> callback);
 
     /**
      * get user permission info on selected disk resources
-     * 
-     * @param body - Post body in JSONObject format
+     *  @param paths - Post body in JSONObject format
      * @param callback callback object
      */
-    void getPermissions(JSONObject body, DECallback<String> callback);
+    void getPermissions(HasPaths paths, DECallback<String> callback);
 
     /**
      * Get info about a selected file or folder

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/CollaboratorListCallbackConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/CollaboratorListCallbackConverter.java
@@ -36,6 +36,7 @@ public class CollaboratorListCallbackConverter extends AsyncCallbackConverter<St
             public void accept(OldCollaborator oldCollaborator) {
                 Subject subject = factory.getSubject().as();
                 subject.setId(oldCollaborator.getUserName());
+                subject.setName(oldCollaborator.getName());
                 subject.setFirstName(oldCollaborator.getFirstName());
                 subject.setLastName(oldCollaborator.getLastName());
                 subject.setEmail(oldCollaborator.getEmail());

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/FastMapCollaboratorCallbackConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/FastMapCollaboratorCallbackConverter.java
@@ -1,7 +1,6 @@
 package org.iplantc.de.client.services.converters;
 
 import org.iplantc.de.client.models.collaborators.CollaboratorAutoBeanFactory;
-import org.iplantc.de.client.models.collaborators.OldCollaborator;
 import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.util.JsonUtil;
 
@@ -33,20 +32,10 @@ public class FastMapCollaboratorCallbackConverter extends AsyncCallbackConverter
 
             for (String username : users.keySet()) {
                 JSONObject userJson = jsonUtil.getObject(users, username);
-                OldCollaborator oldCollaborator = AutoBeanCodex.decode(factory, OldCollaborator.class,
+                Subject subject = AutoBeanCodex.decode(factory, Subject.class,
                                                                       userJson.toString()).as();
-                Subject subject = factory.getSubject().as();
-                subject.setId(oldCollaborator.getUserName());
-                subject.setFirstName(oldCollaborator.getFirstName());
-                subject.setLastName(oldCollaborator.getLastName());
-                subject.setName(oldCollaborator.getName());
-                subject.setEmail(oldCollaborator.getEmail());
-                subject.setInstitution(oldCollaborator.getInstitution());
-                subject.setSourceId("ldap");
-
                 userResults.put(username, subject);
             }
-
         }
         return userResults;
     }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/FastMapCollaboratorCallbackConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/FastMapCollaboratorCallbackConverter.java
@@ -1,12 +1,12 @@
 package org.iplantc.de.client.services.converters;
 
-import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.collaborators.CollaboratorAutoBeanFactory;
+import org.iplantc.de.client.models.collaborators.OldCollaborator;
+import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.util.JsonUtil;
 
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 
 import com.sencha.gxt.core.shared.FastMap;
@@ -33,9 +33,18 @@ public class FastMapCollaboratorCallbackConverter extends AsyncCallbackConverter
 
             for (String username : users.keySet()) {
                 JSONObject userJson = jsonUtil.getObject(users, username);
-                AutoBean<Subject> bean = AutoBeanCodex.decode(factory, Subject.class,
-                                                              userJson.toString());
-                userResults.put(username, bean.as());
+                OldCollaborator oldCollaborator = AutoBeanCodex.decode(factory, OldCollaborator.class,
+                                                                      userJson.toString()).as();
+                Subject subject = factory.getSubject().as();
+                subject.setId(oldCollaborator.getUserName());
+                subject.setFirstName(oldCollaborator.getFirstName());
+                subject.setLastName(oldCollaborator.getLastName());
+                subject.setName(oldCollaborator.getName());
+                subject.setEmail(oldCollaborator.getEmail());
+                subject.setInstitution(oldCollaborator.getInstitution());
+                subject.setSourceId("ldap");
+
+                userResults.put(username, subject);
             }
 
         }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/CollaboratorsServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/CollaboratorsServiceFacadeImpl.java
@@ -17,6 +17,7 @@ import org.iplantc.de.shared.DEProperties;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.shared.services.ServiceCallWrapper;
 
+import com.google.common.base.Joiner;
 import com.google.gwt.http.client.URL;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
@@ -95,18 +96,9 @@ public class CollaboratorsServiceFacadeImpl implements CollaboratorsServiceFacad
         address.append("user-info"); //$NON-NLS-1$
 
         if (usernames != null && !usernames.isEmpty()) {
-            address.append("?"); //$NON-NLS-1$
-            boolean first = true;
-            for (String user : usernames) {
-                if (first) {
-                    first = false;
-                } else {
-                    address.append("&"); //$NON-NLS-1$
-                }
-
-                address.append("username="); //$NON-NLS-1$
-                address.append(URL.encodeQueryString(user.trim()));
-            }
+            address.append("?username="); //$NON-NLS-1$
+            String userList = Joiner.on("&username=").join(usernames);
+            address.append(URL.encode(userList));
         }
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(address.toString());

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
@@ -25,6 +25,8 @@ import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateInfoList;
 import org.iplantc.de.client.models.diskResources.RootFolders;
 import org.iplantc.de.client.models.diskResources.TYPE;
+import org.iplantc.de.client.models.diskResources.sharing.DataSharingRequestList;
+import org.iplantc.de.client.models.diskResources.sharing.DataUnsharingRequestList;
 import org.iplantc.de.client.models.services.DiskResourceMove;
 import org.iplantc.de.client.models.services.DiskResourceRename;
 import org.iplantc.de.client.models.viewer.InfoType;
@@ -664,12 +666,13 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void shareDiskResource(JSONObject body, AsyncCallback<String> callback) {
+    public void shareDiskResource(DataSharingRequestList requestList, AsyncCallback<String> callback) {
         String address = deProperties.getMuleServiceBaseUrl() + "share"; //$NON-NLS-1$
         HashMap<String, String> mdcMap = Maps.newHashMap();
         mdcMap.put(METRIC_TYPE_KEY, SHARE_EVENT);
 
-        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, body.toString());
+        String payload = AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(requestList)).getPayload();
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, payload);
 
         deServiceFacade.getServiceData(wrapper,
                                        mdcMap,
@@ -677,12 +680,14 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void unshareDiskResource(JSONObject body, AsyncCallback<String> callback) {
+    public void unshareDiskResource(DataUnsharingRequestList unsharingRequestList, AsyncCallback<String> callback) {
         String address = deProperties.getMuleServiceBaseUrl() + "unshare"; //$NON-NLS-1$
         HashMap<String, String> mdcMap = Maps.newHashMap();
         mdcMap.put(METRIC_TYPE_KEY, SHARE_EVENT);
 
-        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, body.toString());
+        String payload = AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(unsharingRequestList)).getPayload();
+
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, payload);
 
         deServiceFacade.getServiceData(wrapper,
                                        mdcMap,
@@ -690,9 +695,10 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
     }
 
     @Override
-    public void getPermissions(JSONObject body, DECallback<String> callback) {
+    public void getPermissions(HasPaths paths, DECallback<String> callback) {
         String fullAddress = deProperties.getDataMgmtBaseUrl() + "user-permissions"; //$NON-NLS-1$
-        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, body.toString());
+        String payload = AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(paths)).getPayload();
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, fullAddress, payload);
         callService(wrapper, callback);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/client/sharing/SharingPermissionsPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/sharing/SharingPermissionsPanel.java
@@ -19,7 +19,9 @@ import com.google.gwt.core.shared.GWT;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.uibinder.client.UiTemplate;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -44,7 +46,6 @@ import com.sencha.gxt.widget.core.client.event.SelectEvent.SelectHandler;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
-import com.sencha.gxt.widget.core.client.toolbar.FillToolItem;
 import com.sencha.gxt.widget.core.client.toolbar.ToolBar;
 
 import java.util.ArrayList;
@@ -54,8 +55,8 @@ import java.util.List;
 /**
  * @author sriram, jstroot
  */
-public class SharingPermissionsPanel implements SharingPermissionView,
-                                                UserSearchResultSelected.UserSearchResultSelectedEventHandler {
+public class SharingPermissionsPanel
+        implements SharingPermissionView, UserSearchResultSelected.UserSearchResultSelectedEventHandler {
 
     @UiTemplate("SharingPermissionsView.ui.xml")
     interface MyUiBinder extends UiBinder<Widget, SharingPermissionsPanel> {
@@ -63,17 +64,19 @@ public class SharingPermissionsPanel implements SharingPermissionView,
 
     @UiField Grid<Sharing> grid;
     @UiField ToolBar toolbar;
-    @UiField(provided = true) ListStore<Sharing> listStore;
-    @UiField(provided = true) ColumnModel<Sharing> cm;
+    @UiField HorizontalPanel explainPanel;
+    @UiField TextButton explainBtn;
+    @UiField TextButton chooseCollabBtn;
+    @UiField ListStore<Sharing> listStore;
+    @UiField ColumnModel<Sharing> cm;
     @UiField VerticalLayoutContainer container;
     @UiField(provided = true) final SharingAppearance appearance;
-    private UserSearchField searchField;
+    @UiField(provided = true) UserSearchField searchField;
 
     private FastMap<List<Sharing>> originalList;
     private final FastMap<SharedResource> resources;
     private final SharingPresenter presenter;
     private FastMap<List<Sharing>> sharingMap;
-    private HorizontalPanel explainPanel;
     final Widget widget;
 
     @Inject AsyncProviderWrapper<ManageCollaboratorsDialog> collaboratorsDialogProvider;
@@ -89,9 +92,7 @@ public class SharingPermissionsPanel implements SharingPermissionView,
         this.resources = resources;
         this.appearance = appearance;
         this.searchField = searchField;
-        init();
         widget = uiBinder.createAndBindUi(this);
-        initToolbar();
         searchField.addUserSearchResultSelectedEventHandler(this);
     }
 
@@ -100,59 +101,40 @@ public class SharingPermissionsPanel implements SharingPermissionView,
         return widget;
     }
 
-    private void init() {
-        listStore = new ListStore<>(new DataSharingKeyProvider());
-        cm = buildColumnModel();
+    @UiFactory
+    ListStore<Sharing> createListStore() {
+        return new ListStore<>(new DataSharingKeyProvider());
     }
 
-    private void initToolbar() {
-        toolbar.setHorizontalSpacing(5);
-        addExplainPanel();
-        toolbar.add(searchField);
-        toolbar.add(new FillToolItem());
-        toolbar.add(buildChooseCollabButton());
-    }
-
-    private TextButton buildChooseCollabButton() {
-        TextButton button = new TextButton();
-        button.setText(appearance.chooseFromCollab());
-        button.addSelectHandler(new SelectHandler() {
+    @UiHandler("chooseCollabBtn")
+    void chooseCollabBtnSelected(SelectEvent event) {
+        collaboratorsDialogProvider.get(new AsyncCallback<ManageCollaboratorsDialog>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                ErrorHandler.post(caught);
+            }
 
             @Override
-            public void onSelect(SelectEvent event) {
-                collaboratorsDialogProvider.get(new AsyncCallback<ManageCollaboratorsDialog>() {
-                    @Override
-                    public void onFailure(Throwable caught) {
-                        ErrorHandler.post(caught);
-                    }
+            public void onSuccess(ManageCollaboratorsDialog result) {
+                result.setModal(true);
+                result.show(ManageCollaboratorsView.MODE.SELECT);
+                result.addOkButtonSelectHandler(new SelectHandler() {
 
                     @Override
-                    public void onSuccess(ManageCollaboratorsDialog result) {
-                        result.setModal(true);
-                        result.show(ManageCollaboratorsView.MODE.SELECT);
-                        result.addOkButtonSelectHandler(new SelectHandler() {
-
-                            @Override
-                            public void onSelect(SelectEvent event) {
-                                List<Subject> selected = result.getSelectedSubjects();
-                                if (selected != null && selected.size() > 0) {
-                                    for (Subject c : selected) {
-                                        addSubject(c);
-                                    }
-                                }
+                    public void onSelect(SelectEvent event) {
+                        List<Subject> selected = result.getSelectedSubjects();
+                        if (selected != null && selected.size() > 0) {
+                            for (Subject c : selected) {
+                                addSubject(c);
                             }
-                        });
+                        }
                     }
                 });
             }
-
         });
-        button.setToolTip(appearance.chooseFromCollab());
-        button.setIcon(appearance.shareIcon());
-        return button;
     }
 
-    private ComboBoxCell<PermissionValue> buildPermissionsCombo() {
+    ComboBoxCell<PermissionValue> buildPermissionsCombo() {
         ListStore<PermissionValue> perms = new ListStore<>(new ModelKeyProvider<PermissionValue>() {
 
             @Override
@@ -164,14 +146,13 @@ public class SharingPermissionsPanel implements SharingPermissionView,
         perms.add(PermissionValue.write);
         perms.add(PermissionValue.own);
 
-        final ComboBoxCell<PermissionValue> permCombo = new ComboBoxCell<>(perms,
-                                                                           new StringLabelProvider<PermissionValue>() {
-                                                                               @Override
-                                                                               public String
-                                                                                       getLabel(PermissionValue value) {
-                                                                                   return value.toString();
-                                                                               }
-                                                                           });
+        final ComboBoxCell<PermissionValue> permCombo =
+                new ComboBoxCell<>(perms, new StringLabelProvider<PermissionValue>() {
+                    @Override
+                    public String getLabel(PermissionValue value) {
+                        return value.toString();
+                    }
+                });
 
         permCombo.setForceSelection(true);
         permCombo.setSelectOnFocus(true);
@@ -192,33 +173,23 @@ public class SharingPermissionsPanel implements SharingPermissionView,
         return permCombo;
     }
 
-    private void addExplainPanel() {
-        explainPanel = new HorizontalPanel();
-        TextButton explainBtn = new TextButton(appearance.variablePermissionsNotice() + ":"
-                + appearance.explain(), new SelectHandler() {
+    @UiHandler("explainBtn")
+    void onExplainBtnSelected(SelectEvent event) {
+        ArrayList<Sharing> shares = new ArrayList<>();
+        for (String user : sharingMap.keySet()) {
+            shares.addAll(sharingMap.get(user));
+        }
 
-            @Override
-            public void onSelect(SelectEvent event) {
-                ArrayList<Sharing> shares = new ArrayList<>();
-                for (String user : sharingMap.keySet()) {
-                    shares.addAll(sharingMap.get(user));
-                }
-
-                ShareBreakDownDialog explainDlg = new ShareBreakDownDialog(shares);
-                explainDlg.setHeading(appearance.whoHasAccess());
-                explainDlg.show();
-            }
-        });
-        explainBtn.setIcon(appearance.helpIcon());
-        explainPanel.add(explainBtn);
-        toolbar.add(explainPanel);
+        ShareBreakDownDialog explainDlg = new ShareBreakDownDialog(shares);
+        explainDlg.setHeading(appearance.whoHasAccess());
+        explainDlg.show();
     }
 
     private void addSubject(Subject user) {
         String userName = user.getId();
         if (userName != null && userName.equalsIgnoreCase(UserInfo.getInstance().getUsername())) {
-            AlertMessageBox amb = new AlertMessageBox(appearance.warning(),
-                                                      appearance.selfShareWarning());
+            AlertMessageBox amb =
+                    new AlertMessageBox(appearance.warning(), appearance.selfShareWarning());
             amb.show();
             return;
         }
@@ -295,7 +266,8 @@ public class SharingPermissionsPanel implements SharingPermissionView,
         }
     }
 
-    private ColumnModel<Sharing> buildColumnModel() {
+    @UiFactory
+    ColumnModel<Sharing> createColumnModel() {
         List<ColumnConfig<Sharing, ?>> configs = new ArrayList<>();
         DataSharingProperties props = GWT.create(DataSharingProperties.class);
 
@@ -327,18 +299,18 @@ public class SharingPermissionsPanel implements SharingPermissionView,
 
     @Override
     public void hidePermissionColumn() {
-      for(ColumnConfig<Sharing, ?> cc: grid.getColumnModel().getColumns()) {
-          if(cc.getHeader().asString().equals(appearance.permissionsColumnLabel())) {
+        for (ColumnConfig<Sharing, ?> cc : grid.getColumnModel().getColumns()) {
+            if (cc.getHeader().asString().equals(appearance.permissionsColumnLabel())) {
                 cc.setHidden(true);
                 return;
-          }
-      }
+            }
+        }
     }
 
     @Override
     public void showPermissionColumn() {
-        for(ColumnConfig<Sharing, ?> cc: grid.getColumnModel().getColumns()) {
-            if(cc.getHeader().asString().equals(appearance.permissionsColumnLabel())) {
+        for (ColumnConfig<Sharing, ?> cc : grid.getColumnModel().getColumns()) {
+            if (cc.getHeader().asString().equals(appearance.permissionsColumnLabel())) {
                 cc.setHidden(false);
                 return;
             }
@@ -415,8 +387,6 @@ public class SharingPermissionsPanel implements SharingPermissionView,
     }
 
     /**
-     * 
-     * 
      * @return the sharing list
      */
     @Override
@@ -512,7 +482,7 @@ public class SharingPermissionsPanel implements SharingPermissionView,
 
     /**
      * @return true if the given sharingList list has a different size than the resources list, or if not
-     *         every permission in the given sharingList list is the same; false otherwise.
+     * every permission in the given sharingList list is the same; false otherwise.
      */
     private boolean hasVaryingPermissions(List<Sharing> sharingList) {
         if (sharingList == null || sharingList.size() != resources.size()) {

--- a/de-lib/src/main/java/org/iplantc/de/client/sharing/SharingPermissionsView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/client/sharing/SharingPermissionsView.ui.xml
@@ -2,7 +2,9 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
              xmlns:gxt="urn:import:com.sencha.gxt.widget.core.client"
+             xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
              xmlns:grid="urn:import:com.sencha.gxt.widget.core.client.grid"
+             xmlns:search="urn:import:org.iplantc.de.collaborators.client.util"
              xmlns:toolbar="urn:import:com.sencha.gxt.widget.core.client.toolbar">
 
     <ui:with field="appearance"
@@ -35,7 +37,28 @@
         </container:child>
         <container:child>
             <toolbar:ToolBar ui:field="toolbar"
-                             height="30"/>
+                             height="30"
+                             horizontalSpacing="5">
+                <toolbar:child>
+                    <gwt:HorizontalPanel ui:field="explainPanel">
+                        <gxt:button.TextButton ui:field="explainBtn"
+                                               text="{appearance.variablePermissionsNotice}"
+                                               icon="{appearance.helpIcon}"/>
+                    </gwt:HorizontalPanel>
+                </toolbar:child>
+                <toolbar:child>
+                    <search:UserSearchField ui:field="searchField"/>
+                </toolbar:child>
+                <toolbar:child>
+                    <toolbar:FillToolItem/>
+                </toolbar:child>
+                <toolbar:child>
+                    <gxt:button.TextButton ui:field="chooseCollabBtn"
+                                           text="{appearance.chooseFromCollab}"
+                                           toolTip="{appearance.chooseFromCollab}"
+                                           icon="{appearance.shareIcon}"/>
+                </toolbar:child>
+            </toolbar:ToolBar>
         </container:child>
 
     </container:VerticalLayoutContainer>

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -107,4 +107,10 @@ public interface GroupView extends IsWidget,
      * @param group
      */
     void updateCollabList(Group group);
+
+    /**
+     * Set the mode to match the ManageCollaboratorsView mode
+     * @param mode
+     */
+    void setMode(ManageCollaboratorsView.MODE mode);
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/GroupView.java
@@ -113,4 +113,10 @@ public interface GroupView extends IsWidget,
      * @param mode
      */
     void setMode(ManageCollaboratorsView.MODE mode);
+
+    /**
+     * Return the list of currently selected Collaborator Lists
+     * @return
+     */
+    List<Group> getSelectedCollabLists();
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -108,7 +108,7 @@ public interface ManageCollaboratorsView extends IsWidget,
          * Returns the list of currently selected collaborators from the ManageCollaboratorsView
          * @return
          */
-        List<Subject> getSelectedCollaborators();
+        List<Subject> getSelectedSubjects();
     }
 
     /**
@@ -179,7 +179,7 @@ public interface ManageCollaboratorsView extends IsWidget,
      * Returns the list of currently selected collaborators from the ManageCollaboratorsView
      * @return
      */
-    List<Subject> getSelectedCollaborators();
+    List<Subject> getSelectedSubjects();
 
     /**
      * Returns the mode the ManageCollaboratorsView is currently set to

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -230,8 +230,8 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     }
 
     @Override
-    public List<Subject> getSelectedCollaborators() {
-        return view.getSelectedCollaborators();
+    public List<Subject> getSelectedSubjects() {
+        return view.getSelectedSubjects();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/CollaboratorsUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/CollaboratorsUtil.java
@@ -3,14 +3,10 @@
  */
 package org.iplantc.de.collaborators.client.util;
 
-import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.collaborators.CollaboratorAutoBeanFactory;
+import org.iplantc.de.client.models.collaborators.Subject;
 
 import com.google.gwt.core.shared.GWT;
-import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.json.client.JSONString;
-import com.google.web.bindery.autobean.shared.AutoBean;
-import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 
 import java.util.List;
 
@@ -36,10 +32,7 @@ public class CollaboratorsUtil {
 
     //TODO Do I still need this for Subject?
     public Subject getDummySubject(String userName) {
-        JSONObject obj = new JSONObject();
-        obj.put("username", new JSONString(userName));
-        AutoBean<Subject> bean = AutoBeanCodex.decode(factory, Subject.class, obj.toString());
-        return bean.as();
+        return factory.getSubject().as();
     }
 
     public boolean isCurrentCollaborator(Subject c, List<Subject> subjects) {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -28,6 +28,7 @@ import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
+import com.sencha.gxt.widget.core.client.grid.CheckBoxSelectionModel;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -53,6 +54,7 @@ public class GroupViewImpl extends Composite implements GroupView {
     @UiField(provided = true) GroupViewAppearance appearance;
 
     GroupNameCell nameCell;
+    CheckBoxSelectionModel<Group> checkBoxModel;
     @Inject AsyncProviderWrapper<GroupDetailsDialog> groupDetailsDialog;
 
     private final GroupProperties props;
@@ -65,9 +67,11 @@ public class GroupViewImpl extends Composite implements GroupView {
         this.appearance = appearance;
         this.props = props;
         this.nameCell = nameCell;
+        checkBoxModel = new CheckBoxSelectionModel<>(new IdentityValueProvider<Group>());
 
         initWidget(uiBinder.createAndBindUi(this));
-        grid.getSelectionModel().setSelectionMode(Style.SelectionMode.SINGLE);
+        checkBoxModel.setSelectionMode(Style.SelectionMode.MULTI);
+        grid.setSelectionModel(checkBoxModel);
         grid.getView().setEmptyText(appearance.noCollabLists());
     }
 
@@ -75,12 +79,15 @@ public class GroupViewImpl extends Composite implements GroupView {
     ColumnModel<Group> createColumnModel() {
         List<ColumnConfig<Group, ?>> columns = Lists.newArrayList();
 
+        ColumnConfig<Group, Group> checkBoxCol = checkBoxModel.getColumn();
+
         ColumnConfig<Group, Group> nameCol = new ColumnConfig<>(new IdentityValueProvider<Group>("name"),
                                                                 appearance.nameColumnWidth(),
                                                                 appearance.nameColumnLabel());
         ColumnConfig<Group, String> descriptionCol = new ColumnConfig<>(props.description(),
                                                                         appearance.descriptionColumnWidth(),
                                                                         appearance.descriptionColumnLabel());
+        columns.add(checkBoxCol);
         nameCol.setCell(nameCell);
         columns.add(nameCol);
         columns.add(descriptionCol);

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -2,6 +2,7 @@ package org.iplantc.de.collaborators.client.views;
 
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.collaborators.client.GroupView;
+import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.DeleteGroupSelected;
 import org.iplantc.de.collaborators.client.events.GroupNameSelected;
@@ -55,6 +56,7 @@ public class GroupViewImpl extends Composite implements GroupView {
     @Inject AsyncProviderWrapper<GroupDetailsDialog> groupDetailsDialog;
 
     private final GroupProperties props;
+    private ManageCollaboratorsView.MODE mode;
 
     @Inject
     public GroupViewImpl(GroupViewAppearance appearance,
@@ -118,6 +120,13 @@ public class GroupViewImpl extends Composite implements GroupView {
     @Override
     public void updateCollabList(Group group) {
         listStore.update(group);
+    }
+
+    @Override
+    public void setMode(ManageCollaboratorsView.MODE mode) {
+        this.mode = mode;
+        toolBar.setVisible(ManageCollaboratorsView.MODE.MANAGE == mode);
+        toolBar.forceLayout();
     }
 
     @UiHandler("addGroup")

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/GroupViewImpl.java
@@ -136,6 +136,11 @@ public class GroupViewImpl extends Composite implements GroupView {
         toolBar.forceLayout();
     }
 
+    @Override
+    public List<Group> getSelectedCollabLists() {
+        return grid.getSelectionModel().getSelectedItems();
+    }
+
     @UiHandler("addGroup")
     void addGroupSelected(SelectEvent event) {
         fireEvent(new AddGroupSelected());

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsView.ui.xml
@@ -65,6 +65,11 @@
 				<!-- This is the tool bar -->
 				<container:north layoutData="{northData}">
 					<container:HorizontalLayoutContainer ui:field="searchPanel">
+						<button:TextButton debugId="idManage"
+										   ui:field="manageBtn"
+										   text="{appearance.manageCollaborators}"
+										   visible="false"
+										   icon="{appearance.shareIcon}"/>
 						<userSearch:UserSearchField ui:field="searchField"/>
 					</container:HorizontalLayoutContainer>
 				</container:north>
@@ -85,11 +90,6 @@
 														   text="{appearance.delete}"
 														   icon="{appearance.deleteIcon}"
 														   enabled="false"/>
-										<button:TextButton debugId="idManage"
-														   ui:field="manageBtn"
-														   text="{appearance.manageCollaborators}"
-														   visible="false"
-														   icon="{appearance.shareIcon}"/>
 									</toolbar:ToolBar>
 								</container:child>
 								<container:child layoutData="{middleData}">

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -26,7 +26,6 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
 import com.sencha.gxt.core.client.IdentityValueProvider;
-import com.sencha.gxt.core.client.Style.LayoutRegion;
 import com.sencha.gxt.core.client.Style.SelectionMode;
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.widget.core.client.Composite;
@@ -186,16 +185,17 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
             case MANAGE:
                 grid.getView().setEmptyText(appearance.noCollaborators());
                 manageBtn.setVisible(false);
-                deleteBtn.setVisible(true);
-                con.show(LayoutRegion.NORTH);
+                searchField.asWidget().setVisible(true);
+                toolbar.setVisible(true);
                 break;
             case SELECT:
                 grid.getView().setEmptyText(appearance.noCollaborators());
-                con.hide(LayoutRegion.NORTH);
                 manageBtn.setVisible(true);
-                deleteBtn.setVisible(false);
+                searchField.asWidget().setVisible(false);
+                toolbar.setVisible(false);
                 break;
         }
+        toolbar.forceLayout();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -181,6 +181,7 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     @Override
     public void setMode(MODE mode) {
         this.mode = mode;
+        groupView.setMode(mode);
         switch (mode) {
             case MANAGE:
                 grid.getView().setEmptyText(appearance.noCollaborators());

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -14,6 +14,8 @@ import org.iplantc.de.collaborators.client.util.UserSearchField;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -112,8 +114,10 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     }
 
     @Override
-    public List<Subject> getSelectedCollaborators() {
-        return grid.getSelectionModel().getSelectedItems();
+    public List<Subject> getSelectedSubjects() {
+        List<Group> selectedCollabLists = groupView.getSelectedCollabLists();
+        List<Subject> selectedCollaborators = grid.getSelectionModel().getSelectedItems();
+        return Lists.newArrayList(Iterables.concat(selectedCollabLists, selectedCollaborators));
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ManageCollaboratorsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ManageCollaboratorsDialog.java
@@ -75,6 +75,6 @@ public class ManageCollaboratorsDialog extends IPlantDialog {
     }
 
     public List<Subject> getSelectedSubjects() {
-        return presenter.getSelectedCollaborators();
+        return presenter.getSelectedSubjects();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/gin/CommonsGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/gin/CommonsGinModule.java
@@ -1,8 +1,8 @@
-package org.iplantc.de.client.gin;
+package org.iplantc.de.commons.client.gin;
 
-import org.iplantc.de.client.gin.factory.SharingPermissionViewFactory;
-import org.iplantc.de.client.sharing.SharingPermissionView;
-import org.iplantc.de.client.sharing.SharingPermissionsPanel;
+import org.iplantc.de.commons.client.gin.factory.SharingPermissionViewFactory;
+import org.iplantc.de.commons.client.views.sharing.SharingPermissionView;
+import org.iplantc.de.commons.client.views.sharing.SharingPermissionsPanel;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
@@ -10,7 +10,7 @@ import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
 /**
  * @author aramsey
  */
-public class ClientGinModule extends AbstractGinModule {
+public class CommonsGinModule extends AbstractGinModule {
     @Override
     protected void configure() {
         install(new GinFactoryModuleBuilder().implement(SharingPermissionView.class,

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/gin/factory/SharingPermissionViewFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/gin/factory/SharingPermissionViewFactory.java
@@ -1,8 +1,8 @@
-package org.iplantc.de.client.gin.factory;
+package org.iplantc.de.commons.client.gin.factory;
 
 import org.iplantc.de.client.models.sharing.SharedResource;
-import org.iplantc.de.client.sharing.SharingPermissionView;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.views.sharing.SharingPermissionView;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 
 import com.sencha.gxt.core.shared.FastMap;
 

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/presenter/SharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/presenter/SharingPresenter.java
@@ -17,4 +17,5 @@ public interface SharingPresenter extends org.iplantc.de.commons.client.presente
 
     void processRequest();
 
+    void setViewDebugId(String debugId);
 }

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/presenter/SharingPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/presenter/SharingPresenter.java
@@ -1,4 +1,4 @@
-package org.iplantc.de.client.sharing;
+package org.iplantc.de.commons.client.presenter;
 
 import org.iplantc.de.client.models.diskResources.PermissionValue;
 

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingAppearance.java
@@ -1,4 +1,4 @@
-package org.iplantc.de.client.sharing;
+package org.iplantc.de.commons.client.views.sharing;
 
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safecss.shared.SafeStyles;

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionNameCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionNameCell.java
@@ -1,0 +1,38 @@
+package org.iplantc.de.commons.client.views.sharing;
+
+import static com.google.gwt.dom.client.BrowserEvents.CLICK;
+
+import org.iplantc.de.client.models.sharing.Sharing;
+import org.iplantc.de.commons.share.CommonsModule;
+
+import com.google.gwt.cell.client.AbstractCell;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+
+/**
+ * @author aramsey
+ */
+public class SharingPermissionNameCell extends AbstractCell<Sharing> {
+
+    public interface SharingPermissionNameCellAppearance {
+        void render(SafeHtmlBuilder safeHtmlBuilder, Sharing sharing, String debugID);
+    }
+
+    private final SharingPermissionNameCellAppearance appearance =
+            GWT.create(SharingPermissionNameCellAppearance.class);
+    private String baseDebugId;
+
+    public SharingPermissionNameCell() {
+        super(CLICK);
+    }
+
+    @Override
+    public void render(Context context, Sharing value, SafeHtmlBuilder sb) {
+        String debugID = baseDebugId + value.getId() + CommonsModule.IDs.SHARING_NAME_CELL;
+        appearance.render(sb, value, debugID);
+    }
+
+    public void setBaseDebugId(String baseDebugId) {
+        this.baseDebugId = baseDebugId;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionNameCell.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionNameCell.java
@@ -28,7 +28,7 @@ public class SharingPermissionNameCell extends AbstractCell<Sharing> {
 
     @Override
     public void render(Context context, Sharing value, SafeHtmlBuilder sb) {
-        String debugID = baseDebugId + value.getId() + CommonsModule.IDs.SHARING_NAME_CELL;
+        String debugID = baseDebugId + "." + value.getId() + CommonsModule.IDs.SHARING_NAME_CELL;
         appearance.render(sb, value, debugID);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionView.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionView.java
@@ -1,4 +1,4 @@
-package org.iplantc.de.client.sharing;
+package org.iplantc.de.commons.client.views.sharing;
 
 import org.iplantc.de.client.models.sharing.Sharing;
 

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
@@ -1,4 +1,4 @@
-package org.iplantc.de.client.sharing;
+package org.iplantc.de.commons.client.views.sharing;
 
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.collaborators.Subject;
@@ -10,6 +10,7 @@ import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
 import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
 import org.iplantc.de.commons.client.ErrorHandler;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.diskResource.client.model.DataSharingKeyProvider;
 import org.iplantc.de.diskResource.client.model.DataSharingProperties;
 import org.iplantc.de.diskResource.client.views.sharing.dialogs.ShareBreakDownDialog;

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
@@ -11,6 +11,7 @@ import org.iplantc.de.collaborators.client.util.UserSearchField;
 import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.presenter.SharingPresenter;
+import org.iplantc.de.commons.share.CommonsModule;
 import org.iplantc.de.diskResource.client.model.DataSharingKeyProvider;
 import org.iplantc.de.diskResource.client.model.DataSharingProperties;
 import org.iplantc.de.diskResource.client.views.sharing.dialogs.ShareBreakDownDialog;
@@ -39,6 +40,7 @@ import com.sencha.gxt.core.shared.FastMap;
 import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.data.shared.ModelKeyProvider;
 import com.sencha.gxt.data.shared.StringLabelProvider;
+import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.box.AlertMessageBox;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
@@ -57,7 +59,7 @@ import java.util.List;
 /**
  * @author sriram, jstroot
  */
-public class SharingPermissionsPanel
+public class SharingPermissionsPanel extends Composite
         implements SharingPermissionView, UserSearchResultSelected.UserSearchResultSelectedEventHandler {
 
     @UiTemplate("SharingPermissionsView.ui.xml")
@@ -79,7 +81,6 @@ public class SharingPermissionsPanel
     private final FastMap<SharedResource> resources;
     private final SharingPresenter presenter;
     private FastMap<List<Sharing>> sharingMap;
-    final Widget widget;
 
     @Inject AsyncProviderWrapper<ManageCollaboratorsDialog> collaboratorsDialogProvider;
 
@@ -94,13 +95,26 @@ public class SharingPermissionsPanel
         this.resources = resources;
         this.appearance = appearance;
         this.searchField = searchField;
-        widget = uiBinder.createAndBindUi(this);
+        initWidget(uiBinder.createAndBindUi(this));
         searchField.addUserSearchResultSelectedEventHandler(this);
     }
 
     @Override
-    public Widget asWidget() {
-        return widget;
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        grid.ensureDebugId(baseID + CommonsModule.IDs.PERM_GRID);
+        toolbar.ensureDebugId(baseID + CommonsModule.IDs.PERM_TOOLBAR);
+        explainPanel.ensureDebugId(toolbar.getId() + CommonsModule.IDs.PERM_EXPLAIN_PNL);
+        explainBtn.ensureDebugId(explainPanel.getElement().getId() + CommonsModule.IDs.PERM_EXPLAIN_BTN);
+        chooseCollabBtn.ensureDebugId(toolbar.getId() + CommonsModule.IDs.PERM_CHOOSE_COLLAB);
+        searchField.asWidget().ensureDebugId(toolbar.getId() + CommonsModule.IDs.PERM_USER_SEARCH);
+
+        for (ColumnConfig<Sharing, ?> cc : cm.getColumns()) {
+            if (cc.getCell() instanceof SharingPermissionNameCell) {
+                ((SharingPermissionNameCell)cc.getCell()).setBaseDebugId(grid.getId());
+            }
+        }
     }
 
     @UiFactory

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
@@ -33,6 +33,7 @@ import com.google.inject.assistedinject.Assisted;
 import com.sencha.gxt.cell.core.client.TextButtonCell;
 import com.sencha.gxt.cell.core.client.form.ComboBoxCell;
 import com.sencha.gxt.cell.core.client.form.ComboBoxCell.TriggerAction;
+import com.sencha.gxt.core.client.IdentityValueProvider;
 import com.sencha.gxt.core.client.ValueProvider;
 import com.sencha.gxt.core.shared.FastMap;
 import com.sencha.gxt.data.shared.ListStore;
@@ -272,25 +273,13 @@ public class SharingPermissionsPanel
         List<ColumnConfig<Sharing, ?>> configs = new ArrayList<>();
         DataSharingProperties props = GWT.create(DataSharingProperties.class);
 
-        ColumnConfig<Sharing, String> name = new ColumnConfig<>(new ValueProvider<Sharing, String>() {
-            @Override
-            public String getValue(Sharing object) {
-                return object.getCollaboratorName();
-            }
-
-            @Override
-            public void setValue(Sharing object, String value) {
-
-            }
-
-            @Override
-            public String getPath() {
-                return null;
-            }
-        }, appearance.nameColumnWidth(), appearance.nameColumnLabel());
+        ColumnConfig<Sharing, Sharing> name = new ColumnConfig<>(new IdentityValueProvider<Sharing>("id"),
+                                                                 appearance.nameColumnWidth(),
+                                                                 appearance.nameColumnLabel());
         ColumnConfig<Sharing, PermissionValue> permission = buildPermissionColumn(props);
         ColumnConfig<Sharing, String> remove = buildRemoveColumn();
 
+        name.setCell(new SharingPermissionNameCell());
         configs.add(name);
         configs.add(permission);
         configs.add(remove);

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsView.ui.xml
@@ -8,7 +8,7 @@
              xmlns:toolbar="urn:import:com.sencha.gxt.widget.core.client.toolbar">
 
     <ui:with field="appearance"
-             type="org.iplantc.de.client.sharing.SharingAppearance"/>
+             type="org.iplantc.de.commons.client.views.sharing.SharingAppearance"/>
     <ui:with field="listStore"
              type="com.sencha.gxt.data.shared.ListStore"/>
     <ui:with field="cm"

--- a/de-lib/src/main/java/org/iplantc/de/commons/share/CommonsModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/share/CommonsModule.java
@@ -10,5 +10,6 @@ public interface CommonsModule {
         String HELP = ".helpBtn";
         String CLOSE = ".closeBtn";
         String CANCEL = ".cancelBtn";
+        String SHARING_NAME_CELL = ".shareName";
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/commons/share/CommonsModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/share/CommonsModule.java
@@ -11,5 +11,11 @@ public interface CommonsModule {
         String CLOSE = ".closeBtn";
         String CANCEL = ".cancelBtn";
         String SHARING_NAME_CELL = ".shareName";
+        String PERM_GRID = ".grid";
+        String PERM_TOOLBAR = ".toolbar";
+        String PERM_EXPLAIN_PNL = ".explainPanel";
+        String PERM_EXPLAIN_BTN = ".explainBtn";
+        String PERM_CHOOSE_COLLAB = ".chooseCollabBtn";
+        String PERM_USER_SEARCH = ".userSearch";
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -316,7 +316,7 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
 
 
     void displayNotificationPopup(NotificationMessage nm) {
-        if (NotificationCategory.ANALYSIS.equals(nm.getCategory())) {
+        if (NotificationCategory.ANALYSIS.equals(nm.getCategory()) && nm.getContext() != null) {
             PayloadAnalysis analysisPayload =
                     AutoBeanCodex.decode(notificationFactory, PayloadAnalysis.class, nm.getContext())
                                  .as();

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/gin/DiskResourceGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/gin/DiskResourceGinModule.java
@@ -1,7 +1,7 @@
 package org.iplantc.de.diskResource.client.gin;
 
 import org.iplantc.de.client.models.diskResources.Folder;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.diskResource.client.DataLinkView;
 import org.iplantc.de.diskResource.client.DataSharingView;
 import org.iplantc.de.diskResource.client.DetailsView;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/gin/factory/DataSharingPresenterFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/gin/factory/DataSharingPresenterFactory.java
@@ -1,7 +1,7 @@
 package org.iplantc.de.diskResource.client.gin.factory;
 
 import org.iplantc.de.client.models.diskResources.DiskResource;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 
 import java.util.List;
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
@@ -26,6 +26,7 @@ import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.diskResource.client.DataSharingView;
+import org.iplantc.de.diskResource.share.DiskResourceModule;
 import org.iplantc.de.shared.DataCallback;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -202,6 +203,12 @@ public class DataSharingPresenterImpl implements SharingPresenter {
             IplantAnnouncer.getInstance().schedule(appearance.sharingCompleteMsg());
         }
 
+    }
+
+    @Override
+    public void setViewDebugId(String debugId) {
+        view.asWidget().ensureDebugId(debugId + DiskResourceModule.Ids.SHARING_VIEW);
+        permissionsPanel.asWidget().ensureDebugId(debugId + DiskResourceModule.Ids.SHARING_VIEW + DiskResourceModule.Ids.SHARING_PERMS);
     }
 
     private List<DataPermission> buildShareDataPermissionList(List<Sharing> shareList) {

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
@@ -1,6 +1,6 @@
 package org.iplantc.de.diskResource.client.presenters.sharing;
 
-import org.iplantc.de.client.gin.factory.SharingPermissionViewFactory;
+import org.iplantc.de.commons.client.gin.factory.SharingPermissionViewFactory;
 import org.iplantc.de.client.models.HasPaths;
 import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.diskResources.DiskResource;
@@ -19,8 +19,8 @@ import org.iplantc.de.client.models.sharing.SharedResource;
 import org.iplantc.de.client.models.sharing.Sharing;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
-import org.iplantc.de.client.sharing.SharingPermissionView;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.views.sharing.SharingPermissionView;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.ErrorHandler;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/sharing/DataSharingPresenterImpl.java
@@ -1,9 +1,20 @@
 package org.iplantc.de.diskResource.client.presenters.sharing;
 
 import org.iplantc.de.client.gin.factory.SharingPermissionViewFactory;
+import org.iplantc.de.client.models.HasPaths;
 import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.diskResources.DiskResource;
+import org.iplantc.de.client.models.diskResources.DiskResourceAutoBeanFactory;
 import org.iplantc.de.client.models.diskResources.PermissionValue;
+import org.iplantc.de.client.models.diskResources.sharing.DataPermission;
+import org.iplantc.de.client.models.diskResources.sharing.DataSharingAutoBeanFactory;
+import org.iplantc.de.client.models.diskResources.sharing.DataSharingRequest;
+import org.iplantc.de.client.models.diskResources.sharing.DataSharingRequestList;
+import org.iplantc.de.client.models.diskResources.sharing.DataUnsharingRequest;
+import org.iplantc.de.client.models.diskResources.sharing.DataUnsharingRequestList;
+import org.iplantc.de.client.models.diskResources.sharing.DataUserPermission;
+import org.iplantc.de.client.models.diskResources.sharing.DataUserPermissionList;
+import org.iplantc.de.client.models.sharing.OldUserPermission;
 import org.iplantc.de.client.models.sharing.SharedResource;
 import org.iplantc.de.client.models.sharing.Sharing;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
@@ -11,21 +22,17 @@ import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.sharing.SharingPermissionView;
 import org.iplantc.de.client.sharing.SharingPresenter;
 import org.iplantc.de.client.util.DiskResourceUtil;
-import org.iplantc.de.client.util.JsonUtil;
 import org.iplantc.de.collaborators.client.util.CollaboratorsUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.diskResource.client.DataSharingView;
 import org.iplantc.de.shared.DataCallback;
 
-import com.google.gwt.json.client.JSONArray;
-import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.json.client.JSONString;
-import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 
 import com.sencha.gxt.core.shared.FastMap;
 
@@ -33,52 +40,59 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * FIXME Tighten contract with data sharing service. Should not have to manually construct the json here.
+ *
  * @author sriram, jstroot
  */
 public class DataSharingPresenterImpl implements SharingPresenter {
 
-    private final class LoadPermissionsCallback extends DataCallback<String> {
-        private final class GetUserInfoCallback implements AsyncCallback<FastMap<Subject>> {
-            private final List<String> usernames;
+    class GetUserInfoCallback implements AsyncCallback<FastMap<Subject>> {
 
-            private GetUserInfoCallback(List<String> usernames) {
-                this.usernames = usernames;
-            }
+        private DataUserPermissionList dataPermsList;
 
-            @Override
-            public void onFailure(Throwable caught) {
-                ErrorHandler.post(caught);
-            }
+        private GetUserInfoCallback(DataUserPermissionList dataPermsList) {
+            this.dataPermsList = dataPermsList;
+        }
 
-            @Override
-            public void onSuccess(FastMap<Subject> results) {
-                dataSharingMap = new FastMap<>();
-                for (String userName : usernames) {
+        @Override
+        public void onFailure(Throwable caught) {
+            ErrorHandler.post(caught);
+        }
+
+        @Override
+        public void onSuccess(FastMap<Subject> results) {
+            FastMap<List<Sharing>> dataSharingMap = new FastMap<>();
+            for (DataUserPermission dataPermission : dataPermsList.getDataUserPermissions()) {
+                for (OldUserPermission userPerms : dataPermission.getUserPermissions()) {
+                    String userName = userPerms.getUser();
+
                     Subject user = results.get(userName);
                     if (user == null) {
                         user = collaboratorsUtil.getDummySubject(userName);
                     }
 
-                    List<Sharing> dataShares = new ArrayList<>();
+                    List<Sharing> dataShares = dataSharingMap.get(userName);
 
-                    dataSharingMap.put(userName, dataShares);
-
-                    for (JSONObject share : sharingList.get(userName)) {
-                        String path = jsonUtil.getString(share, "path"); //$NON-NLS-1$
-                        Sharing dataSharing = new Sharing(user,
-                                                                  buildPermissionFromJson(share),
-                                                                  path,
-                                                                  DiskResourceUtil.getInstance()
-                                                                                  .parseNameFromPath(path));
-                        dataShares.add(dataSharing);
+                    if (dataShares == null) {
+                        dataShares = new ArrayList<>();
+                        dataSharingMap.put(userName, dataShares);
                     }
-                }
 
-                permissionsPanel.loadSharingData(dataSharingMap);
-                permissionsPanel.unmask();
+                    String path = dataPermission.getPath();
+                    Sharing dataSharing = new Sharing(user,
+                                                      PermissionValue.valueOf(userPerms.getPermission()),
+                                                      path,
+                                                      DiskResourceUtil.getInstance()
+                                                                      .parseNameFromPath(path));
+                    dataShares.add(dataSharing);
+                }
             }
+            permissionsPanel.loadSharingData(dataSharingMap);
+            permissionsPanel.unmask();
         }
+    }
+
+
+    class LoadPermissionsCallback extends DataCallback<String> {
 
         @Override
         public void onFailure(Integer statusCode, Throwable caught) {
@@ -88,21 +102,19 @@ public class DataSharingPresenterImpl implements SharingPresenter {
 
         @Override
         public void onSuccess(String result) {
-            JSONArray permissionsArray = jsonUtil.getArray(jsonUtil.getObject(result), "paths"); //$NON-NLS-1$
-            if (permissionsArray != null) {
-                sharingList = new FastMap<>();
-                for (int i = 0; i < permissionsArray.size(); i++) {
-                    JSONObject user_perm_obj = permissionsArray.get(i).isObject();
-                    String path = jsonUtil.getString(user_perm_obj, "path"); //$NON-NLS-1$
-                    JSONArray user_arr = jsonUtil.getArray(user_perm_obj, "user-permissions"); //$NON-NLS-1$
-                    loadPermissions(path, user_arr);
-                }
+            DataUserPermissionList dataPermsList =
+                    AutoBeanCodex.decode(dataSharingFactory, DataUserPermissionList.class, result).as();
 
-                final List<String> usernames = new ArrayList<>();
-                usernames.addAll(sharingList.keySet());
-                collaboratorsServiceFacade.getUserInfo(usernames, new GetUserInfoCallback(usernames));
+            final List<String> usernames = new ArrayList<>();
+
+            for (DataUserPermission dataUserPermission : dataPermsList.getDataUserPermissions()) {
+                for (OldUserPermission up : dataUserPermission.getUserPermissions()) {
+                    usernames.add(up.getUser());
+                }
             }
+            collaboratorsServiceFacade.getUserInfo(usernames, new GetUserInfoCallback(dataPermsList));
         }
+
     }
 
     final DataSharingView view;
@@ -110,10 +122,9 @@ public class DataSharingPresenterImpl implements SharingPresenter {
     private final SharingPermissionView permissionsPanel;
     private final List<DiskResource> selectedResources;
     private final Appearance appearance;
-    private FastMap<List<Sharing>> dataSharingMap;
-    private FastMap<List<JSONObject>> sharingList;
+    private DataSharingAutoBeanFactory dataSharingFactory;
+    private DiskResourceAutoBeanFactory drFactory;
     private CollaboratorsServiceFacade collaboratorsServiceFacade;
-    private final JsonUtil jsonUtil;
     private final CollaboratorsUtil collaboratorsUtil;
 
 
@@ -123,16 +134,18 @@ public class DataSharingPresenterImpl implements SharingPresenter {
                                     final DataSharingView view,
                                     final CollaboratorsUtil collaboratorsUtil,
                                     CollaboratorsServiceFacade collaboratorsServiceFacade,
-                                    final JsonUtil jsonUtil,
                                     SharingPresenter.Appearance appearance,
-                                    SharingPermissionViewFactory sharingViewFactory) {
+                                    SharingPermissionViewFactory sharingViewFactory,
+                                    DataSharingAutoBeanFactory dataSharingFactory,
+                                    DiskResourceAutoBeanFactory drFactory) {
         this.diskResourceService = diskResourceService;
         this.view = view;
         this.selectedResources = selectedResources;
         this.collaboratorsUtil = collaboratorsUtil;
         this.collaboratorsServiceFacade = collaboratorsServiceFacade;
-        this.jsonUtil = jsonUtil;
         this.appearance = appearance;
+        this.dataSharingFactory = dataSharingFactory;
+        this.drFactory = drFactory;
         permissionsPanel = sharingViewFactory.create(this, getSelectedResourcesAsMap(selectedResources));
         view.addShareWidget(permissionsPanel.asWidget());
         loadResources();
@@ -157,19 +170,32 @@ public class DataSharingPresenterImpl implements SharingPresenter {
     @Override
     public void loadPermissions() {
         permissionsPanel.mask();
-        diskResourceService.getPermissions(buildPermissionsRequestBody(), new LoadPermissionsCallback());
+        diskResourceService.getPermissions(getPaths(selectedResources), new LoadPermissionsCallback());
+    }
+
+    HasPaths getPaths(List<DiskResource> selectedResources) {
+        HasPaths hasPaths = drFactory.pathsList().as();
+        List<String> paths = new ArrayList<>();
+
+        for (DiskResource resource : selectedResources) {
+            String path = resource.getPath();
+            paths.add(path);
+        }
+
+        hasPaths.setPaths(paths);
+        return hasPaths;
     }
 
     @Override
     public void processRequest() {
-        JSONObject requestBody = buildSharingJson();
-        JSONObject unshareRequestBody = buildUnSharingJson();
+        DataSharingRequestList requestBody = buildSharingRequest();
+        DataUnsharingRequestList unshareRequestBody = buildUnsharingRequest();
         if (requestBody != null) {
-            share(requestBody);
+            callSharingService(requestBody);
         }
 
         if (unshareRequestBody != null) {
-            unshare(unshareRequestBody);
+            callUnshareService(unshareRequestBody);
         }
 
         if (requestBody != null || unshareRequestBody != null) {
@@ -178,93 +204,76 @@ public class DataSharingPresenterImpl implements SharingPresenter {
 
     }
 
-    private JSONArray buildPathArr(List<Sharing> shareList) {
-        JSONArray pathArr = new JSONArray();
-        int index = 0;
-        for (Sharing s : shareList) {
-            pathArr.set(index++, new JSONString(s.getId()));
-        }
-        return pathArr;
-    }
+    private List<DataPermission> buildShareDataPermissionList(List<Sharing> shareList) {
+        List<DataPermission> dataPermList = new ArrayList<>();
 
-    private JSONArray buildPathArrWithPermissions(List<Sharing> shareList) {
-        JSONArray pathArr = new JSONArray();
-        int index = 0;
-        JSONObject obj;
-        for (Sharing s : shareList) {
-            obj = new JSONObject();
-            obj.put("path", new JSONString(s.getId()));
-            obj.put("permission", buildSharingPermissionsAsJson(s));
-            pathArr.set(index++, obj);
+        for(Sharing sharing : shareList) {
+            DataPermission dataPerm = dataSharingFactory.getDataPermission().as();
+            dataPerm.setPath(sharing.getId());
+            dataPerm.setPermission(sharing.getPermission().toString());
+            dataPermList.add(dataPerm);
         }
 
-        return pathArr;
+        return dataPermList;
     }
 
-    private PermissionValue buildPermissionFromJson(JSONObject perm) {
-        return PermissionValue.valueOf(jsonUtil.getString(perm, "permission"));
-    }
+    DataSharingRequestList buildSharingRequest() {
+        DataSharingRequestList sharingRequestList = null;
 
-    private JSONObject buildPermissionsRequestBody() {
-        JSONObject obj = new JSONObject();
-        JSONArray ids = new JSONArray();
-        for (int i = 0; i < selectedResources.size(); i++) {
-            ids.set(i, new JSONString(selectedResources.get(i).getPath()));
-        }
-        obj.put("paths", ids);
-        return obj;
-    }
-
-    private JSONObject buildSharingJson() {
-        JSONObject sharingObj = new JSONObject();
         FastMap<List<Sharing>> sharingMap = permissionsPanel.getSharingMap();
 
         if (sharingMap != null && sharingMap.size() > 0) {
-            JSONArray sharingArr = new JSONArray();
-            int index = 0;
+            List<DataSharingRequest> requests = new ArrayList<>();
+
             for (String userName : sharingMap.keySet()) {
+                DataSharingRequest sharingRequest = dataSharingFactory.getDataSharingRequest().as();
+                sharingRequest.setUser(userName);
                 List<Sharing> shareList = sharingMap.get(userName);
-                JSONObject userObj = new JSONObject();
-                userObj.put("user", new JSONString(userName));
-                userObj.put("paths", buildPathArrWithPermissions(shareList));
-                sharingArr.set(index++, userObj);
+                sharingRequest.setDataPermissions(buildShareDataPermissionList(shareList));
+                requests.add(sharingRequest);
             }
 
-            sharingObj.put("sharing", sharingArr);
-            return sharingObj;
-        } else {
-            return null;
+            sharingRequestList = dataSharingFactory.getDataSharingRequestList().as();
+            sharingRequestList.setDataSharingRequestList(requests);
         }
+
+        return sharingRequestList;
     }
 
-    private JSONValue buildSharingPermissionsAsJson(Sharing sh) {
-        return new JSONString(sh.getPermission().toString());
-    }
+    DataUnsharingRequestList buildUnsharingRequest() {
+        DataUnsharingRequestList unsharingRequestList = null;
 
-    private JSONObject buildUnSharingJson() {
-        JSONObject unsharingObj = new JSONObject();
-        FastMap<List<Sharing>> unSharingMap = permissionsPanel.getUnshareList();
+        FastMap<List<Sharing>> unsharingMap = permissionsPanel.getUnshareList();
 
-        if (unSharingMap != null && unSharingMap.size() > 0) {
-            JSONArray unsharingArr = new JSONArray();
-            int index = 0;
-            for (String userName : unSharingMap.keySet()) {
-                List<Sharing> shareList = unSharingMap.get(userName);
-                JSONObject userObj = new JSONObject();
-                userObj.put("user", new JSONString(userName));
-                userObj.put("paths", buildPathArr(shareList));
-                unsharingArr.set(index++, userObj);
+        if (unsharingMap != null && unsharingMap.size() > 0) {
+            List<DataUnsharingRequest> requests = new ArrayList<>();
+
+            for (String userName : unsharingMap.keySet()) {
+                DataUnsharingRequest unsharingRequest = dataSharingFactory.getDataUnsharingRequest().as();
+                unsharingRequest.setUser(userName);
+                List<Sharing> unshareList = unsharingMap.get(userName);
+                unsharingRequest.setPaths(buildUnsharePathList(unshareList));
+                requests.add(unsharingRequest);
             }
-            unsharingObj.put("unshare", unsharingArr);
-            return unsharingObj;
-        } else {
-            return null;
+
+            unsharingRequestList = dataSharingFactory.getDataUnsharingRequestList().as();
+            unsharingRequestList.setDataUnsharingRequests(requests);
         }
 
+        return unsharingRequestList;
     }
 
-    private void callSharingService(JSONObject obj) {
-        diskResourceService.shareDiskResource(obj, new AsyncCallback<String>() {
+    List<String> buildUnsharePathList(List<Sharing> shareList) {
+        List<String> paths = new ArrayList<>();
+        for(Sharing unshare : shareList) {
+            String path = unshare.getId();
+            paths.add(path);
+        }
+        return paths;
+    }
+
+    void callSharingService(DataSharingRequestList requestList) {
+        diskResourceService.shareDiskResource(requestList, new AsyncCallback<String>() {
 
             @Override
             public void onFailure(Throwable caught) {
@@ -279,8 +288,8 @@ public class DataSharingPresenterImpl implements SharingPresenter {
         });
     }
 
-    private void callUnshareService(JSONObject obj) {
-        diskResourceService.unshareDiskResource(obj, new AsyncCallback<String>() {
+    void callUnshareService(DataUnsharingRequestList unshareRequestList) {
+        diskResourceService.unshareDiskResource(unshareRequestList, new AsyncCallback<String>() {
 
             @Override
             public void onFailure(Throwable caught) {
@@ -300,44 +309,9 @@ public class DataSharingPresenterImpl implements SharingPresenter {
         for (DiskResource sr : selectedResources) {
             resourcesMap.put(sr.getPath(),
                              new SharedResource(sr.getPath(),
-                                                  DiskResourceUtil.getInstance()
-                                                                  .parseNameFromPath(sr.getPath())));
+                                                DiskResourceUtil.getInstance()
+                                                                .parseNameFromPath(sr.getPath())));
         }
         return resourcesMap;
     }
-
-    private void loadPermissions(String path, JSONArray user_arr) {
-        for (int i = 0; i < user_arr.size(); i++) {
-            JSONObject userPermission = jsonUtil.getObjectAt(user_arr, i);
-            JSONObject perm = new JSONObject();
-            String permVal = jsonUtil.getString(userPermission, "permission"); //$NON-NLS-1$
-            String userName = jsonUtil.getString(userPermission, "user"); //$NON-NLS-1$
-
-            List<JSONObject> shareList = sharingList.get(userName);
-            if (shareList == null) {
-                shareList = new ArrayList<>();
-                sharingList.put(userName, shareList);
-            }
-            perm.put("permission", new JSONString(permVal));
-            perm.put("path", new JSONString(path)); //$NON-NLS-1$
-            shareList.add(perm);
-        }
-
-    }
-
-    private void share(JSONObject requestBody) {
-      if (requestBody != null) {
-            callSharingService(requestBody);
-        }
-
-    }
-
-    private void unshare(JSONObject unshareRequestBody) {
-        if (unshareRequestBody != null) {
-            callUnshareService(unshareRequestBody);
-        }
-
-    }
-
-
 }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/DataSharingView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/DataSharingView.ui.xml
@@ -6,7 +6,7 @@
 
 
     <ui:with field="appearance"
-             type="org.iplantc.de.client.sharing.SharingAppearance" />
+             type="org.iplantc.de.commons.client.views.sharing.SharingAppearance" />
 
     <ui:with field="diskResourcesListStore"
              type="com.sencha.gxt.data.shared.ListStore"/>

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/DataSharingViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/DataSharingViewImpl.java
@@ -1,8 +1,8 @@
 package org.iplantc.de.diskResource.client.views.sharing;
 
 import org.iplantc.de.client.models.diskResources.DiskResource;
-import org.iplantc.de.client.sharing.SharingAppearance;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.views.sharing.SharingAppearance;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.diskResource.client.DataSharingView;
 import org.iplantc.de.diskResource.client.model.DiskResourceModelKeyProvider;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/DataSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/DataSharingDialog.java
@@ -5,10 +5,11 @@ package org.iplantc.de.diskResource.client.views.sharing.dialogs;
 
 
 import org.iplantc.de.client.models.diskResources.DiskResource;
-import org.iplantc.de.commons.client.views.sharing.SharingAppearance;
 import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
+import org.iplantc.de.commons.client.views.sharing.SharingAppearance;
 import org.iplantc.de.diskResource.client.gin.factory.DataSharingPresenterFactory;
+import org.iplantc.de.diskResource.share.DiskResourceModule;
 
 import com.google.common.base.Preconditions;
 import com.google.gwt.user.client.ui.HTML;
@@ -40,7 +41,6 @@ public class DataSharingDialog extends IPlantDialog implements SelectHandler {
         setHeading(appearance.manageSharing());
         setOkButtonText(appearance.done());
         addOkButtonSelectHandler(this);
-
     }
 
     @Override
@@ -53,6 +53,8 @@ public class DataSharingDialog extends IPlantDialog implements SelectHandler {
         sharingPresenter = factory.create(resourcesToShare);
         sharingPresenter.go(this);
         super.show();
+
+        ensureDebugId(DiskResourceModule.Ids.SHARING_DLG);
     }
 
     @Override
@@ -61,4 +63,10 @@ public class DataSharingDialog extends IPlantDialog implements SelectHandler {
                                                     "Use show(List<DiskResource>) instead.");
     }
 
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        sharingPresenter.setViewDebugId(baseID);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/DataSharingDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/DataSharingDialog.java
@@ -5,8 +5,8 @@ package org.iplantc.de.diskResource.client.views.sharing.dialogs;
 
 
 import org.iplantc.de.client.models.diskResources.DiskResource;
-import org.iplantc.de.client.sharing.SharingAppearance;
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.views.sharing.SharingAppearance;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 import org.iplantc.de.diskResource.client.gin.factory.DataSharingPresenterFactory;
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/ShareBreakDownDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/ShareBreakDownDialog.java
@@ -118,7 +118,7 @@ public class ShareBreakDownDialog extends Dialog {
 
             @Override
             public String getValue(Sharing object) {
-                return object.getCollaboratorName();
+                return object.getSubjectName();
             }
 
             @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/ShareBreakDownDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/sharing/dialogs/ShareBreakDownDialog.java
@@ -2,7 +2,7 @@ package org.iplantc.de.diskResource.client.views.sharing.dialogs;
 
 import org.iplantc.de.client.models.diskResources.PermissionValue;
 import org.iplantc.de.client.models.sharing.Sharing;
-import org.iplantc.de.client.sharing.SharingAppearance;
+import org.iplantc.de.commons.client.views.sharing.SharingAppearance;
 import org.iplantc.de.diskResource.client.model.DataSharingKeyProvider;
 import org.iplantc.de.diskResource.client.model.DataSharingProperties;
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/share/DiskResourceModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/share/DiskResourceModule.java
@@ -78,6 +78,10 @@ public interface DiskResourceModule {
         String MENU_ITEM_BULK_METADATA = ".bulkmetadata";
         String MENU_ITEM_REQUEST_DOI = ".requestdoi";
         String MENU_ITEM_SELECTFILE = ".selectfile";
+
+        String SHARING_DLG = "dataSharingDlg";
+        String SHARING_VIEW = ".view";
+        String SHARING_PERMS = ".permPanel";
     }
 
     interface MetadataIds {

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/util/UserSearchFieldDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/util/UserSearchFieldDefaultAppearance.java
@@ -7,8 +7,6 @@ import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.regexp.shared.MatchResult;
-import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeUri;
@@ -45,27 +43,12 @@ public class UserSearchFieldDefaultAppearance implements UserSearchField.UserSea
 
     @Override
     public void render(Cell.Context context, Subject subject, SafeHtmlBuilder sb) {
-        if (subject.getSourceId().equals("ldap")) {
-            sb.append(userTemplate.render(subject.getName(), subject.getInstitution(), null));
-        } else {
-            String name = getCollaboratorListDisplayName(subject.getName());
+        String name = subject.getSubjectDisplayName();
+        if (subject.isCollaboratorList()) {
             sb.append(userTemplate.render(name, null, iplantResources.viewCurrentCollabs().getSafeUri()));
+        } else {
+            sb.append(userTemplate.render(name, subject.getInstitution(), null));
         }
-
-    }
-
-    /**
-     * Currently subject.getName from the GET /subjects endpoints returns the full name, for example
-     * iplant:de:de-2:users:aramsey:collaborator-lists:test
-     *
-     * Instead, we want to return the part that comes after "collaborator-lists:"
-     * @param name
-     * @return
-     */
-    String getCollaboratorListDisplayName(String name) {
-        RegExp regex = RegExp.compile(".*collaborator-lists:(.+)");
-        MatchResult match = regex.exec(name);
-        return match.getGroup(1);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/commons/Commons.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/commons/Commons.gwt.xml
@@ -61,4 +61,10 @@
     <replace-with class="org.iplantc.de.theme.base.client.commons.widgets.CustomMaskDefaultAppearance">
         <when-type-is class="org.iplantc.de.commons.client.widgets.CustomMask.CustomMaskAppearance" />
     </replace-with>
+
+    <!--Sharing Permission panel-->
+    <replace-with class="org.iplantc.de.theme.base.client.commons.views.sharing.SharingPermissionNameCellDefaultAppearance">
+        <when-type-is class="org.iplantc.de.commons.client.views.sharing.SharingPermissionNameCell.SharingPermissionNameCellAppearance" />
+    </replace-with>
+
 </module>

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/commons/views/sharing/SharingPermissionNameCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/commons/views/sharing/SharingPermissionNameCellDefaultAppearance.java
@@ -1,0 +1,48 @@
+package org.iplantc.de.theme.base.client.commons.views.sharing;
+
+import org.iplantc.de.client.models.sharing.Sharing;
+import org.iplantc.de.commons.client.views.sharing.SharingPermissionNameCell;
+import org.iplantc.de.resources.client.IplantResources;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.safehtml.shared.SafeUri;
+
+import com.sencha.gxt.core.client.XTemplates;
+
+/**
+ * @author aramsey
+ */
+public class SharingPermissionNameCellDefaultAppearance implements SharingPermissionNameCell.SharingPermissionNameCellAppearance {
+    interface Templates extends XTemplates {
+        @XTemplates.XTemplate("<span id='{debugID}'>{name}</span>")
+        SafeHtml subject(String name, String debugID);
+
+        @XTemplates.XTemplate("<img src='{uri}'/><span id='{debugID}'> {name}</span>")
+        SafeHtml group(SafeUri uri, String name, String debugID);
+    }
+
+    private IplantResources iplantResources;
+    private Templates templates;
+
+    public SharingPermissionNameCellDefaultAppearance() {
+        this(GWT.<IplantResources>create(IplantResources.class),
+             GWT.<Templates>create(Templates.class));
+    }
+
+    public SharingPermissionNameCellDefaultAppearance(IplantResources iplantResources,
+                                                      Templates templates) {
+        this.iplantResources = iplantResources;
+        this.templates = templates;
+    }
+
+    @Override
+    public void render(SafeHtmlBuilder safeHtmlBuilder, Sharing sharing, String debugID) {
+        if (sharing.getSourceId().equals("ldap")) {
+            safeHtmlBuilder.append(templates.subject(sharing.getSubject().getName(), debugID));
+        } else {
+            safeHtmlBuilder.append(templates.group(iplantResources.viewCurrentCollabs().getSafeUri(), sharing.getSubject().getName(), debugID));
+        }
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/commons/views/sharing/SharingPermissionNameCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/commons/views/sharing/SharingPermissionNameCellDefaultAppearance.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.theme.base.client.commons.views.sharing;
 
+import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.sharing.Sharing;
 import org.iplantc.de.commons.client.views.sharing.SharingPermissionNameCell;
 import org.iplantc.de.resources.client.IplantResources;
@@ -39,10 +40,11 @@ public class SharingPermissionNameCellDefaultAppearance implements SharingPermis
 
     @Override
     public void render(SafeHtmlBuilder safeHtmlBuilder, Sharing sharing, String debugID) {
-        if (sharing.getSourceId().equals("ldap")) {
-            safeHtmlBuilder.append(templates.subject(sharing.getSubject().getName(), debugID));
+        String subjectName = sharing.getSubject().getSubjectDisplayName();
+        if (sharing.getSourceId().equals(Subject.GROUP_IDENTIFIER)) {
+            safeHtmlBuilder.append(templates.group(iplantResources.viewCurrentCollabs().getSafeUri(), subjectName, debugID));
         } else {
-            safeHtmlBuilder.append(templates.group(iplantResources.viewCurrentCollabs().getSafeUri(), sharing.getSubject().getName(), debugID));
+            safeHtmlBuilder.append(templates.subject(subjectName, debugID));
         }
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/DiskResource.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/DiskResource.gwt.xml
@@ -122,10 +122,10 @@
 
     <!-- Sharing -->
     <replace-with class="org.iplantc.de.theme.base.client.diskResource.sharing.DataSharingViewDefaultAppearance">
-        <when-type-is class="org.iplantc.de.client.sharing.SharingAppearance" />
+        <when-type-is class="org.iplantc.de.commons.client.views.sharing.SharingAppearance" />
     </replace-with>
     <replace-with class="org.iplantc.de.theme.base.client.diskResource.sharing.presenter.SharingPresenterDefaultAppearance">
-        <when-type-is class="org.iplantc.de.client.sharing.SharingPresenter.Appearance" />
+        <when-type-is class="org.iplantc.de.commons.client.presenter.SharingPresenter.Appearance" />
     </replace-with>
 
     <!-- Search -->

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/sharing/DataSharingViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/sharing/DataSharingViewDefaultAppearance.java
@@ -1,6 +1,6 @@
 package org.iplantc.de.theme.base.client.diskResource.sharing;
 
-import org.iplantc.de.client.sharing.SharingAppearance;
+import org.iplantc.de.commons.client.views.sharing.SharingAppearance;
 import org.iplantc.de.resources.client.IplantResources;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 import org.iplantc.de.theme.base.client.diskResource.DiskResourceMessages;

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/sharing/DataSharingViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/sharing/DataSharingViewDefaultAppearance.java
@@ -192,7 +192,7 @@ public class DataSharingViewDefaultAppearance implements SharingAppearance {
 
     @Override
     public String variablePermissionsNotice() {
-        return sharingMessages.variablePermissionsNotice();
+        return sharingMessages.variablePermissionsNotice() + ":" + explain();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/sharing/presenter/SharingPresenterDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/sharing/presenter/SharingPresenterDefaultAppearance.java
@@ -1,6 +1,6 @@
 package org.iplantc.de.theme.base.client.diskResource.sharing.presenter;
 
-import org.iplantc.de.client.sharing.SharingPresenter;
+import org.iplantc.de.commons.client.presenter.SharingPresenter;
 import org.iplantc.de.theme.base.client.diskResource.sharing.SharingMessages;
 
 import com.google.gwt.core.client.GWT;

--- a/de-webapp/src/main/java/org/iplantc/de/admin/client/gin/BelphegorAppInjector.java
+++ b/de-webapp/src/main/java/org/iplantc/de/admin/client/gin/BelphegorAppInjector.java
@@ -6,7 +6,7 @@ import org.iplantc.de.admin.desktop.client.ontologies.gin.OntologiesGinModule;
 import org.iplantc.de.admin.desktop.client.toolAdmin.gin.ToolAdminGinModule;
 import org.iplantc.de.admin.desktop.client.views.BelphegorView;
 import org.iplantc.de.admin.desktop.client.workshopAdmin.gin.WorkshopAdminGinModule;
-import org.iplantc.de.client.gin.ClientGinModule;
+import org.iplantc.de.commons.client.gin.CommonsGinModule;
 import org.iplantc.de.collaborators.client.gin.CollaboratorsGinModule;
 import org.iplantc.de.commons.client.comments.gin.CommentsGinModule;
 import org.iplantc.de.diskResource.client.gin.DiskResourceGinModule;
@@ -25,7 +25,7 @@ import com.google.gwt.inject.client.Ginjector;
               AdminAppsGinModule.class,
               OntologiesGinModule.class,
               DiskResourceGinModule.class,
-              ClientGinModule.class,
+              CommonsGinModule.class,
               CollaboratorsGinModule.class,
               CommentsGinModule.class,
               TagsGinModule.class,

--- a/de-webapp/src/main/java/org/iplantc/de/client/gin/DEInjector.java
+++ b/de-webapp/src/main/java/org/iplantc/de/client/gin/DEInjector.java
@@ -6,6 +6,7 @@ import org.iplantc.de.apps.integration.client.gin.AppEditorGinModule;
 import org.iplantc.de.apps.widgets.client.gin.AppLaunchGinModule;
 import org.iplantc.de.collaborators.client.gin.CollaboratorsGinModule;
 import org.iplantc.de.commons.client.comments.gin.CommentsGinModule;
+import org.iplantc.de.commons.client.gin.CommonsGinModule;
 import org.iplantc.de.desktop.client.DesktopView;
 import org.iplantc.de.desktop.client.gin.DEGinModule;
 import org.iplantc.de.diskResource.client.gin.DiskResourceGinModule;
@@ -36,7 +37,7 @@ import com.google.gwt.inject.client.Ginjector;
               CollaboratorsGinModule.class,
               NotificationGinModule.class,
               PreferencesGinModule.class,
-              ClientGinModule.class })
+              CommonsGinModule.class })
 public interface DEInjector extends Ginjector {
     public static final DEInjector INSTANCE = GWT.create(DEInjector.class);
 


### PR DESCRIPTION
NOTE: This is a branch on top of another branch.  The commits start at `CORE-8795 Add concept of Mode to GroupView to manage ManageCollaboratorsView mode`. You can also use [this link](https://github.com/cyverse-de/ui/pull/131/files/2b53938c3e812007d6ec39607d15c68c1541be4f..1ffed07f5b3164b0259cf2136895910e2d3fa044) to only view those commits.

This PR should allow users to share apps/analyses/data with Collaborators and/or Collaborator Lists.  Places where "ldap" is hard-coded in the `source_id` field should be updated after the endpoints get updated to return `Subject` types instead of the old `Collaborator` types.