### PR TITLE
Make the NewToolRequestDialog use an AsyncProviderWrapper

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/toolBar/AppsToolbarPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/toolBar/AppsToolbarPresenterImpl.java
@@ -71,7 +71,7 @@ public class AppsToolbarPresenterImpl implements AppsToolbarView.Presenter,
     @Inject
     EventBus eventBus;
     @Inject
-    Provider<NewToolRequestDialog> newToolRequestDialogProvider;
+    AsyncProviderWrapper<NewToolRequestDialog> newToolRequestDialogProvider;
     @Inject
     AsyncProviderWrapper<AppSharingDialog> appSharingDialogProvider;
     @Inject
@@ -169,7 +169,17 @@ public class AppsToolbarPresenterImpl implements AppsToolbarView.Presenter,
 
     @Override
     public void onRequestToolSelected(RequestToolSelected event) {
-        newToolRequestDialogProvider.get().show(NewToolRequestFormView.Mode.NEWTOOL);
+        newToolRequestDialogProvider.get(new AsyncCallback<NewToolRequestDialog>() {
+            @Override
+            public void onFailure(Throwable caught) {
+
+            }
+
+            @Override
+            public void onSuccess(NewToolRequestDialog result) {
+                result.show(NewToolRequestFormView.Mode.NEWTOOL);
+            }
+        });
     }
 
     @Override

--- a/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/toolBar/AppsToolbarPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/apps/client/presenter/toolBar/AppsToolbarPresenterImplTest.java
@@ -66,7 +66,13 @@ public class AppsToolbarPresenterImplTest {
     @Mock EventBus eventBusMock;
 
     @Captor ArgumentCaptor<DECallback<String>> stringCallbackCaptor;
-    @Mock Provider<NewToolRequestDialog> requestToolDlgProviderMock;
+
+    @Mock
+    AsyncProviderWrapper<NewToolRequestDialog> newToolRequestDialogProviderMock;
+    @Captor
+    ArgumentCaptor<AsyncCallback<NewToolRequestDialog>> newToolDialogCaptor;
+    @Mock
+    NewToolRequestDialog toolRequestMock;
 
     @Mock
     AsyncProviderWrapper<SubmitAppForPublicDialog> submitAppDialogAsyncProviderMock;
@@ -90,7 +96,7 @@ public class AppsToolbarPresenterImplTest {
         };
         uut.eventBus = eventBusMock;
         uut.userInfo = userInfoMock;
-        uut.newToolRequestDialogProvider = requestToolDlgProviderMock;
+        uut.newToolRequestDialogProvider = newToolRequestDialogProviderMock;
         uut.submitAppDialogAsyncProvider = submitAppDialogAsyncProviderMock;
         uut.appearance = appearanceMock;
     }
@@ -197,17 +203,17 @@ public class AppsToolbarPresenterImplTest {
 
     @Test public void verifyToolRequestDlgShown_onRequestToolSelected() {
         RequestToolSelected eventMock = mock(RequestToolSelected.class);
-        NewToolRequestDialog dlgMock = mock(NewToolRequestDialog.class);
-        when(requestToolDlgProviderMock.get()).thenReturn(dlgMock);
 
         /*** CALL METHOD UNDER TEST ***/
         uut.onRequestToolSelected(eventMock);
 
-        verify(requestToolDlgProviderMock).get();
-        verify(dlgMock).show(NewToolRequestFormView.Mode.NEWTOOL);
+        verify(newToolRequestDialogProviderMock).get(newToolDialogCaptor.capture());
+        newToolDialogCaptor.getValue().onSuccess(toolRequestMock);
 
-        verifyNoMoreInteractions(dlgMock,
-                                 requestToolDlgProviderMock,
+        verify(toolRequestMock).show(NewToolRequestFormView.Mode.NEWTOOL);
+
+        verifyNoMoreInteractions(toolRequestMock,
+                                 newToolRequestDialogProviderMock,
                                  eventMock);
 
         verifyZeroInteractions(eventBusMock,


### PR DESCRIPTION
This was already doing it one place, I just fixed it the other place. The other convenience is this let me copy the tests from the other place, but that's still the thing I'd like the most review on!

(I wanted a bit of a break from thinking about ops/thinking in Go, and code splits are something perpetually available to work on, hence this PR, heh)