### PR TITLE
CORE-8858 Add deprecated tool warnings to workflow editor.

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/pipelines/PipelineTask.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/pipelines/PipelineTask.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.client.models.pipelines;
 
 import org.iplantc.de.client.models.HasSystemId;
+import org.iplantc.de.client.models.tool.Tool;
 
 import com.google.gwt.user.client.ui.HasName;
 import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
@@ -30,6 +31,10 @@ public interface PipelineTask extends HasName, HasSystemId {
     String getDescription();
 
     void setDescription(String description);
+
+    Tool getTool();
+
+    void setTool(Tool tool);
 
     Integer getStep();
 

--- a/de-lib/src/main/java/org/iplantc/de/client/models/pipelines/ServicePipelineTask.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/pipelines/ServicePipelineTask.java
@@ -3,6 +3,7 @@ package org.iplantc.de.client.models.pipelines;
 import org.iplantc.de.client.models.HasDescription;
 import org.iplantc.de.client.models.HasId;
 import org.iplantc.de.client.models.apps.AppFileParameters;
+import org.iplantc.de.client.models.tool.Tool;
 
 import com.google.gwt.user.client.ui.HasName;
 
@@ -15,6 +16,10 @@ import java.util.List;
  * 
  */
 public interface ServicePipelineTask extends HasId, HasName, HasDescription {
+
+    Tool getTool();
+
+    void setTool(Tool tool);
 
     public List<AppFileParameters> getInputs();
 

--- a/de-lib/src/main/java/org/iplantc/de/client/models/tool/ToolImage.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/tool/ToolImage.java
@@ -19,4 +19,6 @@ public interface ToolImage extends HasName {
 
     @PropertyName("url")
     String getUrl();
+
+    boolean isDeprecated();
 }

--- a/de-lib/src/main/java/org/iplantc/de/pipelines/client/util/PipelineAutoBeanUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/pipelines/client/util/PipelineAutoBeanUtil.java
@@ -14,7 +14,6 @@ import org.iplantc.de.client.models.pipelines.ServicePipelineMapping;
 import org.iplantc.de.client.models.pipelines.ServicePipelineStep;
 import org.iplantc.de.client.models.pipelines.ServicePipelineTask;
 import org.iplantc.de.client.models.pipelines.ServiceSaveResponse;
-import org.iplantc.de.client.services.AppUserServiceFacade;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.resources.client.messages.I18N;
 import org.iplantc.de.shared.AppsCallback;
@@ -344,6 +343,7 @@ public class PipelineAutoBeanUtil {
         if (template != null) {
             ret.setName(template.getName());
             ret.setDescription(template.getDescription());
+            ret.setTool(template.getTool());
             ret.setInputs(templateDataObjectsToPipelineAppData(template.getInputs()));
             ret.setOutputs(templateDataObjectsToPipelineAppData(template.getOutputs()));
         }

--- a/de-lib/src/main/java/org/iplantc/de/resources/client/uiapps/integration/AppIntegrationErrorMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/resources/client/uiapps/integration/AppIntegrationErrorMessages.java
@@ -14,4 +14,7 @@ public interface AppIntegrationErrorMessages {
 
     SafeHtml cannotDeleteLastArgumentGroup();
 
+    String workflowAddingDeprecatedTask();
+
+    String workflowUsesDeprecatedTools();
 }

--- a/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantErrorStrings.properties
+++ b/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantErrorStrings.properties
@@ -89,6 +89,11 @@ appUsesDeprecatedTools = This app uses a deprecated tool. You can still edit and
 appContainsErrorsUnableToSave = App Editor contains errors and cannot be saved.
 appContainsErrorsPromptToContinue = App Editor contains errors and cannot be saved. Do you wish to abandon all changes and continue?
 cannotDeleteLastArgumentGroup = Cannot delete section. App must contain at least one section.
+workflowAddingDeprecatedTask = This app uses a deprecated tool. You can still use this app in your private workflow, \
+  but you will have to replace it with a newer version of the app before this workflow can be made public.
+workflowUsesDeprecatedTools = This workflow contains 1 or more apps that use deprecated tools. \
+  You can still edit and use this private workflow, \
+  but you will have to replace these apps with a newer version before this workflow can be made public.
 
 
 #Tags


### PR DESCRIPTION
This PR will update the `PipelineViewPresenter` to check for deprecated tools, using the details added by cyverse-de/apps#61, in order to display a warning when opening a workflow for editing that uses apps with `deprecated` tools, or when adding apps that use `deprecated` tools to a workflow.