### PR TITLE
core-8926 Fix restricted char display.

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/commons/client/validators/DiskResourceNameValidator.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/validators/DiskResourceNameValidator.java
@@ -1,14 +1,12 @@
 package org.iplantc.de.commons.client.validators;
 
-import org.iplantc.de.resources.client.constants.IplantValidationConstants;
-import org.iplantc.de.resources.client.messages.IplantValidationMessages;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
 import com.google.gwt.editor.client.EditorError;
-
 import com.sencha.gxt.widget.core.client.form.error.DefaultEditorError;
 import com.sencha.gxt.widget.core.client.form.validator.AbstractValidator;
+import org.iplantc.de.resources.client.constants.IplantValidationConstants;
+import org.iplantc.de.resources.client.messages.IplantValidationMessages;
 
 import java.util.Collections;
 import java.util.List;
@@ -63,7 +61,7 @@ public class DiskResourceNameValidator extends AbstractValidator<String> impleme
         }
 
         if (restrictedFound.length() > 0) {
-            String errorMsg = validationMessages.drNameValidationMsg(new String(restrictedChars)) + " " //$NON-NLS-1$
+            String errorMsg = validationMessages.drNameValidationMsg(validationConstants.restrictedDiskResourceNameChars()) + " " //$NON-NLS-1$
                     + validationMessages.invalidChars(restrictedFound.toString());
 
             return createError(new DefaultEditorError(editor, errorMsg, value));

--- a/de-lib/src/main/resources/org/iplantc/de/resources/client/constants/IplantValidationConstants.properties
+++ b/de-lib/src/main/resources/org/iplantc/de/resources/client/constants/IplantValidationConstants.properties
@@ -1,8 +1,8 @@
-restrictedCmdLineArgChars = &<>`~\n
+restrictedCmdLineArgChars = &<>`~\\n
 restrictedCmdLineArgCharsExclNewline = &<>`~
-restrictedCmdLineChars = !\"#$'%()*+,/\\:?@[]^{}|\t&<>`~\n
+restrictedCmdLineChars = !\"#$'%()*+,/\\:?@[]^{}|\\t&<>`~\\n
 restrictedAppNameChars = :@/\\|^#;[]{}<>
-warnedDiskResourceNameChars = !\"#$%()*+,/\\:;?@[]^{}|&<>~='`\n\t 
-restrictedDiskResourceNameChars= '`\n\t
+warnedDiskResourceNameChars = !\"#$%()*+,/\\:;?@[]^{}|&<>~='`\\n\\t
+restrictedDiskResourceNameChars= '`\\n\\t
 maxToolNameLength = 100
 restrictedGroupNameChars = :_


### PR DESCRIPTION
`\n` and `\t` were not being escaped and hence they were not being displayed in the error message for restricted chars.