### PR TITLE
CORE-8893 Enable "View in Genome Browser" for multiple genome files.

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/DiskResourceServiceFacade.java
@@ -291,7 +291,7 @@ public interface DiskResourceServiceFacade {
      * @param diskResourcePaths the paths to query
      * @param callback callback object
      */
-    void shareWithAnonymous(final HasPaths diskResourcePaths, final DECallback<String> callback);
+    void shareWithAnonymous(final HasPaths diskResourcePaths, final DECallback<List<String>> callback);
 
     /**
      * Copy metadata to list of files / folders

--- a/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/util/DiskResourceUtil.java
@@ -413,6 +413,10 @@ public class DiskResourceUtil {
                 || InfoType.BIGBED.equals(infoType) || InfoType.BIGWIG.equals(infoType);
     }
 
+    public boolean isGenomeIndexFile(String path) {
+        return path != null && (path.endsWith(".bai") || path.endsWith(".tbi"));
+    }
+
     private String getInfoType(Splittable obj) {
         if (obj == null)
             return null;

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterWindowEventHandler.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterWindowEventHandler.java
@@ -172,9 +172,14 @@ public class DesktopPresenterWindowEventHandler implements EditAppEvent.EditAppE
 
     @Override
     public void onRequestSendToEnsembl(RequestSendToEnsemblEvent event) {
-        checkNotNull(event.getFile());
-        showFile(event.getFile());
-        new EnsemblUtil(event.getFile(), event.getInfoType().toString(), null).sendToEnsembl(diskResourceServiceFacade);
+        final List<DiskResource> resourcesToSend = event.getResourcesToSend();
+
+        checkNotNull(resourcesToSend);
+        if (resourcesToSend.size() == 1) {
+            showFile((File)resourcesToSend.iterator().next());
+        }
+
+        new EnsemblUtil(resourcesToSend, null).sendToEnsembl(diskResourceServiceFacade);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/events/RequestSendToEnsemblEvent.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/events/RequestSendToEnsemblEvent.java
@@ -1,11 +1,12 @@
 package org.iplantc.de.diskResource.client.events;
 
-import org.iplantc.de.client.models.diskResources.File;
-import org.iplantc.de.client.models.viewer.InfoType;
+import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.diskResource.client.events.RequestSendToEnsemblEvent.RequestSendToEnsemblEventHandler;
 
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
+
+import java.util.List;
 
 public class RequestSendToEnsemblEvent extends GwtEvent<RequestSendToEnsemblEventHandler> {
 
@@ -16,12 +17,10 @@ public class RequestSendToEnsemblEvent extends GwtEvent<RequestSendToEnsemblEven
         void onRequestSendToEnsembl(RequestSendToEnsemblEvent event);
     }
 
-    private final File file;
-    private final InfoType infoType;
+    private final List<DiskResource> resourcesToSend;
 
-    public RequestSendToEnsemblEvent(File file, InfoType infoType) {
-        this.file = file;
-        this.infoType = infoType;
+    public RequestSendToEnsemblEvent(List<DiskResource> resourcesToSend) {
+        this.resourcesToSend = resourcesToSend;
     }
 
     @Override
@@ -35,12 +34,7 @@ public class RequestSendToEnsemblEvent extends GwtEvent<RequestSendToEnsemblEven
 
     }
 
-    public File getFile() {
-        return file;
+    public List<DiskResource> getResourcesToSend() {
+        return resourcesToSend;
     }
-
-    public InfoType getInfoType() {
-        return infoType;
-    }
-
 }

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/ShareAnonymousCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/ShareAnonymousCallback.java
@@ -16,7 +16,6 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextArea;
 
 import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
-import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.form.FieldLabel;
 import com.sencha.gxt.widget.core.client.form.FormPanel.LabelAlign;
 import com.sencha.gxt.widget.core.client.tips.QuickTip;
@@ -35,10 +34,21 @@ public class ShareAnonymousCallback extends DataCallback<List<String>> {
 
         SafeHtml notificationWithContextHelp();
 
+        int notificationWithContextWidth();
+
         String sendToEnsemblMenuItem();
 
         String sendToEnsemblUrlHelp();
 
+        int sendToEnsemblUrlHelpPopupWidth();
+
+        String ensemblUrlDialogWidth();
+
+        String ensemblUrlDialogHeight();
+
+        int ensemblUrlTextAreaWidth();
+
+        int ensemblUrlTextAreaHeight();
     }
 
     private final IsMaskable container;
@@ -79,12 +89,12 @@ public class ShareAnonymousCallback extends DataCallback<List<String>> {
 
         dlg.setHideOnButtonClick(true);
         dlg.setResizable(false);
-        dlg.setSize("640", "320");
+        dlg.setSize(appearance.ensemblUrlDialogWidth(), appearance.ensemblUrlDialogHeight());
 
         FieldLabel fl = new FieldLabel();
         fl.setHTML(SafeHtmlUtils.fromTrustedString(appearance.ensemblUrl()));
         TextArea textBox = new TextArea();
-        textBox.setPixelSize(600, 180);
+        textBox.setPixelSize(appearance.ensemblUrlTextAreaWidth(), appearance.ensemblUrlTextAreaHeight());
         textBox.setReadOnly(true);
         textBox.setValue(Joiner.on('\n').join(linkIds));
         fl.setWidget(textBox);
@@ -101,7 +111,7 @@ public class ShareAnonymousCallback extends DataCallback<List<String>> {
         notification.setHTML(appearance.notificationWithContextHelp());
         new QuickTip(notification);
 
-        notification.setWidth(600);
+        notification.setWidth(appearance.notificationWithContextWidth());
         container.add(notification);
         dlg.setWidget(container);
         dlg.setFocusWidget(textBox);
@@ -111,15 +121,11 @@ public class ShareAnonymousCallback extends DataCallback<List<String>> {
 
     private void attachHelp(final IPlantDialog dlg) {
         final ContextualHelpPopup popup = new ContextualHelpPopup();
-        popup.setWidth(480);
+        popup.setWidth(appearance.sendToEnsemblUrlHelpPopupWidth());
         popup.add(new HTML(appearance.sendToEnsemblUrlHelp()));
-        dlg.getHelpToolButton().addSelectHandler(new SelectEvent.SelectHandler() {
-            @Override
-            public void onSelect(SelectEvent event) {
-                popup.showAt(dlg.getHelpToolButton().getAbsoluteLeft(),
-                             dlg.getHelpToolButton().getAbsoluteTop() + 15);
-            }
-        });
+        dlg.getHelpToolButton()
+           .addSelectHandler(event -> popup.showAt(dlg.getHelpToolButton().getAbsoluteLeft(),
+                                                   dlg.getHelpToolButton().getAbsoluteTop() + 15));
     }
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/ExternalVisualizationURLViewerImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/ExternalVisualizationURLViewerImpl.java
@@ -41,6 +41,7 @@ import com.sencha.gxt.widget.core.client.grid.Grid;
 import com.sencha.gxt.widget.core.client.grid.GridView;
 import com.sencha.gxt.widget.core.client.toolbar.ToolBar;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -190,8 +191,7 @@ public class ExternalVisualizationURLViewerImpl extends AbstractFileViewer imple
             @Override
             public void onSelect(SelectEvent event) {
                 mask(appearance.sendToEnsemblLoadingMask());
-                EnsemblUtil util = new EnsemblUtil(file,
-                                                   infoType,
+                EnsemblUtil util = new EnsemblUtil(Collections.singletonList(file),
                                                    ExternalVisualizationURLViewerImpl.this);
                 util.sendToEnsembl(diskResourceServiceFacade);
             }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerContextualHelpStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerContextualHelpStrings.properties
@@ -1,1 +1,8 @@
-sendToEnsemblUrlHelp = To access this file in genome browsers, this file needs to be public. If you do not want this file to be public, you can change its permissions as follows: <b>1.</b> Navigate to the file in the data window <b>2.</b> Select the file <b>3.</b> Select <i>Share</i>-><i>Share with collaborators</i> from the menu. <b>4.</b> In the <i>Manage Sharing</i> window in the <i>Who has access</i> section and remove permissions to the <i>anonymous</i> user.
+sendToEnsemblUrlHelp = To access a file in genome browsers, the file needs to be public. \
+  If you do not want the file to be public, you can change its permissions as follows:\
+  <ol>\
+  <li><b>1.</b> Navigate to the file in the data window.</li>\
+  <li><b>2.</b> Select the file.</li>\
+  <li><b>3.</b> Select <i>Share</i>-><i>Share with collaborators</i> from the menu.</li>\
+  <li><b>4.</b> In the <i>Manage Sharing</i> window in the <i>Who has access</i> section and remove permissions to the <i>anonymous</i> user.</li>\
+  </ol>

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerStrings.properties
@@ -35,6 +35,11 @@ label = Label
 externalVizUrlColumnHeaderLabel = URL
 defaultViewName = Untitled-{0}
 cogeResponse = Please click <a href={0} target='_blank'>here</a> to load and visualize your genome in CoGe.
-sendToEnsemblePopupNote = Note: Anyone with access to this file''s URL can access the file.
-ensemblUrl = Please visit <a href='http://ensemblgenomes.org/info/genomes' target="_blank">Ensembl</a> / <a href='https://genome.ucsc.edu/goldenPath/customTracks/custTracks.html' target="_blank"> UCSC </a> / <a href='http://www.broadinstitute.org/igv/' target="_blank"> IGV </a> / <a href='http://gmod.org/wiki/GBrowse' target="_blank">GBrowse</a> / <a href='http://jbrowse.org/' target="_blank">jbrowse</a> / <a href='http://epigenomegateway.wustl.edu/browser/' target='_blank'> WashU EPIGenome Browser</a> and use the following URL to import your bam / vcf / gff / bed / bigBed / bigWig file
-
+sendToEnsemblePopupNote = Note: Anyone with access to a file''s URL can access that file.
+ensemblUrl = Please visit <a href='http://ensemblgenomes.org/info/genomes' target="_blank">Ensembl</a> \
+  / <a href='https://genome.ucsc.edu/goldenPath/customTracks/custTracks.html' target="_blank"> UCSC </a> \
+  / <a href='http://www.broadinstitute.org/igv/' target="_blank"> IGV </a> \
+  / <a href='http://gmod.org/wiki/GBrowse' target="_blank">GBrowse</a> \
+  / <a href='http://jbrowse.org/' target="_blank">jbrowse</a> \
+  / <a href='http://epigenomegateway.wustl.edu/browser/' target='_blank'> WashU EPIGenome Browser</a> \
+  and use one of the following URLs to import your bam / vcf / gff / bed / bigBed / bigWig file

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/callbacks/ShareAnonymousCallbackDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/callbacks/ShareAnonymousCallbackDefaultAppearance.java
@@ -52,6 +52,11 @@ public class ShareAnonymousCallbackDefaultAppearance implements ShareAnonymousCa
     }
 
     @Override
+    public int notificationWithContextWidth() {
+        return 600;
+    }
+
+    @Override
     public String sendToEnsemblMenuItem() {
         return displayStrings.sendToEnsemblMenuItem();
     }
@@ -59,6 +64,31 @@ public class ShareAnonymousCallbackDefaultAppearance implements ShareAnonymousCa
     @Override
     public String sendToEnsemblUrlHelp() {
         return helpStrings.sendToEnsemblUrlHelp();
+    }
+
+    @Override
+    public int sendToEnsemblUrlHelpPopupWidth() {
+        return 480;
+    }
+
+    @Override
+    public String ensemblUrlDialogWidth() {
+        return "640";
+    }
+
+    @Override
+    public String ensemblUrlDialogHeight() {
+        return "320";
+    }
+
+    @Override
+    public int ensemblUrlTextAreaWidth() {
+        return 600;
+    }
+
+    @Override
+    public int ensemblUrlTextAreaHeight() {
+        return 180;
     }
 
 }

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onDiskResourceSelectionChangedTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onDiskResourceSelectionChangedTest.java
@@ -86,8 +86,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
     @Mock DiskResourceSearchField searchFieldMock;
     @Mock DiskResourceUtil diskResourceUtilMock;
 
-    private boolean containsFile = false;
-    private boolean containsOnlyFolders = false;
     private final boolean isReadable = true;
     private boolean isSelectionInTrash = false;
     private boolean isSelectionOwner = true;
@@ -99,11 +97,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
 
     @Before public void setup() {
         uut = new DiskResourceViewToolbarImpl(searchFieldMock, mock(UserInfo.class), mockAppearance, mockPresenter){
-            @Override
-            boolean containsFile(List<DiskResource> selection) {
-                return containsFile;
-            }
-
             @Override
             boolean isOwnerList(List<DiskResource> selection) {
                 return isSelectionOwner;
@@ -118,11 +111,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
             boolean isSelectionInTrash(List<DiskResource> selection) {
                 return isSelectionInTrash;
             }
-
-            @Override
-            boolean containsOnlyFolders(List<DiskResource> selection) {
-                return containsOnlyFolders;
-            }
         };
         mockMenuItems(uut);
         uut.diskResourceUtil = diskResourceUtilMock;
@@ -136,7 +124,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_emptySelection(){
         this.isSelectionInTrash = false;
-        this.containsFile = true;
         // Setup mock event
         DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
         final ArrayList<DiskResource> selection = Lists.newArrayList();
@@ -183,13 +170,13 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_file_notInTrash_read() {
         this.isSelectionInTrash = false;
-        this.containsFile = true;
         File mockFile = mock(File.class);
         // Setup mock event
         DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFile);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*=================== Read ====================*/
         this.isSelectionOwner = false;
@@ -240,13 +227,13 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_file_notInTrash_write() {
         this.isSelectionInTrash = false;
-        this.containsFile = true;
         File mockFile = mock(File.class);
         // Setup mock event
         DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFile);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*==================== Write ==================*/
         this.isSelectionOwner = false;
@@ -295,13 +282,13 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_file_notInTrash_own() {
         this.isSelectionInTrash = false;
-        this.containsFile = true;
         File mockFile = mock(File.class);
         // Setup mock event
         DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFile);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*==================== Own ====================*/
         this.isSelectionOwner = true;
@@ -350,13 +337,13 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_file_inTrash_read() {
         this.isSelectionInTrash = true;
-        this.containsFile = true;
         File mockFile = mock(File.class);
         // Setup mock event
         DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFile);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*=================== Read ====================*/
         this.isSelectionOwner = false;
@@ -405,13 +392,13 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_file_inTrash_write() {
         this.isSelectionInTrash = true;
-        this.containsFile = true;
         File mockFile = mock(File.class);
         // Setup mock event
         DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFile);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*==================== Write ==================*/
         this.isSelectionOwner = false;
@@ -460,13 +447,13 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_file_inTrash_own(){
         this.isSelectionInTrash = true;
-        this.containsFile = true;
         File mockFile = mock(File.class);
         // Setup mock event
         DiskResourceSelectionChangedEvent mockEvent = mock(DiskResourceSelectionChangedEvent.class);
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFile);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*==================== Own ====================*/
         this.isSelectionOwner = true;
@@ -522,10 +509,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFolder);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Read ====================*/
         this.isSelectionOwner = false;
-        this.containsOnlyFolders = true;
         when(mockFolder.getPermission()).thenReturn(read);
         uut.onDiskResourceSelectionChanged(mockEvent);
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
@@ -577,10 +564,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFolder);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Write ====================*/
         this.isSelectionOwner = false;
-        this.containsOnlyFolders = true;
         when(mockFolder.getPermission()).thenReturn(write);
         uut.onDiskResourceSelectionChanged(mockEvent);
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
@@ -633,10 +620,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFolder);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Own ====================*/
         this.isSelectionOwner = true;
-        this.containsOnlyFolders = true;
         when(mockFolder.getPermission()).thenReturn(own);
         uut.onDiskResourceSelectionChanged(mockEvent);
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
@@ -743,10 +730,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFolder);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Write ====================*/
         this.isSelectionOwner = false;
-        this.containsOnlyFolders = true;
         when(mockFolder.getPermission()).thenReturn(write);
         uut.onDiskResourceSelectionChanged(mockEvent);
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
@@ -799,10 +786,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(mockFolder);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Own ====================*/
         this.isSelectionOwner = true;
-        this.containsOnlyFolders = true;
         when(mockFolder.getPermission()).thenReturn(own);
         uut.onDiskResourceSelectionChanged(mockEvent);
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
@@ -850,7 +837,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_multiFiles_notInTrash_read() {
         this.isSelectionInTrash = false;
-        this.containsFile = true;
         File mockFile1 = mock(File.class);
         File mockFile2 = mock(File.class);
         // Setup mock event
@@ -859,6 +845,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFile1);
         selection.add(mockFile2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*=================== Read ====================*/
         this.isSelectionOwner = false;
@@ -895,7 +882,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verify(mockCreatePublicLink).setEnabled(false);
         verify(mockShareFolderLocation).setEnabled(false);
         verify(mockSendToCoge).setEnabled(false);
-        verify(mockSendToEnsembl).setEnabled(false);
+        verify(mockSendToEnsembl).setEnabled(true);
         verify(mockSendToTreeViewer).setEnabled(false);
 
         // Trash Menu Items
@@ -908,7 +895,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_multiFiles_notInTrash_write() {
         this.isSelectionInTrash = false;
-        this.containsFile = true;
         File mockFile1 = mock(File.class);
         File mockFile2 = mock(File.class);
         // Setup mock event
@@ -917,6 +903,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFile1);
         selection.add(mockFile2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*==================== Write ==================*/
         this.isSelectionOwner = false;
@@ -954,7 +941,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verify(mockCreatePublicLink).setEnabled(false);
         verify(mockShareFolderLocation).setEnabled(false);
         verify(mockSendToCoge).setEnabled(false);
-        verify(mockSendToEnsembl).setEnabled(false);
+        verify(mockSendToEnsembl).setEnabled(true);
         verify(mockSendToTreeViewer).setEnabled(false);
 
         // Trash Menu Items
@@ -967,7 +954,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_multiFiles_notInTrash_own() {
         this.isSelectionInTrash = false;
-        this.containsFile = true;
         File mockFile1 = mock(File.class);
         File mockFile2 = mock(File.class);
         // Setup mock event
@@ -976,6 +962,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFile1);
         selection.add(mockFile2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*==================== Own ====================*/
         this.isSelectionOwner = true;
@@ -1013,7 +1000,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         verify(mockCreatePublicLink).setEnabled(true);
         verify(mockShareFolderLocation).setEnabled(false);
         verify(mockSendToCoge).setEnabled(false);
-        verify(mockSendToEnsembl).setEnabled(false);
+        verify(mockSendToEnsembl).setEnabled(true);
         verify(mockSendToTreeViewer).setEnabled(false);
 
         // Trash Menu Items
@@ -1034,7 +1021,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_multiFiles_inTrash_read() {
         this.isSelectionInTrash = true;
-        this.containsFile = true;
         File mockFile1 = mock(File.class);
         File mockFile2 = mock(File.class);
         // Setup mock event
@@ -1043,6 +1029,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFile1);
         selection.add(mockFile2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*=================== Read ====================*/
         this.isSelectionOwner = false;
@@ -1092,7 +1079,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_multiFiles_inTrash_write() {
         this.isSelectionInTrash = true;
-        this.containsFile = true;
         File mockFile1 = mock(File.class);
         File mockFile2 = mock(File.class);
         // Setup mock event
@@ -1101,6 +1087,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFile1);
         selection.add(mockFile2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*==================== Write ==================*/
         this.isSelectionOwner = false;
@@ -1150,7 +1137,6 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
      */
     @Test public void testOnDiskResourceSelectionChanged_multiFiles_inTrash_own(){
         this.isSelectionInTrash = true;
-        this.containsFile = true;
         File mockFile1 = mock(File.class);
         File mockFile2 = mock(File.class);
         // Setup mock event
@@ -1159,6 +1145,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFile1);
         selection.add(mockFile2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*==================== Own ====================*/
         this.isSelectionOwner = true;
@@ -1224,6 +1211,7 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFolder1);
         selection.add(mockFolder2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Read ====================*/
         this.isSelectionOwner = false;
@@ -1281,10 +1269,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFolder1);
         selection.add(mockFolder2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Write ====================*/
         this.isSelectionOwner = false;
-        this.containsOnlyFolders = true;
         when(mockFolder1.getPermission()).thenReturn(write);
         when(mockFolder2.getPermission()).thenReturn(write);
         uut.onDiskResourceSelectionChanged(mockEvent);
@@ -1339,10 +1327,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFolder1);
         selection.add(mockFolder2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Own ====================*/
         this.isSelectionOwner = true;
-        this.containsOnlyFolders = true;
         when(mockFolder1.getPermission()).thenReturn(own);
         when(mockFolder2.getPermission()).thenReturn(own);
         uut.onDiskResourceSelectionChanged(mockEvent);
@@ -1392,10 +1380,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(redMockFolder1);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
         when(diskResourceUtilMock.containsFilteredItems(selection)).thenReturn(true);
           /*=================== Own ====================*/
         this.isSelectionOwner = true;
-        this.containsOnlyFolders = true;
         when(redMockFolder1.getPermission()).thenReturn(own);
         uut.onDiskResourceSelectionChanged(mockEvent);
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
@@ -1444,10 +1432,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         final ArrayList<DiskResource> selection = Lists.newArrayList();
         selection.add(redMockFile1);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
         when(diskResourceUtilMock.containsFilteredItems(selection)).thenReturn(true);
           /*=================== Own ====================*/
         this.isSelectionOwner = true;
-        this.containsOnlyFolders = false;
         when(redMockFile1.getPermission()).thenReturn(own);
         uut.onDiskResourceSelectionChanged(mockEvent);
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
@@ -1499,10 +1487,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(redMockFile1);
         selection.add(mockFile2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
         when(diskResourceUtilMock.containsFilteredItems(selection)).thenReturn(true);
           /*=================== Own ====================*/
         this.isSelectionOwner = true;
-        this.containsOnlyFolders = false;
         when(redMockFile1.getPermission()).thenReturn(own);
         uut.onDiskResourceSelectionChanged(mockEvent);
         verifyOnDiskResourceSelectionChangedNeverUsedItems();
@@ -1620,10 +1608,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFolder1);
         selection.add(mockFolder2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Write ====================*/
         this.isSelectionOwner = false;
-        this.containsOnlyFolders = true;
         when(mockFolder1.getPermission()).thenReturn(write);
         when(mockFolder2.getPermission()).thenReturn(write);
         uut.onDiskResourceSelectionChanged(mockEvent);
@@ -1678,10 +1666,10 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFolder1);
         selection.add(mockFolder2);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
 
         /*=================== Own ====================*/
         this.isSelectionOwner = true;
-        this.containsOnlyFolders = true;
         when(mockFolder1.getPermission()).thenReturn(own);
         when(mockFolder2.getPermission()).thenReturn(own);
         uut.onDiskResourceSelectionChanged(mockEvent);
@@ -1743,11 +1731,11 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFolder1);
         selection.add(mockFile1);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*=================== Read ====================*/
         this.isSelectionOwner = false;
-        this.containsOnlyFolders = false;
-        this.containsFile = true;
         when(mockFolder1.getPermission()).thenReturn(read);
         when(mockFile1.getPermission()).thenReturn(read);
         uut.onDiskResourceSelectionChanged(mockEvent);
@@ -1798,11 +1786,11 @@ public class DiskResourceViewToolbar_onDiskResourceSelectionChangedTest {
         selection.add(mockFolder1);
         selection.add(mockFile1);
         when(mockEvent.getSelection()).thenReturn(selection);
+        when(diskResourceUtilMock.containsFolder(selection)).thenReturn(true);
+        when(diskResourceUtilMock.containsFile(selection)).thenReturn(true);
 
         /*=================== Read ====================*/
         this.isSelectionOwner = false;
-        this.containsOnlyFolders = false;
-        this.containsFile = true;
         when(mockFolder1.getPermission()).thenReturn(own);
         when(mockFile1.getPermission()).thenReturn(own);
         uut.onDiskResourceSelectionChanged(mockEvent);

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onFolderSelectedTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/views/toolbar/DiskResourceViewToolbar_onFolderSelectedTest.java
@@ -73,7 +73,6 @@ public class DiskResourceViewToolbar_onFolderSelectedTest {
             mockRefreshButton,
             mockTrashMenu;
     @Mock DiskResourceSearchField searchFieldMock;
-    private final boolean containsFile = false;
     private final boolean isReadable = true;
     private boolean isSelectionInTrash = false;
     private final boolean isSelectionOwner = true;
@@ -85,11 +84,6 @@ public class DiskResourceViewToolbar_onFolderSelectedTest {
 
     @Before public void setup() {
         uut = new DiskResourceViewToolbarImpl(searchFieldMock, mock(UserInfo.class), mockAppearance, mockPresenter){
-            @Override
-            boolean containsFile(List<DiskResource> selection) {
-                return containsFile;
-            }
-
             @Override
             boolean isOwnerList(List<DiskResource> selection) {
                 return isSelectionOwner;


### PR DESCRIPTION
The "View in Genome Browser" menu item is now enabled when multiple genome files or their index files are selected. At least 1 genome file must be selected, but if an index file isn't selected, its existence is still checked and it's still automatically shared with the anon user. The file viewer will only open if only 1 genome file is selected.

The "View in Genome Browser" dialog will now display the URLs for all selected genome files (but not their index files), and its help text and labels have been updated.