### PR TITLE
DE-1164 Fix logic for comparing Sharing equality

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/sharing/Sharing.java
@@ -95,13 +95,23 @@ public class Sharing {
         return displayPermission;
     }
 
+    /**
+     * Two shares are equal if and only if
+     * - The user ID is the same
+     * - The resource ID is the same
+     * - The permission is the same
+     * @param o
+     * @return
+     */
     @Override
     public boolean equals(Object o) {
         if (o == null || !(o instanceof Sharing)) {
             return false;
         }
         Sharing s = (Sharing)o;
-        return getKey().equals(s.getKey()) && s.getDisplayPermission().equals(getDisplayPermission());
+        return getKey().equals(s.getKey()) &&
+               getId().equals(s.getId()) &&
+               s.getDisplayPermission().equals(getDisplayPermission());
     }
 
     public Sharing copy() {


### PR DESCRIPTION
The `equals` logic was slightly incorrect because it was only checking if the user and the permission value were the same between two `Sharing` objects.  However, in the case we just discovered where a user may want to change the permissions for multiple files at a time for one user, it is necessary to check the user, the permission value, and also that the resource is the same between the two objects being compared.