### PR TITLE
CORE-8980 Add Ontology Lookup Service autocomplete widget to DE Metadata Template forms

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
@@ -5,6 +5,7 @@ import org.iplantc.de.apps.widgets.client.view.editors.widgets.CheckBoxAdapter;
 import org.iplantc.de.client.models.diskResources.DiskResourceAutoBeanFactory;
 import org.iplantc.de.client.models.diskResources.MetadataTemplate;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateAttribute;
+import org.iplantc.de.client.models.diskResources.MetadataTemplateAttributeType;
 import org.iplantc.de.client.models.diskResources.TemplateAttributeSelectionItem;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
@@ -285,15 +286,15 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
             }
         });
         typeCombo.setTriggerAction(TriggerAction.ALL);
-        typeCombo.add(Arrays.asList("String",
-                                    "Timestamp",
-                                    "Boolean",
-                                    "Number",
-                                    "Integer",
-                                    "Multiline text",
-                                    "URL/URI",
-                                    "Enum"));
-        typeCombo.setValue("String");
+        typeCombo.add(Arrays.asList(MetadataTemplateAttributeType.STRING.toString(),
+                                    MetadataTemplateAttributeType.TIMESTAMP.toString(),
+                                    MetadataTemplateAttributeType.BOOLEAN.toString(),
+                                    MetadataTemplateAttributeType.NUMBER.toString(),
+                                    MetadataTemplateAttributeType.INTEGER.toString(),
+                                    MetadataTemplateAttributeType.MULTILINE.toString(),
+                                    MetadataTemplateAttributeType.URL.toString(),
+                                    MetadataTemplateAttributeType.ENUM.toString()));
+        typeCombo.setValue(MetadataTemplateAttributeType.STRING.toString());
         typeCombo.setEditable(false);
         typeCombo.setAllowBlank(false);
         return typeCombo;
@@ -317,7 +318,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
         mta.setName("Attribute" + Math.random());
         mta.setRequired(false);
         mta.setDescription("Test");
-        mta.setType("String");
+        mta.setType(MetadataTemplateAttributeType.STRING.toString());
 
         editing.cancelEditing();
         store.add(0, mta);
@@ -352,7 +353,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
                 return false;
             }
             List<TemplateAttributeSelectionItem> items = mta.getValues();
-            if (mta.getType().equals("Enum")) {
+            if (MetadataTemplateAttributeType.ENUM.toString().equalsIgnoreCase(mta.getType())) {
                 if (items == null || items.size() == 0) {
                     return false;
                 }

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/gin/OntologiesGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/ontologies/gin/OntologiesGinModule.java
@@ -10,6 +10,8 @@ import org.iplantc.de.admin.desktop.client.ontologies.views.AppCategorizeView;
 import org.iplantc.de.admin.desktop.client.ontologies.views.AppCategorizeViewImpl;
 import org.iplantc.de.admin.desktop.client.ontologies.views.OntologiesViewImpl;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
+import org.iplantc.de.client.services.OntologyLookupServiceFacade;
+import org.iplantc.de.client.services.impl.OntologyLookupServiceFacadeImpl;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
@@ -29,6 +31,7 @@ public class OntologiesGinModule extends AbstractGinModule {
                 OntologiesViewFactory.class));
         bind(OntologiesView.Presenter.class).to(OntologiesPresenterImpl.class);
         bind(OntologyServiceFacade.class).to(OntologyServiceFacadeImpl.class);
+        bind(OntologyLookupServiceFacade.class).to(OntologyLookupServiceFacadeImpl.class);
         bind(AppCategorizeView.class).to(AppCategorizeViewImpl.class);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/gin/AppsGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/gin/AppsGinModule.java
@@ -40,8 +40,10 @@ import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppCategory;
 import org.iplantc.de.client.models.ontologies.OntologyHierarchy;
 import org.iplantc.de.client.services.AppMetadataServiceFacade;
+import org.iplantc.de.client.services.OntologyLookupServiceFacade;
 import org.iplantc.de.client.services.OntologyServiceFacade;
 import org.iplantc.de.client.services.impl.AppMetadataServiceFacadeImpl;
+import org.iplantc.de.client.services.impl.OntologyLookupServiceFacadeImpl;
 import org.iplantc.de.client.services.impl.OntologyServiceFacadeImpl;
 import org.iplantc.de.commons.client.presenter.SharingPresenter;
 
@@ -71,6 +73,7 @@ public class AppsGinModule extends AbstractGinModule {
         bind(SubmitAppForPublicUseView.Presenter.class).to(SubmitAppForPublicPresenter.class);
         bind(AppMetadataServiceFacade.class).to(AppMetadataServiceFacadeImpl.class);
         bind(OntologyServiceFacade.class).to(OntologyServiceFacadeImpl.class);
+        bind(OntologyLookupServiceFacade.class).to(OntologyLookupServiceFacadeImpl.class);
 
         // Main View
         install(new GinFactoryModuleBuilder().implement(AppsView.class, AppsViewImpl.class)

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateAttributeType.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateAttributeType.java
@@ -6,6 +6,7 @@ public enum MetadataTemplateAttributeType {
     INTEGER("Integer"),
     MULTILINE("Multiline Text"),
     NUMBER("Number"),
+    OLS_ONTOLOGY_TERM("OLS Ontology Term"),
     STRING("String"),
     TIMESTAMP("Timestamp"),
     URL("URL/URI");

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateAttributeType.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateAttributeType.java
@@ -1,0 +1,23 @@
+package org.iplantc.de.client.models.diskResources;
+
+public enum MetadataTemplateAttributeType {
+    BOOLEAN("Boolean"),
+    ENUM("Enum"),
+    INTEGER("Integer"),
+    MULTILINE("Multiline Text"),
+    NUMBER("Number"),
+    STRING("String"),
+    TIMESTAMP("Timestamp"),
+    URL("URL/URI");
+
+    private String label;
+
+    MetadataTemplateAttributeType(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateAttributeType.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateAttributeType.java
@@ -1,5 +1,10 @@
 package org.iplantc.de.client.models.diskResources;
 
+/**
+ * The Attribute types the UI can display in a Metadata Template form.
+ *
+ * @author psarando
+ */
 public enum MetadataTemplateAttributeType {
     BOOLEAN("Boolean"),
     ENUM("Enum"),

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyAutoBeanFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyAutoBeanFactory.java
@@ -10,6 +10,8 @@ public interface OntologyAutoBeanFactory extends AutoBeanFactory {
 
     AutoBean<Ontology> getOntology();
 
+    AutoBean<OntologyClass> getOntologyClass();
+
     AutoBean<OntologyHierarchy> getHierarchy();
 
     AutoBean<OntologyHierarchyList> getHierarchyList();
@@ -18,4 +20,7 @@ public interface OntologyAutoBeanFactory extends AutoBeanFactory {
 
     AutoBean<OntologyVersionDetail> getVersionDetail();
 
+    AutoBean<OntologyLookupServiceResponse> getOntologyLookupServiceResponse();
+
+    AutoBean<OntologyLookupServiceDoc> getOntologyLookupServiceDoc();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyClass.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyClass.java
@@ -1,0 +1,15 @@
+package org.iplantc.de.client.models.ontologies;
+
+import org.iplantc.de.client.models.HasDescription;
+import org.iplantc.de.client.models.HasLabel;
+
+/**
+ * An AutoBean model for an Ontology Class, which has a unique IRI, a label, and a description.
+ *
+ * @author psarando
+ */
+public interface OntologyClass extends HasLabel, HasDescription {
+    String getIri();
+
+    void setIri(String iri);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyHierarchy.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyHierarchy.java
@@ -3,6 +3,11 @@ package org.iplantc.de.client.models.ontologies;
 import java.util.List;
 
 /**
+ * A hierarchy of Ontology Classes.
+ *
+ * Ontology hierarchy service responses will return the root of a hierarchy under the `hierarchy` key.
+ * The root and all classes under it will list their sub-classes under a `subclasses` key.
+ *
  * @author aramsey
  */
 public interface OntologyHierarchy extends OntologyClass {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyHierarchy.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyHierarchy.java
@@ -1,23 +1,13 @@
 package org.iplantc.de.client.models.ontologies;
 
-import org.iplantc.de.client.models.HasDescription;
-
 import java.util.List;
 
 /**
  * @author aramsey
  */
-public interface OntologyHierarchy extends HasDescription {
+public interface OntologyHierarchy extends OntologyClass {
 
     OntologyHierarchy getHierarchy();
-
-    String getIri();
-
-    void setIri(String iri);
-
-    String getLabel();
-
-    void setLabel(String label);
 
     List<OntologyHierarchy> getSubclasses();
 

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceDoc.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceDoc.java
@@ -1,0 +1,10 @@
+package org.iplantc.de.client.models.ontologies;
+
+import org.iplantc.de.client.models.HasId;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+public interface OntologyLookupServiceDoc extends OntologyClass, HasId {
+    @PropertyName("ontology_prefix")
+    String getOntologyPrefix();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceDoc.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceDoc.java
@@ -4,6 +4,11 @@ import org.iplantc.de.client.models.HasId;
 
 import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 
+/**
+ * OntologyClass model for an Ontology Lookup Service search result.
+ *
+ * @author psarando
+ */
 public interface OntologyLookupServiceDoc extends OntologyClass, HasId {
     @PropertyName("ontology_prefix")
     String getOntologyPrefix();

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceResponse.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceResponse.java
@@ -1,0 +1,14 @@
+package org.iplantc.de.client.models.ontologies;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+/**
+ * AutoBean model for Ontology Lookup Service search/autocomplete responses.
+ *
+ * @author psarando
+ */
+public interface OntologyLookupServiceResponse {
+
+    @PropertyName("response")
+    OntologyLookupServiceResults getResults();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceResults.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceResults.java
@@ -1,0 +1,22 @@
+package org.iplantc.de.client.models.ontologies;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+import java.util.List;
+
+/**
+ * AutoBean model for Ontology Lookup Service search/autocomplete results.
+ * Includes the list of search results in its `docs` key.
+ *
+ * @author psarando
+ */
+public interface OntologyLookupServiceResults {
+    @PropertyName("numFound")
+    int getTotal();
+
+    @PropertyName("start")
+    int getOffset();
+
+    @PropertyName("docs")
+    List<OntologyLookupServiceDoc> getClasses();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/OntologyLookupServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/OntologyLookupServiceFacade.java
@@ -13,5 +13,11 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
  */
 public interface OntologyLookupServiceFacade {
 
+    /**
+     * Searches for the user's term in the OLS, fetching paged results with the given load config.
+     *
+     * @param loadConfig The load config for fetching paged search results.
+     * @param callback The OLS search response callback.
+     */
     void searchOntologyLookupService(OntologyLookupServiceLoadConfig loadConfig, AsyncCallback<OntologyLookupServiceResponse> callback);
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/OntologyLookupServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/OntologyLookupServiceFacade.java
@@ -1,0 +1,17 @@
+package org.iplantc.de.client.services;
+
+import org.iplantc.de.client.models.ontologies.OntologyLookupServiceResponse;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceLoadConfig;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+/**
+ * Service Facade interface for EBI's Ontology Lookup Service:
+ * http://www.ebi.ac.uk/ols/docs/api
+ *
+ * @author psarando
+ */
+public interface OntologyLookupServiceFacade {
+
+    void searchOntologyLookupService(OntologyLookupServiceLoadConfig loadConfig, AsyncCallback<OntologyLookupServiceResponse> callback);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/OntologyLookupServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/OntologyLookupServiceFacadeImpl.java
@@ -1,0 +1,56 @@
+package org.iplantc.de.client.services.impl;
+
+import static org.iplantc.de.shared.services.BaseServiceCallWrapper.Type.GET;
+
+import org.iplantc.de.client.models.ontologies.OntologyAutoBeanFactory;
+import org.iplantc.de.client.models.ontologies.OntologyLookupServiceResponse;
+import org.iplantc.de.client.services.OntologyLookupServiceFacade;
+import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceLoadConfig;
+import org.iplantc.de.shared.services.DiscEnvApiService;
+import org.iplantc.de.shared.services.ServiceCallWrapper;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.gwt.http.client.URL;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.inject.Inject;
+import com.google.web.bindery.autobean.shared.AutoBeanCodex;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OntologyLookupServiceFacadeImpl implements OntologyLookupServiceFacade {
+    private final String OLS_BASE_URL = "org.iplantc.services.ontology-lookup-service.base";
+
+    @Inject OntologyAutoBeanFactory factory;
+    @Inject private DiscEnvApiService deService;
+
+    @Override
+    public void searchOntologyLookupService(OntologyLookupServiceLoadConfig loadConfig, AsyncCallback<OntologyLookupServiceResponse> callback) {
+        List<String> queryParams = Lists.newArrayList("rows=" + loadConfig.getLimit(),
+                                                      "start=" + loadConfig.getOffset());
+
+        if (loadConfig.getFilters() != null) {
+            queryParams.addAll(loadConfig.getFilters()
+                                         .stream()
+                                         .filter(config -> !Strings.isNullOrEmpty(config.getValue()))
+                                         .map(config -> (config.getField() + "="
+                                                         + URL.encodeQueryString(config.getValue())))
+                                         .collect(Collectors.toList()));
+        }
+
+        String queryString = Joiner.on('&').join(queryParams);
+
+        String address = OLS_BASE_URL + "?" + queryString;
+
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
+        deService.getServiceData(wrapper, new AsyncCallbackConverter<String, OntologyLookupServiceResponse>(callback) {
+            @Override
+            protected OntologyLookupServiceResponse convertFrom(String response) {
+                return AutoBeanCodex.decode(factory, OntologyLookupServiceResponse.class, response).as();
+            }
+        });
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/OntologyLookupServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/OntologyLookupServiceFacadeImpl.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class OntologyLookupServiceFacadeImpl implements OntologyLookupServiceFacade {
-    private final String OLS_BASE_URL = "org.iplantc.services.ontology-lookup-service.base";
+    private static final String OLS_BASE_URL = "org.iplantc.services.ontology-lookup-service.base";
 
     @Inject OntologyAutoBeanFactory factory;
     @Inject private DiscEnvApiService deService;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/MetadataView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/MetadataView.java
@@ -5,6 +5,7 @@ import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateAttribute;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
 import org.iplantc.de.diskResource.client.presenters.callbacks.DiskResourceMetadataUpdateCallback;
+import org.iplantc.de.diskResource.client.views.search.MetadataTermSearchField;
 
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -136,6 +137,8 @@ public interface MetadataView extends IsWidget {
         Avu setAvuModelKey(Avu avu);
 
         DiskResource getSelectedResource();
+
+        MetadataTermSearchField createMetadataTermSearchField();
 
         void onTemplateSelected(String templateId);
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
@@ -350,7 +350,7 @@ public class MetadataPresenterImpl implements MetadataView.Presenter {
                             templateViewDialog));
                     templateViewDialog.setHeading(result.getName());
                     templateViewDialog.setModal(false);
-                    templateViewDialog.setSize("600px", "400px");
+                    templateViewDialog.setSize("640px", "480px");
                     templateViewDialog.addMdTermDictionary(templateAttributes);
                     templateViewDialog.show(MetadataPresenterImpl.this,
                                             view.getUserMetadata(),

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
@@ -8,6 +8,7 @@ import org.iplantc.de.client.models.diskResources.DiskResourceMetadataList;
 import org.iplantc.de.client.models.diskResources.MetadataTemplate;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateAttribute;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
+import org.iplantc.de.client.models.ontologies.OntologyAutoBeanFactory;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
 import org.iplantc.de.commons.client.ErrorHandler;
@@ -15,8 +16,10 @@ import org.iplantc.de.commons.client.util.WindowUtil;
 import org.iplantc.de.diskResource.client.MetadataView;
 import org.iplantc.de.diskResource.client.events.selection.SaveMetadataSelected;
 import org.iplantc.de.diskResource.client.presenters.callbacks.DiskResourceMetadataUpdateCallback;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceProxy;
 import org.iplantc.de.diskResource.client.views.metadata.dialogs.MetadataTemplateViewDialog;
 import org.iplantc.de.diskResource.client.views.metadata.dialogs.SelectMetadataTemplateDialog;
+import org.iplantc.de.diskResource.client.views.search.MetadataTermSearchField;
 import org.iplantc.de.resources.client.messages.I18N;
 import org.iplantc.de.shared.AsyncProviderWrapper;
 
@@ -101,6 +104,9 @@ public class MetadataPresenterImpl implements MetadataView.Presenter {
     private DiskResource resource;
     private final MetadataView view;
     private final DiskResourceServiceFacade drService;
+    private final OntologyAutoBeanFactory ontologyFactory;
+    private final OntologyLookupServiceProxy searchProxy;
+    private final MetadataTermSearchField.MetadataTermSearchFieldAppearance searchFieldAppearance;
     private List<MetadataTemplateInfo> templates;
 
     private List<Avu> userMdList;
@@ -117,10 +123,16 @@ public class MetadataPresenterImpl implements MetadataView.Presenter {
 
     @Inject
     public MetadataPresenterImpl(final MetadataView view,
-                                 final DiskResourceServiceFacade drService) {
+                                 final DiskResourceServiceFacade drService,
+                                 OntologyAutoBeanFactory ontologyFactory,
+                                 OntologyLookupServiceProxy searchProxy,
+                                 MetadataTermSearchField.MetadataTermSearchFieldAppearance searchFieldAppearance) {
 
         this.view = view;
         this.drService = drService;
+        this.ontologyFactory = ontologyFactory;
+        this.searchProxy = searchProxy;
+        this.searchFieldAppearance = searchFieldAppearance;
         view.setPresenter(this);
     }
 
@@ -202,6 +214,11 @@ public class MetadataPresenterImpl implements MetadataView.Presenter {
     @Override
     public DiskResource getSelectedResource() {
         return resource;
+    }
+
+    @Override
+    public MetadataTermSearchField createMetadataTermSearchField() {
+        return new MetadataTermSearchField(ontologyFactory, searchProxy, searchFieldAppearance);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImpl.java
@@ -124,9 +124,9 @@ public class MetadataPresenterImpl implements MetadataView.Presenter {
     @Inject
     public MetadataPresenterImpl(final MetadataView view,
                                  final DiskResourceServiceFacade drService,
-                                 OntologyAutoBeanFactory ontologyFactory,
-                                 OntologyLookupServiceProxy searchProxy,
-                                 MetadataTermSearchField.MetadataTermSearchFieldAppearance searchFieldAppearance) {
+                                 final OntologyAutoBeanFactory ontologyFactory,
+                                 final OntologyLookupServiceProxy searchProxy,
+                                 final MetadataTermSearchField.MetadataTermSearchFieldAppearance searchFieldAppearance) {
 
         this.view = view;
         this.drService = drService;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceLoadConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceLoadConfig.java
@@ -1,0 +1,137 @@
+package org.iplantc.de.diskResource.client.presenters.metadata.proxy;
+
+import com.sencha.gxt.core.shared.FastMap;
+import com.sencha.gxt.data.shared.loader.FilterConfig;
+import com.sencha.gxt.data.shared.loader.FilterConfigBean;
+import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfigBean;
+
+/**
+ * Search config for the Ontology Lookup Service `select` endpoint:
+ * http://www.ebi.ac.uk/ols/docs/api#_select_terms
+ *
+ * @author psarando
+ */
+public class OntologyLookupServiceLoadConfig extends FilterPagingLoadConfigBean {
+    private static String FILTER_FIELD_QUERY = "q";
+    private static String FILTER_FIELD_ONTOLOGY = "ontology";
+    private static String FILTER_FIELD_ENTITY_TYPE = "type";
+    private static String FILTER_FIELD_CHILDREN = "childrenOf";
+    private static String FILTER_FIELD_ALL_CHILDREN = "allChildrenOf";
+    private static String FILTER_FIELD_RESPONSE_FIELDS = "fieldList";
+
+    /**
+     * OLS searches may be restricted to one of these entity types.
+     */
+    public enum EntityTypeFilterValue {
+        CLASS,
+        PROPERTY,
+        INDIVIDUAL,
+        ONTOLOGY
+    }
+
+    private FastMap<FilterConfig> filterConfigMap = new FastMap<>();
+
+    public OntologyLookupServiceLoadConfig() {
+        filterConfigMap.put(FILTER_FIELD_QUERY,           new FilterConfigBean());
+        filterConfigMap.put(FILTER_FIELD_ONTOLOGY,        new FilterConfigBean());
+        filterConfigMap.put(FILTER_FIELD_ENTITY_TYPE,     new FilterConfigBean());
+        filterConfigMap.put(FILTER_FIELD_CHILDREN,        new FilterConfigBean());
+        filterConfigMap.put(FILTER_FIELD_ALL_CHILDREN,    new FilterConfigBean());
+        filterConfigMap.put(FILTER_FIELD_RESPONSE_FIELDS, new FilterConfigBean());
+
+        filterConfigMap.forEach((key, filterConfig) -> filterConfig.setField(key));
+
+        filterConfigMap.get(FILTER_FIELD_ENTITY_TYPE).setValue(EntityTypeFilterValue.CLASS.toString().toLowerCase());
+        filterConfigMap.get(FILTER_FIELD_RESPONSE_FIELDS).setValue("id,iri,label,ontology_prefix");
+
+        getFilters().addAll(filterConfigMap.values());
+    }
+
+    /**
+     * @return The user's search term.
+     */
+    public String getQuery() {
+        return filterConfigMap.get(FILTER_FIELD_QUERY).getValue();
+    }
+
+    /**
+     * @param query The user's search term.
+     */
+    public void setQuery(String query) {
+        filterConfigMap.get(FILTER_FIELD_QUERY).setValue(query);
+    }
+
+    /**
+     *
+     * @return A comma-separated list of ontologies e.g. "edam" or "uberon,ma"
+     */
+    public String getOntologyListFilter() {
+        return filterConfigMap.get(FILTER_FIELD_ONTOLOGY).getValue();
+    }
+
+    /**
+     * Restrict a search to a set of ontologies.
+     * http://www.ebi.ac.uk/ols/ontologies
+     *
+     * @param ontologies A comma-separated list of ontologies (e.g. "edam" or "uberon,ma") or null to clear the filter.
+     */
+    public void setOntologyListFilter(String ontologies) {
+        filterConfigMap.get(FILTER_FIELD_ONTOLOGY).setValue(ontologies);
+    }
+
+    /**
+     * @return The `type` filter value, or null for no filter.
+     */
+    public EntityTypeFilterValue getEntityTypeFilter() {
+        String value = filterConfigMap.get(FILTER_FIELD_ENTITY_TYPE).getValue();
+
+        return (value == null ? null : EntityTypeFilterValue.valueOf(value.toUpperCase()));
+    }
+
+    /**
+     * Restrict a search to an entity type.
+     *
+     * @param entityTypeFilter null to clear the filter.
+     */
+    public void setEntityTypeFilter(EntityTypeFilterValue entityTypeFilter) {
+        String value = (entityTypeFilter == null ? null : entityTypeFilter.toString().toLowerCase());
+
+        filterConfigMap.get(FILTER_FIELD_ENTITY_TYPE).setValue(value);
+    }
+
+    /**
+     * @return The `childrenOf` filter value, or null for no filter.
+     */
+    public String getChildrenFilter() {
+        return filterConfigMap.get(FILTER_FIELD_CHILDREN).getValue();
+    }
+
+    /**
+     * You can restrict a search to all children of a given term.
+     * Supply a list of IRI for the terms that you want to search under
+     * (subclassOf/is-a relation only).
+     *
+     * @param iriList A comma-separated list of IRIs, or null to clear the filter.
+     */
+    public void setChildrenFilter(String iriList) {
+        filterConfigMap.get(FILTER_FIELD_CHILDREN).setValue(iriList);
+    }
+
+    /**
+     * @return The `allChildrenOf` filter value, or null for no filter.
+     */
+    public String getAllChildrenFilter() {
+        return filterConfigMap.get(FILTER_FIELD_ALL_CHILDREN).getValue();
+    }
+
+    /**
+     * You can restrict a search to all children of a given term.
+     * Supply a list of IRI for the terms that you want to search under
+     * (subclassOf/is-a plus any hierarchical/transitive properties like 'part of' or 'develops from').
+     *
+     * @param iriList A comma-separated list of IRIs, or null to clear the filter.
+     */
+    public void setAllChildrenFilter(String iriList) {
+        filterConfigMap.get(FILTER_FIELD_ALL_CHILDREN).setValue(iriList);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceLoadConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceLoadConfig.java
@@ -12,12 +12,12 @@ import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfigBean;
  * @author psarando
  */
 public class OntologyLookupServiceLoadConfig extends FilterPagingLoadConfigBean {
-    private static String FILTER_FIELD_QUERY = "q";
-    private static String FILTER_FIELD_ONTOLOGY = "ontology";
-    private static String FILTER_FIELD_ENTITY_TYPE = "type";
-    private static String FILTER_FIELD_CHILDREN = "childrenOf";
-    private static String FILTER_FIELD_ALL_CHILDREN = "allChildrenOf";
-    private static String FILTER_FIELD_RESPONSE_FIELDS = "fieldList";
+    private static final String FILTER_FIELD_QUERY = "q";
+    private static final String FILTER_FIELD_ONTOLOGY = "ontology";
+    private static final String FILTER_FIELD_ENTITY_TYPE = "type";
+    private static final String FILTER_FIELD_CHILDREN = "childrenOf";
+    private static final String FILTER_FIELD_ALL_CHILDREN = "allChildrenOf";
+    private static final String FILTER_FIELD_RESPONSE_FIELDS = "fieldList";
 
     /**
      * OLS searches may be restricted to one of these entity types.

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceProxy.java
@@ -1,0 +1,54 @@
+package org.iplantc.de.diskResource.client.presenters.metadata.proxy;
+
+import org.iplantc.de.client.models.ontologies.OntologyLookupServiceDoc;
+import org.iplantc.de.client.models.ontologies.OntologyLookupServiceResponse;
+import org.iplantc.de.client.models.ontologies.OntologyLookupServiceResults;
+import org.iplantc.de.client.services.OntologyLookupServiceFacade;
+
+import com.google.common.base.Strings;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.inject.Inject;
+
+import com.sencha.gxt.data.client.loader.RpcProxy;
+import com.sencha.gxt.data.shared.loader.PagingLoadResult;
+import com.sencha.gxt.data.shared.loader.PagingLoadResultBean;
+
+/**
+ * Ontology Lookup Service RPC proxy that calls the OLS with a given LoadConfig and LoadResult callback.
+ *
+ * @author psarando
+ */
+public class OntologyLookupServiceProxy extends RpcProxy<OntologyLookupServiceLoadConfig, PagingLoadResult<OntologyLookupServiceDoc>> {
+
+    OntologyLookupServiceFacade svcFacade;
+
+    @Inject
+    public OntologyLookupServiceProxy(OntologyLookupServiceFacade svcFacade) {
+        this.svcFacade = svcFacade;
+    }
+
+    @Override
+    public void load(OntologyLookupServiceLoadConfig loadConfig, AsyncCallback<PagingLoadResult<OntologyLookupServiceDoc>> callback) {
+        String queryText = loadConfig.getQuery();
+
+        if (Strings.isNullOrEmpty(queryText)) {
+            // nothing to search
+            return;
+        }
+
+        svcFacade.searchOntologyLookupService(loadConfig, new AsyncCallback<OntologyLookupServiceResponse>() {
+            @Override
+            public void onSuccess(OntologyLookupServiceResponse response) {
+                OntologyLookupServiceResults results = response.getResults();
+                callback.onSuccess(new PagingLoadResultBean<>(results.getClasses(),
+                                                              results.getTotal(),
+                                                              results.getOffset()));
+            }
+
+            @Override
+            public void onFailure(Throwable caught) {
+                callback.onFailure(caught);
+            }
+        });
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceProxy.java
@@ -33,6 +33,8 @@ public class OntologyLookupServiceProxy extends RpcProxy<OntologyLookupServiceLo
 
         if (Strings.isNullOrEmpty(queryText)) {
             // nothing to search
+            callback.onSuccess(new PagingLoadResultBean<>());
+
             return;
         }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/MetadataTemplateView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/MetadataTemplateView.java
@@ -371,7 +371,7 @@ public class MetadataTemplateView implements IsWidget {
         HorizontalPanel panel = new HorizontalPanel();
         panel.add(field);
         panel.setSpacing(10);
-        field.setWidth("480px");
+        field.setWidth("540px");
         TextButton addBtn = new TextButton("+");
         addBtn.addSelectHandler(new SelectEvent.SelectHandler() {
             @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/MetadataTemplateView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/MetadataTemplateView.java
@@ -2,6 +2,7 @@ package org.iplantc.de.diskResource.client.views.metadata;
 
 import org.iplantc.de.client.models.avu.Avu;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateAttribute;
+import org.iplantc.de.client.models.diskResources.MetadataTemplateAttributeType;
 import org.iplantc.de.client.models.diskResources.TemplateAttributeSelectionItem;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.validators.UrlValidator;
@@ -424,21 +425,21 @@ public class MetadataTemplateView implements IsWidget {
     private Field<?> getAttributeValueWidget(String tag) {
         MetadataTemplateAttribute attribute = templateTagAttrMap.get(tag);
         String type = attribute.getType();
-        if (type.equalsIgnoreCase("timestamp")) { //$NON-NLS-1$
+        if (MetadataTemplateAttributeType.TIMESTAMP.toString().equalsIgnoreCase(type)) {
             return buildDateField(tag, attribute);
-        } else if (type.equalsIgnoreCase("boolean")) { //$NON-NLS-1$
+        } else if (MetadataTemplateAttributeType.BOOLEAN.toString().equalsIgnoreCase(type)) {
             return buildBooleanField(tag, attribute);
-        } else if (type.equalsIgnoreCase("number")) { //$NON-NLS-1$
+        } else if (MetadataTemplateAttributeType.NUMBER.toString().equalsIgnoreCase(type)) {
             return buildNumberField(tag, attribute);
-        } else if (type.equalsIgnoreCase("integer")) { //$NON-NLS-1$
+        } else if (MetadataTemplateAttributeType.INTEGER.toString().equalsIgnoreCase(type)) {
             return buildIntegerField(tag, attribute);
-        } else if (type.equalsIgnoreCase("string")) { //$NON-NLS-1$
+        } else if (MetadataTemplateAttributeType.STRING.toString().equalsIgnoreCase(type)) {
             return buildTextField(tag, attribute);
-        } else if (type.equalsIgnoreCase("multiline text")) { //$NON-NLS-1$
+        } else if (MetadataTemplateAttributeType.MULTILINE.toString().equalsIgnoreCase(type)) {
             return buildTextArea(tag, attribute);
-        } else if (type.equalsIgnoreCase("URL/URI")) { //$NON-NLS-1$
+        } else if (MetadataTemplateAttributeType.URL.toString().equalsIgnoreCase(type)) {
             return buildURLField(tag, attribute);
-        } else if (type.equalsIgnoreCase("Enum")) {
+        } else if (MetadataTemplateAttributeType.ENUM.toString().equalsIgnoreCase(type)) {
             return buildListField(tag, attribute);
         } else {
             return null;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/search/MetadataTermSearchField.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/search/MetadataTermSearchField.java
@@ -1,0 +1,156 @@
+package org.iplantc.de.diskResource.client.views.search;
+
+import org.iplantc.de.client.models.ontologies.OntologyAutoBeanFactory;
+import org.iplantc.de.client.models.ontologies.OntologyLookupServiceDoc;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceLoadConfig;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceProxy;
+
+import com.google.common.base.Strings;
+import com.google.gwt.cell.client.AbstractCell;
+import com.google.gwt.cell.client.Cell.Context;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+
+import com.sencha.gxt.cell.core.client.form.ComboBoxCell;
+import com.sencha.gxt.core.client.IdentityValueProvider;
+import com.sencha.gxt.data.shared.Converter;
+import com.sencha.gxt.data.shared.ListStore;
+import com.sencha.gxt.data.shared.SortDir;
+import com.sencha.gxt.data.shared.Store;
+import com.sencha.gxt.data.shared.loader.LoadResultListStoreBinding;
+import com.sencha.gxt.data.shared.loader.PagingLoadResult;
+import com.sencha.gxt.data.shared.loader.PagingLoader;
+import com.sencha.gxt.widget.core.client.ListView;
+import com.sencha.gxt.widget.core.client.form.ComboBox;
+import com.sencha.gxt.widget.core.client.form.IsField;
+import com.sencha.gxt.widget.core.client.form.PropertyEditor;
+import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
+import com.sencha.gxt.widget.core.client.grid.editing.GridRowEditing;
+
+import java.text.ParseException;
+import java.util.Comparator;
+
+/**
+ * A wrapper class for creating a {@link ComboBox} form field that allows the user to enter any text into the field,
+ * by creating a new {@link OntologyLookupServiceDoc} as the field's value which has the user's text as a custom label and no IRI,
+ * but it can also autocomplete text with terms found using the Ontology Lookup Service.
+ *
+ * This class can also be used as a {@link Converter} for the {@link ComboBox} in a
+ * {@link GridRowEditing#addEditor(ColumnConfig, Converter, IsField)} call.
+ */
+public class MetadataTermSearchField implements Converter<String, OntologyLookupServiceDoc> {
+
+    public interface MetadataTermSearchFieldAppearance {
+        void render(Context context, OntologyLookupServiceDoc OntologyLookupServiceDoc, SafeHtmlBuilder sb);
+    }
+
+    /**
+     * A {@link ComboBoxCell} that allows the user to enter any text into a {@link ComboBox} field,
+     * by creating a new {@link OntologyLookupServiceDoc} as the field's value,
+     * which has the user's text as a custom label and no IRI.
+     */
+    private class FreeTextComboBoxCell extends ComboBoxCell<OntologyLookupServiceDoc> {
+        FreeTextComboBoxCell(ListStore<OntologyLookupServiceDoc> store, ListView<OntologyLookupServiceDoc, OntologyLookupServiceDoc> view) {
+            super(store, OntologyLookupServiceDoc::getLabel, view);
+
+            setPropertyEditor(new PropertyEditor<OntologyLookupServiceDoc>() {
+                @Override
+                public OntologyLookupServiceDoc parse(CharSequence text) throws ParseException {
+                    String label = text == null ? "" : text.toString();
+
+                    OntologyLookupServiceDoc selectedClass = getByValue(label);
+
+                    if (selectedClass == null) {
+                        selectedClass = convertModelValue(label);
+                    }
+
+                    return selectedClass;
+                }
+
+                @Override
+                public String render(OntologyLookupServiceDoc object) {
+                    return object.getLabel();
+                }
+            });
+        }
+    }
+
+    private final OntologyAutoBeanFactory factory;
+
+    private ComboBox<OntologyLookupServiceDoc> combo;
+    private ListView<OntologyLookupServiceDoc, OntologyLookupServiceDoc> view;
+
+    public MetadataTermSearchField(OntologyAutoBeanFactory factory,
+                                   OntologyLookupServiceProxy searchProxy,
+                                   MetadataTermSearchFieldAppearance appearance) {
+        this.factory = factory;
+
+        ListStore<OntologyLookupServiceDoc> store = new ListStore<>(OntologyLookupServiceDoc::getId);
+        store.addSortInfo(new Store.StoreSortInfo<>(Comparator.comparing(OntologyLookupServiceDoc::getLabel), SortDir.ASC));
+
+        createView(store, appearance);
+
+        createCombo(store, createLoader(searchProxy, store));
+    }
+
+    private void createView(ListStore<OntologyLookupServiceDoc> store, MetadataTermSearchFieldAppearance appearance) {
+        view = new ListView<>(store, new IdentityValueProvider<>());
+        view.setCell(new AbstractCell<OntologyLookupServiceDoc>() {
+            @Override
+            public void render(Context context, OntologyLookupServiceDoc value, SafeHtmlBuilder sb) {
+                appearance.render(context, value, sb);
+            }
+        });
+    }
+
+    private PagingLoader<OntologyLookupServiceLoadConfig, PagingLoadResult<OntologyLookupServiceDoc>> createLoader(
+            OntologyLookupServiceProxy searchProxy,
+            ListStore<OntologyLookupServiceDoc> store) {
+        PagingLoader<OntologyLookupServiceLoadConfig, PagingLoadResult<OntologyLookupServiceDoc>> loader =
+                new PagingLoader<>(searchProxy);
+
+        loader.useLoadConfig(new OntologyLookupServiceLoadConfig());
+        loader.addLoadHandler(new LoadResultListStoreBinding<>(store));
+
+        loader.addBeforeLoadHandler(event -> {
+            String query = combo.getText();
+
+            if (!Strings.isNullOrEmpty(query)) {
+                event.getLoadConfig().setQuery(query);
+            }
+        });
+
+        return loader;
+    }
+
+    private void createCombo(ListStore<OntologyLookupServiceDoc> store,
+                             PagingLoader<OntologyLookupServiceLoadConfig, PagingLoadResult<OntologyLookupServiceDoc>> loader) {
+        combo = new ComboBox<>(new FreeTextComboBoxCell(store, view));
+        combo.setLoader(loader);
+        combo.setMinChars(3);
+        combo.setWidth(250);
+        combo.setHideTrigger(true);
+        combo.setForceSelection(false);
+        combo.getCell().setPageSize(loader.getLastLoadConfig().getLimit());
+    }
+
+    @Override
+    public String convertFieldValue(OntologyLookupServiceDoc object) {
+        return object == null ? null : object.getLabel();
+    }
+
+    @Override
+    public OntologyLookupServiceDoc convertModelValue(String label) {
+        OntologyLookupServiceDoc customLabel = factory.getOntologyLookupServiceDoc().as();
+        customLabel.setLabel(label);
+
+        return customLabel;
+    }
+
+    public ComboBox<OntologyLookupServiceDoc> asField() {
+        return combo;
+    }
+
+    public void setViewDebugId(String debugId) {
+        view.ensureDebugId(debugId);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/DiskResource.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/DiskResource.gwt.xml
@@ -32,6 +32,10 @@
         <when-type-is class="org.iplantc.de.diskResource.client.MetadataView.Presenter.Appearance" />
     </replace-with>
 
+    <replace-with class="org.iplantc.de.theme.base.client.diskResource.search.MetadataTermSearchFieldDefaultAppearance">
+        <when-type-is class="org.iplantc.de.diskResource.client.views.search.MetadataTermSearchField.MetadataTermSearchFieldAppearance" />
+    </replace-with>
+
     <!-- Dialogs -->
     <replace-with class="org.iplantc.de.theme.base.client.diskResource.dialogs.FolderSelectDialogDefaultAppearance">
         <when-type-is class="org.iplantc.de.diskResource.client.views.dialogs.FolderSelectDialog.FolderSelectDialogAppearance"/>

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/search/MetadataTermSearchFieldDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/search/MetadataTermSearchFieldDefaultAppearance.java
@@ -1,0 +1,34 @@
+package org.iplantc.de.theme.base.client.diskResource.search;
+
+import org.iplantc.de.client.models.ontologies.OntologyLookupServiceDoc;
+import org.iplantc.de.diskResource.client.views.search.MetadataTermSearchField;
+
+import com.google.gwt.cell.client.Cell.Context;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+
+import com.sencha.gxt.core.client.XTemplates;
+
+public class MetadataTermSearchFieldDefaultAppearance implements MetadataTermSearchField.MetadataTermSearchFieldAppearance {
+
+    private final OntologySearchResultTemplate template;
+
+    interface OntologySearchResultTemplate extends XTemplates {
+        @XTemplate(source = "OntologySearchResult.html")
+        SafeHtml render(String iri, String label, String ontology);
+    }
+
+    public MetadataTermSearchFieldDefaultAppearance() {
+        this(GWT.create(OntologySearchResultTemplate.class));
+    }
+
+    public MetadataTermSearchFieldDefaultAppearance(OntologySearchResultTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public void render(Context context, OntologyLookupServiceDoc ontologyClass, SafeHtmlBuilder sb) {
+        sb.append(template.render(ontologyClass.getIri(), ontologyClass.getLabel(), ontologyClass.getOntologyPrefix()));
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/search/OntologySearchResult.html
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/search/OntologySearchResult.html
@@ -1,0 +1,10 @@
+<div style="border: 1px solid #EFEFEF;">
+    <span style="font-weight: bold">{label}</span>
+    <br/>
+    <tpl if="ontology != null">
+        <span style="font-style: italic">{ontology}:&nbsp;</span>
+    </tpl>
+    <tpl if="iri != null">
+        <span style="font-style: italic;">{iri}</span>
+    </tpl>
+</div>

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImplTest.java
@@ -4,12 +4,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.iplantc.de.client.models.avu.Avu;
-import org.iplantc.de.client.models.diskResources.DiskResource;
-import org.iplantc.de.client.models.diskResources.DiskResourceAutoBeanFactory;
-import org.iplantc.de.client.models.diskResources.MetadataTemplateInfo;
+import org.iplantc.de.client.models.ontologies.OntologyAutoBeanFactory;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.diskResource.client.MetadataView;
-import org.iplantc.de.diskResource.client.views.metadata.dialogs.MetadataTemplateViewDialog;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceProxy;
+import org.iplantc.de.diskResource.client.views.search.MetadataTermSearchField;
 
 import com.google.gwtmockito.GxtMockitoTestRunner;
 
@@ -28,19 +27,17 @@ import java.util.List;
 @RunWith(GxtMockitoTestRunner.class)
 public class MetadataPresenterImplTest {
 
-    @Mock  DiskResource resource;
     @Mock  MetadataView view;
     @Mock  DiskResourceServiceFacade drService;
-    @Mock  List<MetadataTemplateInfo> templates;
-    @Mock  MetadataTemplateViewDialog templateView;
     @Mock  List<Avu> userMdList;
-    @Mock  DiskResourceAutoBeanFactory autoBeanFactory;
-    @Mock MetadataView.Presenter.Appearance appearance;
+    @Mock OntologyAutoBeanFactory autoBeanFactory;
+    @Mock OntologyLookupServiceProxy olsProxy;
+    @Mock MetadataTermSearchField.MetadataTermSearchFieldAppearance appearance;
 
     private MetadataPresenterImpl presenter;
     @Before
     public void setUp() {
-       presenter = new MetadataPresenterImpl(view,drService);
+        presenter = new MetadataPresenterImpl(view, drService, autoBeanFactory, olsProxy, appearance);
     }
 
     @Test

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceProxyTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceProxyTest.java
@@ -1,0 +1,52 @@
+package org.iplantc.de.diskResource.client.presenters.metadata.proxy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.client.models.ontologies.OntologyLookupServiceDoc;
+import org.iplantc.de.client.services.OntologyLookupServiceFacade;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import com.sencha.gxt.data.shared.loader.PagingLoadResult;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class OntologyLookupServiceProxyTest {
+    @Mock OntologyLookupServiceFacade svcFacadeMock;
+    @Mock OntologyLookupServiceLoadConfig loadConfigMock;
+    @Mock AsyncCallback<PagingLoadResult<OntologyLookupServiceDoc>> callbackMock;
+
+    OntologyLookupServiceProxy proxyUnderTest;
+
+    @Before
+    public void setUp() {
+        proxyUnderTest = new OntologyLookupServiceProxy(svcFacadeMock);
+    }
+
+    @Test
+    public void loadQuery() {
+        when(loadConfigMock.getQuery()).thenReturn("search");
+
+        // Call method under test
+        proxyUnderTest.load(loadConfigMock, callbackMock);
+
+        verify(svcFacadeMock).searchOntologyLookupService(eq(loadConfigMock), any());
+    }
+
+    @Test
+    public void loadNoQuery() {
+        // Call method under test
+        proxyUnderTest.load(loadConfigMock, callbackMock);
+
+        verifyZeroInteractions(svcFacadeMock);
+    }
+}

--- a/de.properties.tmpl
+++ b/de.properties.tmpl
@@ -141,6 +141,11 @@ org.iplantc.services.admin.ontologies = {{ key (printf "%s/terrain/base" $base) 
 org.iplantc.services.ontologies = {{ key (printf "%s/terrain/base" $base) }}/ontologies
 
 ###############################################################################
+# 3rd Party Service URL/Endpoint Settings
+###############################################################################
+org.iplantc.services.ontology-lookup-service.base = http://www.ebi.ac.uk/ols/api/select
+
+###############################################################################
 # Default workspace App Categories.
 ###############################################################################
 org.iplantc.discoveryenvironment.workspace.rootAppCategory = {{ key (printf "%s/de/root-app-category" $base) }}


### PR DESCRIPTION
This PR will add a `MetadataTermSearchField` widget that can create a ComboBox for use as a Metadata Template attribute type.

The ComboBox can lookup terms using the Ontology Lookup Service ["select" endpoint](http://www.ebi.ac.uk/ols/docs/api#_select_terms) to populate its drop-down list. This ComboBox will allow the user to either select one of the suggested terms, or enter any other text they wish as the metadata attribute's value.

The `MetadataTermSearchField` can also be used as a `Converter` for the ComboBox widget in a GridRowEditing column, such as in the AVU editing grid.

![OLS ComboBox screen shot](https://user-images.githubusercontent.com/996408/29390978-c658a252-82a8-11e7-88f2-fd95ce017817.png)

The OLS searches are restricted to only `class` entity types by default. The search results are presented in the ComboBox drop-down with the ontology class `label` listed first in bold, and underneath the `label` the `ontology_prefix` and `IRI` are displayed in italics.