### PR TITLE
CORE-8883 Prevent new users from seeing an error banner regarding preferences

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/InitializationCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/InitializationCallbacks.java
@@ -208,9 +208,11 @@ class InitializationCallbacks {
                                      IplantAnnouncer announcer,
                                      DesktopView.Presenter.DesktopPresenterAppearance appearance) {
         if (userInfo.hasPreferencesError()) {
-            announcer.schedule(new ErrorAnnouncementConfig(SafeHtmlUtils.fromString(appearance.userPreferencesLoadError()),
-                                                           false,
-                                                           5000));
+            if (!userInfo.isNewUser()) {
+                announcer.schedule(new ErrorAnnouncementConfig(SafeHtmlUtils.fromString(appearance.userPreferencesLoadError()),
+                                                               false,
+                                                               5000));
+            }
             userSettings.setUserSettings(null);
         } else {
             userSettings.setUserSettings(userInfo.getUserPreferences());

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/DesktopMessages.properties
@@ -35,4 +35,4 @@ sessionConnectionFailed = Connection to session service failed.
 faqs = FAQs
 feedback = Feedback
 preferencesFailure = We were unable to fetch your preferences.  A default set of preferences will be used instead.
-preferencesSuccess = Preferences successfully restored!
+preferencesSuccess = Preferences successfully loaded


### PR DESCRIPTION
I also changed some wording.  If preferences failed to load during bootstrap, we retry fetching preferences when opening the Preferences window.  In the case of a new user, "restored" doesn't make much sense, but "loaded" should work for all scenarios.