### PR TITLE
CORE-8992 Enable teams in the UI

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/CollaborationView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/CollaborationView.java
@@ -1,11 +1,14 @@
 package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.IsMaskable;
+import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.commons.client.views.window.configs.CollaborationWindowConfig;
 import org.iplantc.de.commons.client.widgets.DETabPanel;
 
 import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.gwt.user.client.ui.IsWidget;
+
+import java.util.List;
 
 /**
  * The primary view within the Collaboration window.  It is a composite of all other views within
@@ -32,7 +35,15 @@ public interface CollaborationView extends IsWidget,
     interface Presenter {
 
         /**
-         * Initialize the sub-view presenters and add the overall view to the container
+         * Initialize the sub-view presenters and add the overall view to the container,
+         * most likely for a dialog
+         * @param container
+         */
+        void go(HasOneWidget container);
+
+        /**
+         * Initialize the sub-view presenters and add the overall view to the container,
+         * most likely for the Collaboration window
          * @param container
          * @param windowConfig
          */
@@ -43,6 +54,12 @@ public interface CollaborationView extends IsWidget,
          * @param baseId
          */
         void setViewDebugId(String baseId);
+
+        /**
+         * Return all users and teams selected in the Collaboration View
+         * @return
+         */
+        List<Subject> getSelectedCollaborators();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/CollaborationView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/CollaborationView.java
@@ -17,6 +17,11 @@ import java.util.List;
 public interface CollaborationView extends IsWidget,
                                            IsMaskable {
 
+    enum TAB {
+        Collaborators,
+        Teams
+    }
+
     /**
      * An appearance class that handles only the strings necessary for the CollaborationView.
      * Any sub-views have their own appearance classes.
@@ -36,7 +41,7 @@ public interface CollaborationView extends IsWidget,
 
         /**
          * Initialize the sub-view presenters and add the overall view to the container,
-         * most likely for a dialog
+         * most likely for a dialog, specifically the ChooseCollaboratorsDialog
          * @param container
          */
         void go(HasOneWidget container);
@@ -67,5 +72,11 @@ public interface CollaborationView extends IsWidget,
      * @return
      */
     DETabPanel getCollaborationTabPanel();
+
+    /**
+     * Set which tab in the view should be active/selected
+     * @param selectedTab
+     */
+    void setActiveTab(TAB selectedTab);
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/CollaborationView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/CollaborationView.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.collaborators.client;
 
 import org.iplantc.de.client.models.IsMaskable;
+import org.iplantc.de.commons.client.views.window.configs.CollaborationWindowConfig;
 import org.iplantc.de.commons.client.widgets.DETabPanel;
 
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -33,8 +34,9 @@ public interface CollaborationView extends IsWidget,
         /**
          * Initialize the sub-view presenters and add the overall view to the container
          * @param container
+         * @param windowConfig
          */
-        void go(HasOneWidget container);
+        void go(HasOneWidget container, CollaborationWindowConfig windowConfig);
 
         /**
          * Set the debug id for the view

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/CollaborationView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/CollaborationView.java
@@ -1,0 +1,52 @@
+package org.iplantc.de.collaborators.client;
+
+import org.iplantc.de.client.models.IsMaskable;
+import org.iplantc.de.commons.client.widgets.DETabPanel;
+
+import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.gwt.user.client.ui.IsWidget;
+
+/**
+ * The primary view within the Collaboration window.  It is a composite of all other views within
+ * the Collaboration window.
+ */
+public interface CollaborationView extends IsWidget,
+                                           IsMaskable {
+
+    /**
+     * An appearance class that handles only the strings necessary for the CollaborationView.
+     * Any sub-views have their own appearance classes.
+     */
+    interface CollaborationViewAppearance {
+
+        String getCollaboratorsTabText();
+
+        String getTeamsTabText();
+    }
+
+    /**
+     * This presenter is responsible for starting up the presenters from the sub-components
+     * within the Collaboration window
+     */
+    interface Presenter {
+
+        /**
+         * Initialize the sub-view presenters and add the overall view to the container
+         * @param container
+         */
+        void go(HasOneWidget container);
+
+        /**
+         * Set the debug id for the view
+         * @param baseId
+         */
+        void setViewDebugId(String baseId);
+    }
+
+    /**
+     * Return the tab panel containing the sub-views
+     * @return
+     */
+    DETabPanel getCollaborationTabPanel();
+
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -129,6 +129,10 @@ public interface ManageCollaboratorsView extends IsWidget,
         String removePermissionsBtn();
 
         int retainPermissionsWidth();
+
+        int chooseCollaboratorsWidth();
+
+        int chooseCollaboratorsHeight();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -177,6 +177,12 @@ public interface ManageCollaboratorsView extends IsWidget,
          * @return
          */
         List<Subject> getSelectedSubjects();
+
+        /**
+         * Returns the view
+         * @return
+         */
+        ManageCollaboratorsView getView();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -172,6 +172,12 @@ public interface ManageCollaboratorsView extends IsWidget,
          * @return
          */
         ManageCollaboratorsView getView();
+
+        /**
+         * Returns the tab type that identifies this view in the Collaboration window
+         * @return
+         */
+        CollaborationView.TAB getTabType();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -11,7 +11,6 @@ import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.gwt.user.client.ui.IsWidget;
 
 import java.util.List;
@@ -139,9 +138,8 @@ public interface ManageCollaboratorsView extends IsWidget,
 
         /**
          * Method used to initialize the presenter
-         * @param container The UI container the presenter will put its view into
          */
-        void go (HasOneWidget container);
+        void go ();
 
         /**
          * Add collaborators to the view
@@ -158,18 +156,6 @@ public interface ManageCollaboratorsView extends IsWidget,
          * Fetch the list of current collaborators
          */
         void loadCurrentCollaborators();
-
-        /**
-         * Set the mode (manage or select) to put the ManageCollaboratorsView into
-         * @param mode
-         */
-        void setCurrentMode(MODE mode);
-
-        /**
-         * Getter for the ManageCollaboratorsView mode
-         * @return
-         */
-        MODE getCurrentMode();
 
         /**
          * Returns the list of currently selected collaborators from the ManageCollaboratorsView
@@ -197,13 +183,6 @@ public interface ManageCollaboratorsView extends IsWidget,
     void removeCollaboratorsById(List<String> userIds);
 
     /**
-     *  The collection of modes the ManageCollaboratorsView can step into
-     */
-    enum MODE {
-        MANAGE, SELECT
-    }
-
-    /**
      * Set the list of collaborators in the ManageCollaboratorsView
      * @param models
      */
@@ -227,22 +206,10 @@ public interface ManageCollaboratorsView extends IsWidget,
     void unmaskCollaborators();
 
     /**
-     * Set the mode for the ManageCollaboratorsView
-     * @param mode
-     */
-    void setMode(MODE mode);
-
-    /**
      * Returns the list of currently selected collaborators from the ManageCollaboratorsView
      * @return
      */
     List<Subject> getSelectedSubjects();
-
-    /**
-     * Returns the mode the ManageCollaboratorsView is currently set to
-     * @return
-     */
-    MODE getMode();
 
     /**
      * Add to the list of collaborators in the ManageCollaboratorsView

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/ManageCollaboratorsView.java
@@ -140,9 +140,8 @@ public interface ManageCollaboratorsView extends IsWidget,
         /**
          * Method used to initialize the presenter
          * @param container The UI container the presenter will put its view into
-         * @param mode The mode (manage or select) to put the ManageCollaboratorsView into
          */
-        void go (HasOneWidget container, MODE mode);
+        void go (HasOneWidget container);
 
         /**
          * Add collaborators to the view

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaborationViewFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaborationViewFactory.java
@@ -1,0 +1,11 @@
+package org.iplantc.de.collaborators.client.gin;
+
+import org.iplantc.de.collaborators.client.CollaborationView;
+import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.teams.client.TeamsView;
+
+public interface CollaborationViewFactory {
+
+    CollaborationView create(ManageCollaboratorsView collaboratorsView,
+                             TeamsView teamsView);
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaboratorsGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaboratorsGinModule.java
@@ -2,11 +2,14 @@ package org.iplantc.de.collaborators.client.gin;
 
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.client.services.impl.GroupServiceFacadeImpl;
+import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.collaborators.client.GroupDetailsView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.collaborators.client.presenter.CollaborationPresenterImpl;
 import org.iplantc.de.collaborators.client.presenter.GroupDetailsPresenterImpl;
 import org.iplantc.de.collaborators.client.presenter.ManageCollaboratorsPresenter;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
+import org.iplantc.de.collaborators.client.views.CollaborationViewImpl;
 import org.iplantc.de.collaborators.client.views.GroupDetailsViewImpl;
 import org.iplantc.de.collaborators.client.views.ManageCollaboratorsViewImpl;
 import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
@@ -20,6 +23,11 @@ import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
 public class CollaboratorsGinModule extends AbstractGinModule {
     @Override
     protected void configure() {
+        install(new GinFactoryModuleBuilder().implement(CollaborationView.class,
+                                                        CollaborationViewImpl.class)
+                                             .build(CollaborationViewFactory.class));
+        bind(CollaborationView.Presenter.class).to(CollaborationPresenterImpl.class);
+
         install(new GinFactoryModuleBuilder().implement(ManageCollaboratorsView.class,
                                                         ManageCollaboratorsViewImpl.class)
                                              .build(ManageCollaboratorsViewFactory.class));

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaboratorsGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/CollaboratorsGinModule.java
@@ -12,7 +12,7 @@ import org.iplantc.de.collaborators.client.util.UserSearchField;
 import org.iplantc.de.collaborators.client.views.CollaborationViewImpl;
 import org.iplantc.de.collaborators.client.views.GroupDetailsViewImpl;
 import org.iplantc.de.collaborators.client.views.ManageCollaboratorsViewImpl;
-import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
+import org.iplantc.de.collaborators.client.views.dialogs.ChooseCollaboratorsDialog;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
@@ -32,7 +32,7 @@ public class CollaboratorsGinModule extends AbstractGinModule {
                                                         ManageCollaboratorsViewImpl.class)
                                              .build(ManageCollaboratorsViewFactory.class));
         bind(ManageCollaboratorsView.Presenter.class).to(ManageCollaboratorsPresenter.class);
-        bind(ManageCollaboratorsDialog.class);
+        bind(ChooseCollaboratorsDialog.class);
         bind(GroupServiceFacade.class).to(GroupServiceFacadeImpl.class);
         bind(GroupDetailsView.class).to(GroupDetailsViewImpl.class);
         bind(GroupDetailsView.Presenter.class).to(GroupDetailsPresenterImpl.class);

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/ManageCollaboratorsViewFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/gin/ManageCollaboratorsViewFactory.java
@@ -8,5 +8,5 @@ import org.iplantc.de.collaborators.client.views.CollaboratorDNDHandler;
  */
 public interface ManageCollaboratorsViewFactory {
 
-    ManageCollaboratorsView create(ManageCollaboratorsView.MODE mode, CollaboratorDNDHandler dndHandler);
+    ManageCollaboratorsView create(CollaboratorDNDHandler dndHandler);
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
@@ -4,6 +4,7 @@ import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.gin.CollaborationViewFactory;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
+import org.iplantc.de.commons.client.views.window.configs.CollaborationWindowConfig;
 import org.iplantc.de.teams.client.TeamsView;
 
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -26,7 +27,10 @@ public class CollaborationPresenterImpl implements CollaborationView.Presenter {
     }
 
     @Override
-    public void go(HasOneWidget container) {
+    public void go(HasOneWidget container, CollaborationWindowConfig windowConfig) {
+        collabPresenter.go(null, ManageCollaboratorsView.MODE.MANAGE);
+        teamPresenter.go();
+
         container.setWidget(view);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
@@ -1,0 +1,37 @@
+package org.iplantc.de.collaborators.client.presenter;
+
+import org.iplantc.de.collaborators.client.CollaborationView;
+import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.collaborators.client.gin.CollaborationViewFactory;
+import org.iplantc.de.collaborators.shared.CollaboratorsModule;
+import org.iplantc.de.teams.client.TeamsView;
+
+import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.inject.Inject;
+
+public class CollaborationPresenterImpl implements CollaborationView.Presenter {
+
+    private ManageCollaboratorsView.Presenter collabPresenter;
+    private TeamsView.Presenter teamPresenter;
+    private CollaborationView view;
+
+    @Inject
+    public CollaborationPresenterImpl(ManageCollaboratorsView.Presenter collabPresenter,
+                                      TeamsView.Presenter teamPresenter,
+                                      CollaborationViewFactory viewFactory) {
+
+        this.collabPresenter = collabPresenter;
+        this.teamPresenter = teamPresenter;
+        this.view = viewFactory.create(collabPresenter.getView(), teamPresenter.getView());
+    }
+
+    @Override
+    public void go(HasOneWidget container) {
+        container.setWidget(view);
+    }
+
+    @Override
+    public void setViewDebugId(String baseId) {
+        view.asWidget().ensureDebugId(baseId + CollaboratorsModule.Ids.VIEW);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
@@ -1,5 +1,8 @@
 package org.iplantc.de.collaborators.client.presenter;
 
+import org.iplantc.de.client.models.collaborators.Subject;
+import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
 import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.gin.CollaborationViewFactory;
@@ -7,23 +10,36 @@ import org.iplantc.de.collaborators.shared.CollaboratorsModule;
 import org.iplantc.de.commons.client.views.window.configs.CollaborationWindowConfig;
 import org.iplantc.de.teams.client.TeamsView;
 
+import com.google.common.collect.Lists;
 import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.inject.Inject;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class CollaborationPresenterImpl implements CollaborationView.Presenter {
 
     private ManageCollaboratorsView.Presenter collabPresenter;
     private TeamsView.Presenter teamPresenter;
+    private GroupAutoBeanFactory factory;
     private CollaborationView view;
 
     @Inject
     public CollaborationPresenterImpl(ManageCollaboratorsView.Presenter collabPresenter,
                                       TeamsView.Presenter teamPresenter,
-                                      CollaborationViewFactory viewFactory) {
+                                      CollaborationViewFactory viewFactory,
+                                      GroupAutoBeanFactory factory) {
 
         this.collabPresenter = collabPresenter;
         this.teamPresenter = teamPresenter;
+        this.factory = factory;
         this.view = viewFactory.create(collabPresenter.getView(), teamPresenter.getView());
+    }
+
+    @Override
+    public void go(HasOneWidget container) {
+        go(container, null);
+        teamPresenter.showCheckBoxes();
     }
 
     @Override
@@ -37,5 +53,20 @@ public class CollaborationPresenterImpl implements CollaborationView.Presenter {
     @Override
     public void setViewDebugId(String baseId) {
         view.asWidget().ensureDebugId(baseId + CollaboratorsModule.Ids.VIEW);
+    }
+
+    @Override
+    public List<Subject> getSelectedCollaborators() {
+        List<Subject> allCollaborators = Lists.newArrayList();
+
+        List<Subject> collaborators = collabPresenter.getSelectedSubjects();
+        List<Group> teams = teamPresenter.getSelectedTeams();
+        List<Subject> teamsToSubjects = teams.stream()
+                                             .map(team -> factory.convertGroupToSubject(team))
+                                             .collect(Collectors.toList());
+
+        allCollaborators.addAll(collaborators);
+        allCollaborators.addAll(teamsToSubjects);
+        return allCollaborators;
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
@@ -28,7 +28,7 @@ public class CollaborationPresenterImpl implements CollaborationView.Presenter {
 
     @Override
     public void go(HasOneWidget container, CollaborationWindowConfig windowConfig) {
-        collabPresenter.go(null, ManageCollaboratorsView.MODE.MANAGE);
+        collabPresenter.go();
         teamPresenter.go();
 
         container.setWidget(view);

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
@@ -60,16 +60,24 @@ public class CollaborationPresenterImpl implements CollaborationView.Presenter {
 
     @Override
     public List<Subject> getSelectedCollaborators() {
-        List<Subject> allCollaborators = Lists.newArrayList();
+        List<Subject> allCollaborators = createEmptySubjectList();
 
         List<Subject> collaborators = collabPresenter.getSelectedSubjects();
         List<Group> teams = teamPresenter.getSelectedTeams();
-        List<Subject> teamsToSubjects = teams.stream()
-                                             .map(team -> factory.convertGroupToSubject(team))
-                                             .collect(Collectors.toList());
+        List<Subject> teamsToSubjects = convertTeamsToSubjects(teams);
 
         allCollaborators.addAll(collaborators);
         allCollaborators.addAll(teamsToSubjects);
         return allCollaborators;
+    }
+
+    List<Subject> createEmptySubjectList() {
+        return Lists.newArrayList();
+    }
+
+    List<Subject> convertTeamsToSubjects(List<Group> teams) {
+        return teams.stream()
+                    .map(team -> factory.convertGroupToSubject(team))
+                    .collect(Collectors.toList());
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
@@ -44,6 +44,9 @@ public class CollaborationPresenterImpl implements CollaborationView.Presenter {
 
     @Override
     public void go(HasOneWidget container, CollaborationWindowConfig windowConfig) {
+        if (windowConfig != null) {
+            view.setActiveTab(windowConfig.getSelectedTab());
+        }
         collabPresenter.go();
         teamPresenter.go();
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -158,7 +158,6 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     @Inject EventBus eventBus;
     @Inject IplantAnnouncer announcer;
     @Inject UserInfo userInfo;
-    private ManageCollaboratorsViewFactory factory;
     private GroupAutoBeanFactory groupFactory;
     private GroupServiceFacade groupServiceFacade;
     private CollaboratorsServiceFacade collabServiceFacade;
@@ -175,11 +174,13 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
                                         GroupServiceFacade groupServiceFacade,
                                         CollaboratorsServiceFacade collabServiceFacade,
                                         ManageCollaboratorsView.Appearance groupAppearance) {
-        this.factory = factory;
         this.groupFactory = groupFactory;
         this.groupServiceFacade = groupServiceFacade;
         this.collabServiceFacade = collabServiceFacade;
         this.groupAppearance = groupAppearance;
+        this.view = factory.create(getCollaboratorDNDHandler());
+
+        addEventHandlers();
     }
 
     void addEventHandlers() {
@@ -197,12 +198,13 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
      */
     @Override
     public void go(HasOneWidget container, ManageCollaboratorsView.MODE mode) {
-        CollaboratorDNDHandler dndHandler = getCollaboratorDNDHandler();
-        this.view = factory.create(mode, dndHandler);
+        view.setMode(mode);
         loadCurrentCollaborators();
         getGroups();
-        addEventHandlers();
-        container.setWidget(view.asWidget());
+
+        if (container != null) {
+            container.setWidget(view.asWidget());
+        }
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -11,6 +11,7 @@ import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
 import org.iplantc.de.client.models.groups.UpdateMemberResult;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
+import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.CollaboratorsLoadedEvent;
@@ -470,6 +471,11 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     @Override
     public ManageCollaboratorsView getView() {
         return view;
+    }
+
+    @Override
+    public CollaborationView.TAB getTabType() {
+        return CollaborationView.TAB.Collaborators;
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -482,6 +482,11 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
     }
 
     @Override
+    public ManageCollaboratorsView getView() {
+        return view;
+    }
+
+    @Override
     public void onAddGroupSelected(AddGroupSelected event) {
         groupDetailsDialog.get(new AsyncCallback<GroupDetailsDialog>() {
             @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -37,7 +37,6 @@ import com.google.common.collect.Lists;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.inject.Inject;
 
 import com.sencha.gxt.widget.core.client.Dialog;
@@ -197,14 +196,9 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
      * org.iplantc.de.commons.client.presenter.Presenter#go(com.google.gwt.user.client.ui.HasOneWidget )
      */
     @Override
-    public void go(HasOneWidget container, ManageCollaboratorsView.MODE mode) {
-        view.setMode(mode);
+    public void go() {
         loadCurrentCollaborators();
         getGroups();
-
-        if (container != null) {
-            container.setWidget(view.asWidget());
-        }
     }
 
     @Override
@@ -466,16 +460,6 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
 
         });
 
-    }
-
-    @Override
-    public void setCurrentMode(ManageCollaboratorsView.MODE m) {
-        view.setMode(m);
-    }
-
-    @Override
-    public ManageCollaboratorsView.MODE getCurrentMode() {
-        return view.getMode();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/CollaborationViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/CollaborationViewImpl.java
@@ -44,6 +44,14 @@ public class CollaborationViewImpl extends Composite implements CollaborationVie
     }
 
     @Override
+    public void setActiveTab(TAB selectedTab) {
+        if (selectedTab != null) {
+            Widget item = collaborationTabs.findItem(selectedTab.name(), true);
+            collaborationTabs.setActiveWidget(item);
+        }
+    }
+
+    @Override
     protected void onEnsureDebugId(String baseID) {
         super.onEnsureDebugId(baseID);
 

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/CollaborationViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/CollaborationViewImpl.java
@@ -1,0 +1,57 @@
+package org.iplantc.de.collaborators.client.views;
+
+import org.iplantc.de.collaborators.client.CollaborationView;
+import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.collaborators.shared.CollaboratorsModule;
+import org.iplantc.de.commons.client.widgets.DETabPanel;
+import org.iplantc.de.teams.client.TeamsView;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+import com.sencha.gxt.widget.core.client.Composite;
+
+public class CollaborationViewImpl extends Composite implements CollaborationView {
+
+    interface MyUiBinder extends UiBinder<Widget, CollaborationViewImpl> {
+    }
+
+    private static final MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
+
+    @UiField DETabPanel collaborationTabs;
+    @UiField(provided = true) ManageCollaboratorsView collaboratorsView;
+    @UiField(provided = true) TeamsView teamsView;
+    @UiField(provided = true) CollaborationViewAppearance appearance;
+
+    @Inject
+    public CollaborationViewImpl(@Assisted ManageCollaboratorsView collaboratorsView,
+                                 @Assisted TeamsView teamsView,
+                                 CollaborationView.CollaborationViewAppearance appearance) {
+        this.collaboratorsView = collaboratorsView;
+        this.teamsView = teamsView;
+        this.appearance = appearance;
+
+        initWidget(uiBinder.createAndBindUi(this));
+    }
+
+    @Override
+    public DETabPanel getCollaborationTabPanel() {
+        return collaborationTabs;
+    }
+
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        super.onEnsureDebugId(baseID);
+
+        collaborationTabs.setTabDebugId(collaboratorsView.asWidget(), baseID + CollaboratorsModule.Ids.COLLABORATORS_TAB);
+        collaboratorsView.asWidget().ensureDebugId(baseID + CollaboratorsModule.Ids.COLLABORATORS_TAB);
+
+        collaborationTabs.setTabDebugId(teamsView.asWidget(), baseID + CollaboratorsModule.Ids.TEAMS_TAB);
+        teamsView.asWidget().ensureDebugId(baseID + CollaboratorsModule.Ids.COLLABORATORS_TAB);
+
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/CollaborationViewImpl.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/CollaborationViewImpl.ui.xml
@@ -1,0 +1,32 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:container="urn:import:com.sencha.gxt.widget.core.client.container"
+             xmlns:deTabs="urn:import:org.iplantc.de.commons.client.widgets"
+             xmlns:collab="urn:import:org.iplantc.de.collaborators.client"
+             xmlns:team="urn:import:org.iplantc.de.teams.client"
+>
+
+    <ui:with field="appearance"
+             type="org.iplantc.de.collaborators.client.CollaborationView.CollaborationViewAppearance"/>
+
+    <ui:with field="collaboratorsTabConfig"
+             type="com.sencha.gxt.widget.core.client.TabItemConfig">
+        <ui:attributes text="{appearance.getCollaboratorsTabText}" />
+    </ui:with>
+    <ui:with field="teamsTabConfig"
+             type="com.sencha.gxt.widget.core.client.TabItemConfig">
+        <ui:attributes text="{appearance.getTeamsTabText}" />
+    </ui:with>
+
+    <container:SimpleContainer>
+        <deTabs:DETabPanel ui:field="collaborationTabs">
+            <deTabs:child config="{collaboratorsTabConfig}">
+                <collab:ManageCollaboratorsView ui:field="collaboratorsView"/>
+            </deTabs:child>
+            <deTabs:child config="{teamsTabConfig}">
+                <team:TeamsView ui:field="teamsView"/>
+            </deTabs:child>
+        </deTabs:DETabPanel>
+    </container:SimpleContainer>
+
+</ui:UiBinder>

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsView.ui.xml
@@ -5,12 +5,9 @@
 			 xmlns:button="urn:import:com.sencha.gxt.widget.core.client.button"
 			 xmlns:toolbar="urn:import:com.sencha.gxt.widget.core.client.toolbar"
 			 xmlns:userSearch="urn:import:org.iplantc.de.collaborators.client.util"
-			 xmlns:gxt="urn:import:com.sencha.gxt.widget.core.client"
-			 xmlns:de="urn:import:org.iplantc.de.commons.client.widgets">
+>
 
 	<ui:with field="appearance"
-			 type="org.iplantc.de.collaborators.client.ManageCollaboratorsView.Appearance"/>
-	<ui:with field="groupAppearance"
 			 type="org.iplantc.de.collaborators.client.ManageCollaboratorsView.Appearance"/>
 
  	<!-- Main Panel -->
@@ -22,20 +19,6 @@
 		<ui:attributes forceFit="true" autoFill="true" />
 	</ui:with>
 
-	<ui:with field="centerMargins" type="com.sencha.gxt.core.client.util.Margins">
-		<ui:attributes top="0" right="0" bottom="0" left="0" />
-	</ui:with>
-
-	<ui:with field="northMargins" type="com.sencha.gxt.core.client.util.Margins">
-		<ui:attributes top="30" right="0" bottom="0" left="30" />
-	</ui:with>
-
-	<ui:with field="northData"
-		type="com.sencha.gxt.widget.core.client.container.BorderLayoutContainer.BorderLayoutData">
-		  <ui:attributes size="50"
-                     maxSize="50"
-                     hidden="false" margins="{northMargins}"/>
-	</ui:with>
 
 	<ui:with
 		type="com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer.VerticalLayoutData"
@@ -43,78 +26,39 @@
 		<ui:attributes width="1" height="1" />
 	</ui:with>
 
-	<ui:with field="centerData"
-		type="com.sencha.gxt.widget.core.client.container.MarginData">
-		<ui:attributes margins="{centerMargins}" />
-	</ui:with>
-
-	<ui:with field="collaboratorTabConfig"
-			 type="com.sencha.gxt.widget.core.client.TabItemConfig">
-		<ui:attributes text="{appearance.collaboratorTab}"/>
-	</ui:with>
-
-	<ui:with field="collaboratorListTabConfig"
-			 type="com.sencha.gxt.widget.core.client.TabItemConfig">
-		<ui:attributes text="{appearance.collaboratorListTab}"/>
-	</ui:with>
-
-
-	<container:SimpleContainer>
-		<container:child>
-			<container:BorderLayoutContainer
-					ui:field="con" borders="true">
-				<!-- This is the tool bar -->
-				<container:north layoutData="{northData}">
-					<container:HorizontalLayoutContainer ui:field="searchPanel">
-						<button:TextButton debugId="idManage"
-										   ui:field="manageBtn"
-										   text="{appearance.manageCollaborators}"
-										   visible="false"
-										   icon="{appearance.shareIcon}"/>
+	<container:VerticalLayoutContainer>
+			<container:child>
+				<toolbar:ToolBar height="30" ui:field="toolbar">
+					<toolbar:child>
+						<button:TextButton debugId="idDeleteBtn"
+										   ui:field="deleteBtn"
+										   text="{appearance.delete}"
+										   icon="{appearance.deleteIcon}"
+										   enabled="false"/>
+					</toolbar:child>
+					<toolbar:child>
+						<toolbar:SeparatorToolItem/>
+					</toolbar:child>
+					<toolbar:child>
+						<button:TextButton ui:field="addGroup"
+										   text="{appearance.addGroup}"
+										   icon="{appearance.addIcon}"/>
+					</toolbar:child>
+					<toolbar:child>
 						<userSearch:UserSearchField ui:field="searchField"/>
-					</container:HorizontalLayoutContainer>
-				</container:north>
-				<!-- This is the main panel -->
-				<container:center layoutData="{centerData}">
-					<gxt:FramedPanel ui:field="collaboratorListPnl"
-									 pixelSize="445,175" collapsible="false"
-									 headerVisible="true"
-					heading="My Collaborators">
+					</toolbar:child>
+				</toolbar:ToolBar>
+			</container:child>
+			<container:child layoutData="{middleData}">
+				<grid:Grid ui:field="grid"
+						   cm="{cm}"
+						   store="{listStore}"
+						   view="{gridView}"
+						   loadMask="true"
+						   columnReordering="true"
+						   borders="false">
+				</grid:Grid>
+			</container:child>
+		</container:VerticalLayoutContainer>
 
-							<container:VerticalLayoutContainer pixelSize="445,150">
-								<container:child>
-									<toolbar:ToolBar height="30" ui:field="toolbar">
-										<toolbar:child>
-											<button:TextButton debugId="idDeleteBtn"
-															   ui:field="deleteBtn"
-															   text="{appearance.delete}"
-															   icon="{appearance.deleteIcon}"
-															   enabled="false"/>
-										</toolbar:child>
-										<toolbar:child>
-											<toolbar:SeparatorToolItem/>
-										</toolbar:child>
-										<toolbar:child>
-											<button:TextButton ui:field="addGroup"
-															   text="{groupAppearance.addGroup}"
-															   icon="{groupAppearance.addIcon}"/>
-										</toolbar:child>
-									</toolbar:ToolBar>
-								</container:child>
-								<container:child layoutData="{middleData}">
-									<grid:Grid ui:field="grid"
-											   cm="{cm}"
-											   store="{listStore}"
-											   view="{gridView}"
-											   loadMask="true"
-											   columnReordering="true"
-											   borders="false">
-									</grid:Grid>
-								</container:child>
-							</container:VerticalLayoutContainer>
-					</gxt:FramedPanel>
-				</container:center>
-			</container:BorderLayoutContainer>
-		</container:child>
-	</container:SimpleContainer>
 </ui:UiBinder>

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -70,7 +70,6 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     private CollaboratorDNDHandler dndHandler;
     @UiField HorizontalLayoutContainer searchPanel;
     @UiField ToolBar toolbar;
-    private DETabPanel tabPanel;
     @UiField FramedPanel collaboratorListPnl;
 
     @UiField(provided = true) ManageCollaboratorsView.Appearance appearance;
@@ -81,8 +80,7 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     private String baseID;
 
     @Inject
-    public ManageCollaboratorsViewImpl(@Assisted final MODE mode,
-                                       ManageCollaboratorsView.Appearance appearance,
+    public ManageCollaboratorsViewImpl(ManageCollaboratorsView.Appearance appearance,
                                        UserSearchField searchField,
                                        @Assisted CollaboratorDNDHandler dndHandler) {
         this.appearance = appearance;
@@ -101,7 +99,6 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
             }
         });
         init();
-        setMode(mode);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/ManageCollaboratorsViewImpl.java
@@ -10,7 +10,6 @@ import org.iplantc.de.collaborators.client.models.SubjectKeyProvider;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
 import org.iplantc.de.collaborators.client.views.cells.SubjectNameCell;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
-import org.iplantc.de.commons.client.widgets.DETabPanel;
 
 import com.google.common.base.Strings;
 import com.google.gwt.cell.client.Cell;
@@ -32,10 +31,7 @@ import com.sencha.gxt.data.shared.ListStore;
 import com.sencha.gxt.dnd.core.client.DragSource;
 import com.sencha.gxt.dnd.core.client.DropTarget;
 import com.sencha.gxt.widget.core.client.Composite;
-import com.sencha.gxt.widget.core.client.FramedPanel;
 import com.sencha.gxt.widget.core.client.button.TextButton;
-import com.sencha.gxt.widget.core.client.container.BorderLayoutContainer;
-import com.sencha.gxt.widget.core.client.container.HorizontalLayoutContainer;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.ViewReadyEvent;
 import com.sencha.gxt.widget.core.client.grid.CheckBoxSelectionModel;
@@ -60,23 +56,18 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     }
     @UiField ColumnModel<Subject> cm;
     @UiField ListStore<Subject> listStore;
-    @UiField BorderLayoutContainer con;
     @UiField TextButton deleteBtn;
     @UiField TextButton addGroup;
     @UiField Grid<Subject> grid;
     @UiField GridView<Subject> gridView;
-    @UiField TextButton manageBtn;
     @UiField(provided = true) UserSearchField searchField;
     private CollaboratorDNDHandler dndHandler;
-    @UiField HorizontalLayoutContainer searchPanel;
     @UiField ToolBar toolbar;
-    @UiField FramedPanel collaboratorListPnl;
 
     @UiField(provided = true) ManageCollaboratorsView.Appearance appearance;
 
     private static MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
     private final CheckBoxSelectionModel<Subject> checkBoxModel;
-    private MODE mode;
     private String baseID;
 
     @Inject
@@ -123,11 +114,6 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     }
 
     @Override
-    public MODE getMode() {
-        return mode;
-    }
-
-    @Override
     public List<Subject> getSelectedSubjects() {
         return grid.getSelectionModel().getSelectedItems();
     }
@@ -160,14 +146,13 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
         if (Strings.isNullOrEmpty(maskText)) {
             maskText = appearance.loadingMask();
         }
-        collaboratorListPnl.mask(maskText);
+        super.mask(maskText);
     }
 
     @Override
     public void onSelectionChanged(SelectionChangedEvent<Subject> event) {
         if (event.getSelection() != null
-                && event.getSelection().size() > 0
-                && MODE.MANAGE.equals(mode)) {
+                && event.getSelection().size() > 0) {
             deleteBtn.enable();
         } else {
             deleteBtn.disable();
@@ -187,28 +172,8 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     }
 
     @Override
-    public void setMode(MODE mode) {
-        this.mode = mode;
-        switch (mode) {
-            case MANAGE:
-                grid.getView().setEmptyText(appearance.noCollaborators());
-                manageBtn.setVisible(false);
-                searchField.asWidget().setVisible(true);
-                toolbar.setVisible(true);
-                break;
-            case SELECT:
-                grid.getView().setEmptyText(appearance.noCollaborators());
-                manageBtn.setVisible(true);
-                searchField.asWidget().setVisible(false);
-                toolbar.setVisible(false);
-                break;
-        }
-        toolbar.forceLayout();
-    }
-
-    @Override
     public void unmaskCollaborators() {
-        collaboratorListPnl.unmask();
+        super.unmask();
     }
 
     @Override
@@ -253,11 +218,6 @@ public class ManageCollaboratorsViewImpl extends Composite implements ManageColl
     @UiHandler("addGroup")
     void addGroupSelected(SelectEvent event) {
         fireEvent(new AddGroupSelected());
-    }
-
-    @UiHandler("manageBtn")
-    void manageCollaborators(SelectEvent event) {
-        setMode(MODE.MANAGE);
     }
 
     private void init() {

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ChooseCollaboratorsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ChooseCollaboratorsDialog.java
@@ -18,7 +18,7 @@ import javax.inject.Inject;
  * @author sriram, jstroot
  * 
  */
-public class ManageCollaboratorsDialog extends IPlantDialog {
+public class ChooseCollaboratorsDialog extends IPlantDialog {
 
 
     private final CollaborationView.Presenter presenter;
@@ -26,7 +26,7 @@ public class ManageCollaboratorsDialog extends IPlantDialog {
 
 
     @Inject
-    ManageCollaboratorsDialog(final ManageCollaboratorsView.Appearance appearance,
+    ChooseCollaboratorsDialog(final ManageCollaboratorsView.Appearance appearance,
                               CollaborationView.Presenter presenter) {
         super(true);
         this.appearance = appearance;

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ChooseCollaboratorsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ChooseCollaboratorsDialog.java
@@ -36,7 +36,7 @@ public class ChooseCollaboratorsDialog extends IPlantDialog {
 
     @Override
     public void show() {
-        presenter.go(this, null);
+        presenter.go(this);
 
         super.show();
         ensureDebugId(CollaboratorsModule.Ids.DIALOG);
@@ -70,6 +70,6 @@ public class ChooseCollaboratorsDialog extends IPlantDialog {
     }
 
     public List<Subject> getSelectedSubjects() {
-        return null;
+        return presenter.getSelectedCollaborators();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ChooseCollaboratorsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ChooseCollaboratorsDialog.java
@@ -54,7 +54,7 @@ public class ChooseCollaboratorsDialog extends IPlantDialog {
         setPredefinedButtons(PredefinedButton.OK);
         setHeading(appearance.collaborators());
         addHelp(new HTML(appearance.collaboratorsHelp()));
-        setPixelSize(450, 400);
+        setPixelSize(appearance.chooseCollaboratorsWidth(), appearance.chooseCollaboratorsHeight());
         addOkButtonHandler();
         setHideOnButtonClick(true);
     }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ManageCollaboratorsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/ManageCollaboratorsDialog.java
@@ -1,8 +1,8 @@
 package org.iplantc.de.collaborators.client.views.dialogs;
 
 import org.iplantc.de.client.models.collaborators.Subject;
+import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
-import org.iplantc.de.collaborators.client.ManageCollaboratorsView.MODE;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
 import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
 
@@ -21,21 +21,22 @@ import javax.inject.Inject;
 public class ManageCollaboratorsDialog extends IPlantDialog {
 
 
-    private final ManageCollaboratorsView.Presenter presenter;
+    private final CollaborationView.Presenter presenter;
     private final ManageCollaboratorsView.Appearance appearance;
 
 
     @Inject
     ManageCollaboratorsDialog(final ManageCollaboratorsView.Appearance appearance,
-                              ManageCollaboratorsView.Presenter presenter) {
+                              CollaborationView.Presenter presenter) {
         super(true);
         this.appearance = appearance;
         this.presenter = presenter;
         initDialog();
     }
 
-    public void show(MODE mode) {
-        presenter.go(this, mode);
+    @Override
+    public void show() {
+        presenter.go(this, null);
 
         super.show();
         ensureDebugId(CollaboratorsModule.Ids.DIALOG);
@@ -68,13 +69,7 @@ public class ManageCollaboratorsDialog extends IPlantDialog {
         });
     }
 
-    @Override
-    public void show() throws UnsupportedOperationException {
-        throw new UnsupportedOperationException(
-                "This method is not supported. Use show(MODE mode) method instead.");
-    }
-
     public List<Subject> getSelectedSubjects() {
-        return presenter.getSelectedSubjects();
+        return null;
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/shared/CollaboratorsModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/shared/CollaboratorsModule.java
@@ -33,5 +33,7 @@ public interface CollaboratorsModule {
         String REMOVE_PERMS_BTN = ".removeBtn";
         String CANCEL_BTN = ".cancelBtn";
         String HELP_BTN = ".helpBtn";
+        String TEAMS_TAB = ".teamsTab";
+        String COLLABORATORS_TAB = ".collaboratorsTab";
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
@@ -8,7 +8,7 @@ import org.iplantc.de.client.models.sharing.SharedResource;
 import org.iplantc.de.client.models.sharing.Sharing;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
-import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
+import org.iplantc.de.collaborators.client.views.dialogs.ChooseCollaboratorsDialog;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
@@ -85,7 +85,7 @@ public class SharingPermissionsPanel extends Composite
     private FastMap<List<Sharing>> sharingMap;
 
     @Inject IplantAnnouncer announcer;
-    @Inject AsyncProviderWrapper<ManageCollaboratorsDialog> collaboratorsDialogProvider;
+    @Inject AsyncProviderWrapper<ChooseCollaboratorsDialog> collaboratorsDialogProvider;
 
     private static final MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
 
@@ -127,14 +127,14 @@ public class SharingPermissionsPanel extends Composite
 
     @UiHandler("chooseCollabBtn")
     void chooseCollabBtnSelected(SelectEvent event) {
-        collaboratorsDialogProvider.get(new AsyncCallback<ManageCollaboratorsDialog>() {
+        collaboratorsDialogProvider.get(new AsyncCallback<ChooseCollaboratorsDialog>() {
             @Override
             public void onFailure(Throwable caught) {
                 ErrorHandler.post(caught);
             }
 
             @Override
-            public void onSuccess(ManageCollaboratorsDialog result) {
+            public void onSuccess(ChooseCollaboratorsDialog result) {
                 result.setModal(true);
                 result.show();
                 result.addOkButtonSelectHandler(new SelectHandler() {

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/sharing/SharingPermissionsPanel.java
@@ -6,7 +6,6 @@ import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.models.sharing.PermissionValue;
 import org.iplantc.de.client.models.sharing.SharedResource;
 import org.iplantc.de.client.models.sharing.Sharing;
-import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.UserSearchResultSelected;
 import org.iplantc.de.collaborators.client.util.UserSearchField;
 import org.iplantc.de.collaborators.client.views.dialogs.ManageCollaboratorsDialog;
@@ -137,7 +136,7 @@ public class SharingPermissionsPanel extends Composite
             @Override
             public void onSuccess(ManageCollaboratorsDialog result) {
                 result.setModal(true);
-                result.show(ManageCollaboratorsView.MODE.SELECT);
+                result.show();
                 result.addOkButtonSelectHandler(new SelectHandler() {
 
                     @Override

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/window/configs/CollaborationWindowConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/window/configs/CollaborationWindowConfig.java
@@ -1,8 +1,14 @@
 package org.iplantc.de.commons.client.views.window.configs;
 
+import org.iplantc.de.collaborators.client.CollaborationView;
+
 /**
  * Window configuration for the Collaboration window
  * @author aramsey
  */
 public interface CollaborationWindowConfig extends WindowConfig {
+
+    void setSelectedTab(CollaborationView.TAB tab);
+    CollaborationView.TAB getSelectedTab();
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/CollaborationWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/CollaborationWindow.java
@@ -1,8 +1,8 @@
 package org.iplantc.de.desktop.client.views.windows;
 
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
-import org.iplantc.de.collaborators.client.presenter.ManageCollaboratorsPresenter;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
 import org.iplantc.de.commons.client.views.window.configs.CollaborationWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
@@ -19,11 +19,12 @@ import com.google.inject.Inject;
 public class CollaborationWindow extends IplantWindowBase {
 
     public static final String COLLABORATION = "#collaboration";
-    private final ManageCollaboratorsPresenter presenter;
+    private final CollaborationView.Presenter presenter;
     private ManageCollaboratorsView.Appearance appearance;
 
     @Inject
-    CollaborationWindow(final ManageCollaboratorsPresenter presenter, ManageCollaboratorsView.Appearance appearance) {
+    CollaborationWindow(final CollaborationView.Presenter presenter,
+                        ManageCollaboratorsView.Appearance appearance) {
         this.presenter = presenter;
         this.appearance = appearance;
 
@@ -43,7 +44,7 @@ public class CollaborationWindow extends IplantWindowBase {
                                               final String tag,
                                               final boolean isMaximizable) {
         final CollaborationWindowConfig collabWindowConfig = (CollaborationWindowConfig)windowConfig;
-        presenter.go(this, ManageCollaboratorsView.MODE.MANAGE);
+        presenter.go(this, collabWindowConfig);
         super.show(windowConfig, tag, isMaximizable);
 
         ensureDebugId(DeModule.WindowIds.COLLABORATION_WINDOW);

--- a/de-lib/src/main/java/org/iplantc/de/notifications/client/utils/NotificationUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/notifications/client/utils/NotificationUtil.java
@@ -21,6 +21,7 @@ import org.iplantc.de.client.models.notifications.payload.PayloadTeam;
 import org.iplantc.de.client.models.requestStatus.RequestHistory;
 import org.iplantc.de.client.util.CommonModelUtils;
 import org.iplantc.de.client.util.DiskResourceUtil;
+import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.commons.client.views.window.configs.AnalysisWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.AppsWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.CollaborationWindowConfig;
@@ -260,6 +261,7 @@ public class NotificationUtil {
                         });
                     } else {
                         CollaborationWindowConfig window = ConfigFactory.collaborationWindowConfig();
+                        window.setSelectedTab(CollaborationView.TAB.Teams);
                         eventBus.fireEvent(new WindowShowRequestEvent(window, true));
                     }
                     break;

--- a/de-lib/src/main/java/org/iplantc/de/resources/client/messages/IplantContextualHelpStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/resources/client/messages/IplantContextualHelpStrings.java
@@ -11,7 +11,16 @@ public interface IplantContextualHelpStrings extends com.google.gwt.i18n.client.
    * 
    * @return translated "<p>The Collaborators window allows you to quickly find, add, and remove CyVerse users within your Collaborators list.</p><br/><p>Adding someone as your collaborator enhances the sharing feature, making it even easier to share data with one, a few, or all of your collaborators.</p><br/><p>To add a collaborator, begin typing their name or CyVerse username in the search field and a results drop-down will appear. Select your desired name to add them to your list of collaborators. You can also easily access this list when sharing.</p>"
    */
-  @DefaultMessage("<p>The Collaboration window allows you to quickly find, add, and remove CyVerse users within your set of Collaborators.</p><p>Adding someone as your collaborator enhances the sharing feature, making it even easier to share data with one, a few, or all of your collaborators.</p> <p>To add a collaborator, begin typing their name or CyVerse username in the search field and a results drop-down will appear. Select your desired name to add them to your set of collaborators. You can also easily access this set when sharing.</p><p>Additionally, if you have the need to frequently share data with several of the same collaborators, you can create a Collaborator List.  Click the \"Add List\" button to start creating your own custom lists of Collaborators.</p>")
+  @DefaultMessage("<p>The Collaboration window allows you different ways to quickly find, add, and remove CyVerse users within your set of Collaborators.</p>"
+                  + "<p>Adding someone as your collaborator enhances the sharing feature, making it even easier to share data with one, a few, or all of your collaborators.</p>"
+                  + "<br><p><u>Collaborators</u></p>"
+                  + "<p>Using the Collaborators tab allows you to organize your own private set and lists of collaborators.</p>"
+                  + "<p>To add a collaborator, begin typing their name or CyVerse username in the search field and a results drop-down will appear. Select your desired name to add them to your set of collaborators. You can also easily access this set when sharing.</p>"
+                  + "<p>Additionally, if you have the need to frequently share data with several of the same collaborators, you can create a Collaborator List.  Click the \"Add List\" button to start creating your own custom lists of Collaborators.</p>"
+                  + "<br><p><u>Teams</u></p>"
+                  + "<p>Using the Teams tab allows you to create, organize, and join public or private groups of collaborators.</p>"
+                  + "<p>Any teams you are a member of will show up under \"My Teams\".  You can find other public teams that you can join by selecting \"All Teams\".</p>"
+                  + "<p>You can also create your own team, defining your own team members and team privileges, by selecting \"Create Team\".</p>")
   @Key("collaboratorsHelp")
   String collaboratorsHelp();
 

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/TeamsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/TeamsView.java
@@ -184,6 +184,18 @@ public interface TeamsView extends IsWidget,
          * @return
          */
         TeamsView getView();
+
+        /**
+         * Show the check box column in the teams grid, so that users can select multiple
+         * teams at once
+         */
+        void showCheckBoxes();
+
+        /**
+         * Return the list of selected teams from the view
+         * @return
+         */
+        List<Group> getSelectedTeams();
     }
 
     /**
@@ -214,4 +226,16 @@ public interface TeamsView extends IsWidget,
      * @param team
      */
     void removeTeam(Group team);
+
+    /**
+     * Show the check box column in the grid, so that users can select multiple
+     * teams at once
+     */
+    void showCheckBoxes();
+
+    /**
+     * Return the list of selected teams
+     * @return
+     */
+    List<Group> getSelectedTeams();
 }

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/TeamsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/TeamsView.java
@@ -178,6 +178,12 @@ public interface TeamsView extends IsWidget,
          * Initialize the Team presenter to begin fetching teams
          */
         void go();
+
+        /**
+         * Returns the view
+         * @return
+         */
+        TeamsView getView();
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
@@ -72,12 +72,22 @@ public class TeamsPresenterImpl implements TeamsView.Presenter, TeamNameSelected
     @Override
     public void go() {
         currentFilter = view.getCurrentFilter();
-        getSelectedTeams();
+        getFilteredTeams();
     }
 
     @Override
     public TeamsView getView() {
         return view;
+    }
+
+    @Override
+    public void showCheckBoxes() {
+        view.showCheckBoxes();
+    }
+
+    @Override
+    public List<Group> getSelectedTeams() {
+        return view.getSelectedTeams();
     }
 
     @Override
@@ -124,10 +134,10 @@ public class TeamsPresenterImpl implements TeamsView.Presenter, TeamNameSelected
 
         currentFilter = filter;
 
-        getSelectedTeams();
+        getFilteredTeams();
     }
 
-    void getSelectedTeams() {
+    void getFilteredTeams() {
         if (TeamsFilter.MY_TEAMS.equals(currentFilter)) {
             getMyTeams();
         } else {

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
@@ -4,6 +4,7 @@ import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
+import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
@@ -76,6 +76,11 @@ public class TeamsPresenterImpl implements TeamsView.Presenter, TeamNameSelected
     }
 
     @Override
+    public TeamsView getView() {
+        return view;
+    }
+
+    @Override
     public void onTeamNameSelected(TeamNameSelected event) {
         Group group = event.getTeam();
         editTeamDlgProvider.get(new AsyncCallback<EditTeamDialog>() {

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/views/TeamsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/views/TeamsViewImpl.java
@@ -36,6 +36,7 @@ import com.sencha.gxt.widget.core.client.Composite;
 import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.form.SimpleComboBox;
+import com.sencha.gxt.widget.core.client.grid.CheckBoxSelectionModel;
 import com.sencha.gxt.widget.core.client.grid.ColumnConfig;
 import com.sencha.gxt.widget.core.client.grid.ColumnModel;
 import com.sencha.gxt.widget.core.client.grid.Grid;
@@ -71,6 +72,8 @@ public class TeamsViewImpl extends Composite implements TeamsView {
     @UiField GridView<Group> gridView;
     @UiField ListStore<Group> listStore;
     private GroupProperties properties;
+    private CheckBoxSelectionModel<Group> checkBoxSelectionModel;
+    private ColumnConfig<Group, Group> checkBoxCol;
     private TeamNameCell nameCell;
     private PagingLoader<FilterPagingLoadConfig, PagingLoadResult<Group>> loader;
 
@@ -83,6 +86,7 @@ public class TeamsViewImpl extends Composite implements TeamsView {
         this.properties = properties;
         this.nameCell = nameCell;
         this.loader = loader;
+        this.checkBoxSelectionModel = getCheckBoxSelectionModel();
 
         initWidget(uiBinder.createAndBindUi(this));
         grid.getSelectionModel().setSelectionMode(Style.SelectionMode.MULTI);
@@ -108,6 +112,7 @@ public class TeamsViewImpl extends Composite implements TeamsView {
     @UiFactory
     ColumnModel<Group> createColumnModel() {
         List<ColumnConfig<Group, ?>> list = Lists.newArrayList();
+        checkBoxCol = checkBoxSelectionModel.getColumn();
         ColumnConfig<Group, Group> nameCol = new ColumnConfig<>(new IdentityValueProvider<>("extension"),
                                                                  appearance.nameColumnWidth(),
                                                                  appearance.nameColumnLabel());
@@ -119,9 +124,12 @@ public class TeamsViewImpl extends Composite implements TeamsView {
                                                                  appearance.descColumnLabel());
         nameCol.setCell(nameCell);
         nameCol.setComparator(new TeamNameComparator());
+        list.add(checkBoxCol);
         list.add(nameCol);
         list.add(creatorCol);
         list.add(descCol);
+
+        checkBoxCol.setHidden(true);
         return new ColumnModel<>(list);
     }
 
@@ -196,6 +204,22 @@ public class TeamsViewImpl extends Composite implements TeamsView {
         if (found != null) {
             listStore.remove(found);
         }
+    }
+
+    @Override
+    public void showCheckBoxes() {
+        grid.setSelectionModel(checkBoxSelectionModel);
+        checkBoxCol.setHidden(false);
+        grid.getView().refresh(true);
+    }
+
+    @Override
+    public List<Group> getSelectedTeams() {
+        return grid.getSelectionModel().getSelectedItems();
+    }
+
+    CheckBoxSelectionModel<Group> getCheckBoxSelectionModel() {
+        return new CheckBoxSelectionModel<>(new IdentityValueProvider<Group>());
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/CollaborationDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/CollaborationDisplayStrings.java
@@ -1,0 +1,9 @@
+package org.iplantc.de.theme.base.client.collaborators;
+
+import com.google.gwt.i18n.client.Messages;
+
+public interface CollaborationDisplayStrings extends Messages {
+    String getCollaboratorsTabText();
+
+    String getTeamsTabText();
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/CollaborationDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/CollaborationDisplayStrings.properties
@@ -1,0 +1,2 @@
+getCollaboratorsTabText=Collaborators
+getTeamsTabText=Teams

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/CollaborationViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/CollaborationViewDefaultAppearance.java
@@ -1,0 +1,28 @@
+package org.iplantc.de.theme.base.client.collaborators;
+
+import org.iplantc.de.collaborators.client.CollaborationView;
+
+import com.google.gwt.core.client.GWT;
+
+public class CollaborationViewDefaultAppearance implements CollaborationView.CollaborationViewAppearance{
+
+    private CollaborationDisplayStrings displayStrings;
+
+    public CollaborationViewDefaultAppearance() {
+        this(GWT.create(CollaborationDisplayStrings.class));
+    }
+
+    public CollaborationViewDefaultAppearance(CollaborationDisplayStrings displayStrings) {
+        this.displayStrings = displayStrings;
+    }
+
+    @Override
+    public String getCollaboratorsTabText() {
+        return displayStrings.getCollaboratorsTabText();
+    }
+
+    @Override
+    public String getTeamsTabText() {
+        return displayStrings.getTeamsTabText();
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/Collaborators.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/Collaborators.gwt.xml
@@ -4,6 +4,10 @@
 <module>
     <inherits name="org.iplantc.de.collaborators.Collaborators"/>
 
+    <replace-with class="org.iplantc.de.theme.base.client.collaborators.CollaborationViewDefaultAppearance">
+        <when-type-is class="org.iplantc.de.collaborators.client.CollaborationView.CollaborationViewAppearance" />
+    </replace-with>
+
     <replace-with class="org.iplantc.de.theme.base.client.collaborators.ManageCollaboratorsViewDefaultAppearance">
         <when-type-is class="org.iplantc.de.collaborators.client.ManageCollaboratorsView.Appearance" />
     </replace-with>

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/ManageCollaboratorsViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/collaborators/ManageCollaboratorsViewDefaultAppearance.java
@@ -337,4 +337,14 @@ public class ManageCollaboratorsViewDefaultAppearance implements ManageCollabora
     public int retainPermissionsWidth() {
         return 350;
     }
+
+    @Override
+    public int chooseCollaboratorsWidth() {
+        return 550;
+    }
+
+    @Override
+    public int chooseCollaboratorsHeight() {
+        return 400;
+    }
 }

--- a/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantContextualHelpStrings.properties
+++ b/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantContextualHelpStrings.properties
@@ -1,7 +1,13 @@
-collaboratorsHelp = <p>The Collaboration window allows you to quickly find, add, and remove CyVerse users within your set of Collaborators.</p>\
+collaboratorsHelp = <p>The Collaboration window allows you different ways to quickly find, add, and remove CyVerse users within your set of Collaborators.</p>\
   <p>Adding someone as your collaborator enhances the sharing feature, making it even easier to share data with one, a few, or all of your collaborators.</p>\
+  <br><p><u>Collaborators</u></p>\
+  <p>Using the Collaborators tab allows you to organize your own private set and lists of collaborators.</p>\
   <p>To add a collaborator, begin typing their name or CyVerse username in the search field and a results drop-down will appear. Select your desired name to add them to your set of collaborators. You can also easily access this set when sharing.</p> \
-  <p>Additionally, if you have the need to frequently share data with several of the same collaborators, you can create a Collaborator List.  Click the "Add List" button to start creating your own custom lists of Collaborators.</p>
+  <p>Additionally, if you have the need to frequently share data with several of the same collaborators, you can create a Collaborator List.  Click the "Add List" button to start creating your own custom lists of Collaborators.</p>\
+  <br><p><u>Teams</u></p>\
+  <p>Using the Teams tab allows you to create, organize, and join public or private groups of collaborators.</p>\
+  <p>Any teams you are a member of will show up under "My Teams".  You can find other public teams that you can join by selecting "All Teams".</p>\
+  <p>You can also create your own team, defining your own team members and team privileges, by selecting "Create Team".</p>
 toolRequestStatusHelp = Your Tool Request will be in one of the following Statuses.
 toolRequestStatusSubmittedHelp = Your tool request has been submitted. You will receive updates in the Discovery Environment as the evaluation and installation process proceeds.
 toolRequestStatusPendingHelp = The CyVerse team is waiting for more information regarding your tool request. Please see the Status Comments for more information.

--- a/de-lib/src/test/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImplTest.java
@@ -1,0 +1,106 @@
+package org.iplantc.de.collaborators.client.presenter;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.iplantc.de.client.models.collaborators.Subject;
+import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
+import org.iplantc.de.collaborators.client.CollaborationView;
+import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
+import org.iplantc.de.collaborators.client.gin.CollaborationViewFactory;
+import org.iplantc.de.commons.client.views.window.configs.CollaborationWindowConfig;
+import org.iplantc.de.teams.client.TeamsView;
+
+import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.util.List;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class CollaborationPresenterImplTest {
+
+    @Mock ManageCollaboratorsView.Presenter collabPresenterMock;
+    @Mock TeamsView.Presenter teamPresenterMock;
+    @Mock GroupAutoBeanFactory factoryMock;
+    @Mock CollaborationView viewMock;
+    @Mock CollaborationViewFactory viewFactoryMock;
+    @Mock List<Subject> collabListMock;
+    @Mock List<Group> teamListMock;
+    @Mock List<Subject> teamSubjectListMock;
+    @Mock List<Subject> subjectListMock;
+
+    CollaborationPresenterImpl uut;
+
+    @Before
+    public void setUp() {
+        when(viewFactoryMock.create(any(), any())).thenReturn(viewMock);
+
+        uut = new CollaborationPresenterImpl(collabPresenterMock,
+                                             teamPresenterMock,
+                                             viewFactoryMock,
+                                             factoryMock){
+            @Override
+            List<Subject> convertTeamsToSubjects(List<Group> teams) {
+                return teamSubjectListMock;
+            }
+
+            @Override
+            List<Subject> createEmptySubjectList() {
+                return subjectListMock;
+            }
+        };
+    }
+
+    @Test
+    public void go() {
+        CollaborationPresenterImpl spy = spy(uut);
+        HasOneWidget containerMock = mock(HasOneWidget.class);
+
+        /** CALL METHOD UNDER TEST **/
+        spy.go(containerMock);
+
+        verify(spy).go(eq(containerMock), eq(null));
+        verify(teamPresenterMock).showCheckBoxes();
+    }
+
+    @Test
+    public void go1() {
+        HasOneWidget containerMock = mock(HasOneWidget.class);
+        CollaborationWindowConfig windowConfigMock = mock(CollaborationWindowConfig.class);
+        when(windowConfigMock.getSelectedTab()).thenReturn(CollaborationView.TAB.Teams);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.go(containerMock, windowConfigMock);
+        verify(viewMock).setActiveTab(eq(CollaborationView.TAB.Teams));
+        verify(collabPresenterMock).go();
+        verify(teamPresenterMock).go();
+
+        verify(containerMock).setWidget(eq(viewMock));
+    }
+
+    @Test
+    public void getSelectedCollaborators() {
+        when(collabPresenterMock.getSelectedSubjects()).thenReturn(collabListMock);
+        when(teamPresenterMock.getSelectedTeams()).thenReturn(teamListMock);
+
+        /** CALL METHOD UNDER TEST **/
+        uut.getSelectedCollaborators();
+
+        verify(collabPresenterMock).getSelectedSubjects();
+        verify(teamPresenterMock).getSelectedTeams();
+
+        verify(subjectListMock).addAll(collabListMock);
+        verify(subjectListMock).addAll(teamSubjectListMock);
+    }
+
+}

--- a/de-lib/src/test/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenterTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenterTest.java
@@ -37,7 +37,6 @@ import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.web.bindery.autobean.shared.AutoBean;
@@ -113,7 +112,7 @@ public class ManageCollaboratorsPresenterTest {
 
     @Before
     public void setUp() {
-        when(factoryMock.create(ManageCollaboratorsView.MODE.MANAGE, dndHandlerMock)).thenReturn(viewMock);
+        when(factoryMock.create(dndHandlerMock)).thenReturn(viewMock);
         when(viewMock.asWidget()).thenReturn(viewWidgetMock);
         when(groupMock.getName()).thenReturn("name");
         when(groupFactoryMock.getGroup()).thenReturn(groupAutoBeanMock);
@@ -194,36 +193,28 @@ public class ManageCollaboratorsPresenterTest {
         uut.permissionsDlgProvider = retainPermsDialogProvider;
 
         parentCallback = uut.new ParentDeleteSubjectsCallback();
+
+        addEventHandlers();
     }
 
-    @Test
-    public void go() {
-        when(groupFactoryMock.getDefaultGroup()).thenReturn(groupMock);
-        HasOneWidget containerMock = mock(HasOneWidget.class);
-        ManageCollaboratorsPresenter spy = spy(uut);
-
-        /** CALL METHOD UNDER TEST **/
-        spy.go(containerMock, ManageCollaboratorsView.MODE.MANAGE);
-
-        verify(factoryMock).create(eq(ManageCollaboratorsView.MODE.MANAGE), eq(dndHandlerMock));
-        verify(viewMock).addRemoveCollaboratorSelectedHandler(eq(spy));
-        verify(spy).loadCurrentCollaborators();
-        verify(spy).getGroups();
-        verify(spy).addEventHandlers();
-        verify(containerMock).setWidget(eq(viewWidgetMock));
-    }
-
-    @Test
     public void addEventHandlers() {
-
-        /** CALL METHOD UNDER TEST **/
-        uut.addEventHandlers();
-
         verify(viewMock).addAddGroupSelectedHandler(eq(uut));
         verify(viewMock).addGroupNameSelectedHandler(eq(uut));
         verify(viewMock).addUserSearchResultSelectedEventHandler(eq(uut));
         verify(viewMock).addRemoveCollaboratorSelectedHandler(eq(uut));
     }
+
+    @Test
+    public void go() {
+        ManageCollaboratorsPresenter spy = spy(uut);
+
+        /** CALL METHOD UNDER TEST **/
+        spy.go();
+
+        verify(spy).loadCurrentCollaborators();
+        verify(spy).getGroups();
+    }
+
 
     @Test
     public void addAsCollaborators() {
@@ -365,14 +356,6 @@ public class ManageCollaboratorsPresenterTest {
         verify(viewMock).unmaskCollaborators();
         verify(viewMock).addCollaborators(eq(subjectListMock));
         verify(eventBusMock).fireEvent(isA(CollaboratorsLoadedEvent.class));
-    }
-
-    @Test
-    public void setCurrentMode() {
-
-        /** CALL METHOD UNDER TEST **/
-        uut.setCurrentMode(ManageCollaboratorsView.MODE.SELECT);
-        verify(viewMock).setMode(eq(ManageCollaboratorsView.MODE.SELECT));
     }
 
     @Test

--- a/de-lib/src/test/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImplTest.java
@@ -122,7 +122,7 @@ public class TeamsPresenterImplTest {
 
         /** CALL METHOD UNDER TEST **/
         spy.go();
-        verify(spy).getSelectedTeams();
+        verify(spy).getFilteredTeams();
     }
 
     @Test
@@ -159,7 +159,7 @@ public class TeamsPresenterImplTest {
 
         /** CALL METHOD UNDER TEST **/
         spy.onTeamFilterSelectionChanged(eventMock);
-        verify(spy, times(0)).getSelectedTeams();
+        verify(spy, times(0)).getFilteredTeams();
     }
 
     @Test
@@ -171,7 +171,7 @@ public class TeamsPresenterImplTest {
 
         /** CALL METHOD UNDER TEST **/
         spy.onTeamFilterSelectionChanged(eventMock);
-        verify(spy).getSelectedTeams();
+        verify(spy).getFilteredTeams();
     }
 
     @Test
@@ -180,7 +180,7 @@ public class TeamsPresenterImplTest {
         spy.currentFilter = TeamsFilter.ALL;
 
         /** CALL METHOD UNDER TEST **/
-        spy.getSelectedTeams();
+        spy.getFilteredTeams();
         verify(spy).getAllTeams();
     }
 
@@ -190,7 +190,7 @@ public class TeamsPresenterImplTest {
         spy.currentFilter = TeamsFilter.MY_TEAMS;
 
         /** CALL METHOD UNDER TEST **/
-        spy.getSelectedTeams();
+        spy.getFilteredTeams();
         verify(spy).getMyTeams();
     }
 

--- a/de-webapp/src/main/java/org/iplantc/de/admin/client/gin/BelphegorAppInjector.java
+++ b/de-webapp/src/main/java/org/iplantc/de/admin/client/gin/BelphegorAppInjector.java
@@ -6,12 +6,13 @@ import org.iplantc.de.admin.desktop.client.ontologies.gin.OntologiesGinModule;
 import org.iplantc.de.admin.desktop.client.toolAdmin.gin.ToolAdminGinModule;
 import org.iplantc.de.admin.desktop.client.views.BelphegorView;
 import org.iplantc.de.admin.desktop.client.workshopAdmin.gin.WorkshopAdminGinModule;
-import org.iplantc.de.commons.client.gin.CommonsGinModule;
 import org.iplantc.de.collaborators.client.gin.CollaboratorsGinModule;
 import org.iplantc.de.commons.client.comments.gin.CommentsGinModule;
+import org.iplantc.de.commons.client.gin.CommonsGinModule;
 import org.iplantc.de.diskResource.client.gin.DiskResourceGinModule;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.tags.client.gin.TagsGinModule;
+import org.iplantc.de.teams.client.gin.TeamsGinModule;
 
 import com.google.gwt.inject.client.GinModules;
 import com.google.gwt.inject.client.Ginjector;
@@ -25,6 +26,7 @@ import com.google.gwt.inject.client.Ginjector;
               DiskResourceGinModule.class,
               CommonsGinModule.class,
               CollaboratorsGinModule.class,
+              TeamsGinModule.class,
               CommentsGinModule.class,
               TagsGinModule.class,
               ToolAdminGinModule.class,


### PR DESCRIPTION
NOTE: This is a branch on top of branches.  The commits for this PR start with `CORE-8992 Create overarching CollaborationView and presenter for Collaboration window`

This PR enables teams in the UI.  That means the Collaboration window now has the final view from the mock ups.  I also created an overarching CollaborationView and Presenter which stitch together the Collaborators and Teams views into tabs.  This way, the `ManageCollaboratorsView` and `TeamsView` can be self-contained views and re-used individually if needed.

![image](https://user-images.githubusercontent.com/8909156/30081473-31e3a57e-923c-11e7-9572-6ebf22a76c54.png)
