### PR TITLE
Patch up NPEs and fix dummy subject creation for anonymous user

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Subject.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Subject.java
@@ -58,7 +58,7 @@ public interface Subject extends HasSettableId, HasName {
     void setSourceId(String sourceId);
 
     default boolean isCollaboratorList() {
-        return getSourceId().equals(GROUP_IDENTIFIER);
+        return GROUP_IDENTIFIER.equals(getSourceId());
     }
 
     default String getSubjectDisplayName() {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/CollaboratorsUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/CollaboratorsUtil.java
@@ -30,9 +30,11 @@ public class CollaboratorsUtil {
         return INSTANCE;
     }
 
-    //TODO Do I still need this for Subject?
     public Subject getDummySubject(String userName) {
-        return factory.getSubject().as();
+        Subject subject = factory.getSubject().as();
+        subject.setId(userName);
+        subject.setName(userName);
+        return subject;
     }
 
     public boolean isCurrentCollaborator(Subject c, List<Subject> subjects) {

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/commons/views/sharing/SharingPermissionNameCellDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/commons/views/sharing/SharingPermissionNameCellDefaultAppearance.java
@@ -41,7 +41,7 @@ public class SharingPermissionNameCellDefaultAppearance implements SharingPermis
     @Override
     public void render(SafeHtmlBuilder safeHtmlBuilder, Sharing sharing, String debugID) {
         String subjectName = sharing.getSubject().getSubjectDisplayName();
-        if (sharing.getSourceId().equals(Subject.GROUP_IDENTIFIER)) {
+        if (Subject.GROUP_IDENTIFIER.equals(sharing.getSourceId())) {
             safeHtmlBuilder.append(templates.group(iplantResources.viewCurrentCollabs().getSafeUri(), subjectName, debugID));
         } else {
             safeHtmlBuilder.append(templates.subject(subjectName, debugID));


### PR DESCRIPTION
When the UI looks up sharing info, it first gets a list of usernames that have permissions on the resource.  Once that's returned, then a secondary call is made to look up the user information to be able to display the user's name.  In the case of the anonymous user, the secondary call returns no information because that user doesn't exist in grouper, so the UI creates a "dummy" collaborator to display.  The UI has been updated to create a dummy collaborator where the username is both the id and the name.  The username is then what is displayed in the UI for that particular case.