### PR TITLE
CORE-8872 Fix Class Cast Exception being thrown during DND within HT …

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/PathListViewer.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/PathListViewer.java
@@ -138,33 +138,48 @@ public class PathListViewer extends AbstractStructuredTextViewer implements Stor
                               CancellableEvent cancellableEvent,
                               StatusProxy statusProxy) {
 
-            if(!hasCorrectData(o)){
+            if(!isNonEmptyCollection(o)){
                 cancellableEvent.setCancelled(true);
                 statusProxy.setStatus(false);
+                return;
             }
-            // TODO Check to see if any items are pathlists. If they are, prevent drop
-            Iterable<DiskResource> iterable = (Iterable<DiskResource>) o;
-            for(DiskResource dr : iterable){
-                InfoType infoType1 = InfoType.fromTypeString(dr.getInfoType());
-                if(InfoType.HT_ANALYSIS_PATH_LIST.equals(infoType1)){
-                    cancellableEvent.setCancelled(true);
-                    statusProxy.update((SafeHtml)appearance::preventPathListDrop);
-                    statusProxy.setStatus(false);
 
-                    return;
+            if (hasDiskResources(o)) {
+
+                // TODO Check to see if any items are pathlists. If they are, prevent drop
+                Iterable<DiskResource> iterable = (Iterable<DiskResource>)o;
+                for (DiskResource dr : iterable) {
+                    InfoType infoType1 = InfoType.fromTypeString(dr.getInfoType());
+                    if (InfoType.HT_ANALYSIS_PATH_LIST.equals(infoType1)) {
+                        cancellableEvent.setCancelled(true);
+                        statusProxy.update((SafeHtml)appearance::preventPathListDrop);
+                        statusProxy.setStatus(false);
+
+                        return;
+                    }
                 }
+                cancellableEvent.setCancelled(false);
+                statusProxy.setStatus(true);
+            } else {
+                cancellableEvent.setCancelled(false);
+                statusProxy.setStatus(true);
             }
-            cancellableEvent.setCancelled(false);
-            statusProxy.setStatus(true);
         }
 
-        boolean hasCorrectData(Object data){
-           boolean isCollection = data instanceof Collection<?>;
-            boolean isEmpty = ((Collection<?>) data).isEmpty();
-            boolean hasDiskResources = ((Collection<?>) data).iterator().next() instanceof DiskResource;
-            return isCollection
-                       && !isEmpty
-                       && hasDiskResources;
+        boolean hasCorrectData(Object data) {
+
+            return isNonEmptyCollection(data)
+                       && hasDiskResources(data);
+        }
+
+        boolean hasDiskResources (Object data) {
+            return ((Collection<?>) data).iterator().next() instanceof DiskResource;
+        }
+
+        boolean isNonEmptyCollection(Object data) {
+            boolean isCollection = data instanceof Collection<?>;
+            boolean isEmpty = isCollection && ((Collection<?>)data).isEmpty();
+            return isCollection && !isEmpty;
         }
 
         private StringBuilder checkForSplChar(List<Splittable> idSet) {


### PR DESCRIPTION
…Files

The DND logic within PathListViewer assumed the user would only ever DND files from the Data window (with type DiskResource) to the HT File viewer (with type Splittable).  In the code, there was logic casting the DND source to DiskResource. This is not always the case as users may want to rearrange files within the HT file viewer, which was unaccounted for.