### PR TITLE
CORE-9000 + CORE-9001: Add 'Unified Astronomy Thesaurus' ontology term autocomplete support to DE and Belphegor Metadata Template forms

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
@@ -356,6 +356,7 @@ public class EditMetadataTemplateViewImpl extends Composite implements IsWidget,
                                     MetadataTemplateAttributeType.MULTILINE.toString(),
                                     MetadataTemplateAttributeType.URL.toString(),
                                     MetadataTemplateAttributeType.OLS_ONTOLOGY_TERM.toString(),
+                                    MetadataTemplateAttributeType.UAT_ONTOLOGY_TERM.toString(),
                                     MetadataTemplateAttributeType.ENUM.toString()));
         typeCombo.setValue(MetadataTemplateAttributeType.STRING.toString());
         typeCombo.setEditable(false);

--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateAttributeType.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/MetadataTemplateAttributeType.java
@@ -14,6 +14,7 @@ public enum MetadataTemplateAttributeType {
     OLS_ONTOLOGY_TERM("OLS Ontology Term"),
     STRING("String"),
     TIMESTAMP("Timestamp"),
+    UAT_ONTOLOGY_TERM("UAT Ontology Term"),
     URL("URL/URI");
 
     private String label;

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/AstroThesaurusDoc.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/AstroThesaurusDoc.java
@@ -1,0 +1,38 @@
+package org.iplantc.de.client.models.ontologies;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+/**
+ * {@link MetadataTermSearchResult} model for Unified Astronomy Thesaurus search results.
+ *
+ * @author psarando
+ */
+public interface AstroThesaurusDoc extends MetadataTermSearchResult {
+    /**
+     * @return UAT search results only include an IRI, so this model's ID will be the same as its IRI.
+     */
+    @PropertyName("_about")
+    String getId();
+
+    /**
+     * @return UAT search results only include an IRI, so this model's ID will be the same as its IRI.
+     */
+    @PropertyName("_about")
+    String getIri();
+
+    /**
+     * @param iri UAT search results only include an IRI, so updating this IRI also updates the ID.
+     */
+    @PropertyName("_about")
+    void setIri(String iri);
+
+    /**
+     * @return The label object for Unified Astronomy Thesaurus search results.
+     */
+    AstroThesaurusDocLabel getPrefLabel();
+
+    /**
+     * @param label The label object for Unified Astronomy Thesaurus search results.
+     */
+    void setPrefLabel(AstroThesaurusDocLabel label);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/AstroThesaurusDocLabel.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/AstroThesaurusDocLabel.java
@@ -1,0 +1,23 @@
+package org.iplantc.de.client.models.ontologies;
+
+import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
+
+/**
+ * An AutoBean model for Unified Astronomy Thesaurus search result labels.
+ *
+ * @author psarando
+ */
+public interface AstroThesaurusDocLabel {
+
+    /**
+     * @return The string value of the label.
+     */
+    @PropertyName("_value")
+    String getValue();
+
+    /**
+     * @param label The string value of the label.
+     */
+    @PropertyName("_value")
+    void setValue(String label);
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/AstroThesaurusResponse.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/AstroThesaurusResponse.java
@@ -1,0 +1,13 @@
+package org.iplantc.de.client.models.ontologies;
+
+/**
+ * An AutoBean model for Unified Astronomy Thesaurus search responses.
+ *
+ * @author psarando
+ */
+public interface AstroThesaurusResponse {
+    /**
+     * @return The UAT search results.
+     */
+    AstroThesaurusResult getResult();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/AstroThesaurusResult.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/AstroThesaurusResult.java
@@ -1,0 +1,25 @@
+package org.iplantc.de.client.models.ontologies;
+
+import java.util.List;
+
+/**
+ * An AutoBean model for Unified Astronomy Thesaurus search results.
+ *
+ * @author psarando
+ */
+public interface AstroThesaurusResult {
+    /**
+     * @return The current page of results returned.
+     */
+    int getPage();
+
+    /**
+     * @return The start index of results returned.
+     */
+    int getStartIndex();
+
+    /**
+     * @return The list of UAT search result items.
+     */
+    List<AstroThesaurusDoc> getItems();
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/MetadataTermSearchResult.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/MetadataTermSearchResult.java
@@ -1,0 +1,11 @@
+package org.iplantc.de.client.models.ontologies;
+
+import org.iplantc.de.client.models.HasId;
+
+/**
+ * {@link OntologyClass} model for ontology service search results.
+ *
+ * @author psarando
+ */
+public interface MetadataTermSearchResult extends OntologyClass, HasId {
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyAutoBeanFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyAutoBeanFactory.java
@@ -26,5 +26,9 @@ public interface OntologyAutoBeanFactory extends AutoBeanFactory {
 
     AutoBean<OntologyLookupServiceDoc> getOntologyLookupServiceDoc();
 
+    AutoBean<AstroThesaurusDoc> getAstroThesaurusDoc();
+
+    AutoBean<AstroThesaurusResponse> getAstroThesaurusResponse();
+
     AutoBean<OntologyLookupServiceQueryParams> getOntologyLookupServiceQueryParams();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyAutoBeanFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyAutoBeanFactory.java
@@ -20,6 +20,8 @@ public interface OntologyAutoBeanFactory extends AutoBeanFactory {
 
     AutoBean<OntologyVersionDetail> getVersionDetail();
 
+    AutoBean<MetadataTermSearchResult> getMetadataTermSearchResult();
+
     AutoBean<OntologyLookupServiceResponse> getOntologyLookupServiceResponse();
 
     AutoBean<OntologyLookupServiceDoc> getOntologyLookupServiceDoc();

--- a/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceDoc.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/ontologies/OntologyLookupServiceDoc.java
@@ -1,7 +1,5 @@
 package org.iplantc.de.client.models.ontologies;
 
-import org.iplantc.de.client.models.HasId;
-
 import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
 
 /**
@@ -9,7 +7,7 @@ import com.google.web.bindery.autobean.shared.AutoBean.PropertyName;
  *
  * @author psarando
  */
-public interface OntologyLookupServiceDoc extends OntologyClass, HasId {
+public interface OntologyLookupServiceDoc extends MetadataTermSearchResult {
     @PropertyName("ontology_prefix")
     String getOntologyPrefix();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/OntologyLookupServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/OntologyLookupServiceFacade.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.client.services;
 
+import org.iplantc.de.client.models.ontologies.AstroThesaurusResponse;
 import org.iplantc.de.client.models.ontologies.OntologyLookupServiceResponse;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.AstroThesaurusLoadConfig;
 import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceLoadConfig;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -20,4 +22,6 @@ public interface OntologyLookupServiceFacade {
      * @param callback The OLS search response callback.
      */
     void searchOntologyLookupService(OntologyLookupServiceLoadConfig loadConfig, AsyncCallback<OntologyLookupServiceResponse> callback);
+
+    void searchUnifiedAstronomyThesaurus(AstroThesaurusLoadConfig loadConfig, AsyncCallback<AstroThesaurusResponse> callback);
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/OntologyLookupServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/OntologyLookupServiceFacadeImpl.java
@@ -2,10 +2,13 @@ package org.iplantc.de.client.services.impl;
 
 import static org.iplantc.de.shared.services.BaseServiceCallWrapper.Type.GET;
 
+import org.iplantc.de.client.models.ontologies.AstroThesaurusResponse;
 import org.iplantc.de.client.models.ontologies.OntologyAutoBeanFactory;
 import org.iplantc.de.client.models.ontologies.OntologyLookupServiceResponse;
 import org.iplantc.de.client.services.OntologyLookupServiceFacade;
 import org.iplantc.de.client.services.converters.AsyncCallbackConverter;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.AstroThesaurusLoadConfig;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.MetadataTermLoadConfig;
 import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceLoadConfig;
 import org.iplantc.de.shared.services.DiscEnvApiService;
 import org.iplantc.de.shared.services.ServiceCallWrapper;
@@ -23,6 +26,7 @@ import java.util.stream.Collectors;
 
 public class OntologyLookupServiceFacadeImpl implements OntologyLookupServiceFacade {
     private static final String OLS_BASE_URL = "org.iplantc.services.ontology-lookup-service.base";
+    private static final String UAT_BASE_URL = "org.iplantc.services.unified-astronomy-thesaurus.base";
 
     @Inject OntologyAutoBeanFactory factory;
     @Inject private DiscEnvApiService deService;
@@ -32,6 +36,39 @@ public class OntologyLookupServiceFacadeImpl implements OntologyLookupServiceFac
         List<String> queryParams = Lists.newArrayList("rows=" + loadConfig.getLimit(),
                                                       "start=" + loadConfig.getOffset());
 
+        AsyncCallbackConverter<String, OntologyLookupServiceResponse> callbackConverter =
+                new AsyncCallbackConverter<String, OntologyLookupServiceResponse>(callback) {
+                    @Override
+                    protected OntologyLookupServiceResponse convertFrom(String response) {
+                        return AutoBeanCodex.decode(factory, OntologyLookupServiceResponse.class, response).as();
+                    }
+                };
+
+        searchMetadataService(OLS_BASE_URL, queryParams, loadConfig, callbackConverter);
+    }
+
+    @Override
+    public void searchUnifiedAstronomyThesaurus(AstroThesaurusLoadConfig loadConfig,
+                                                AsyncCallback<AstroThesaurusResponse> callback) {
+        // UAT responses do not include a 'total' number of results,
+        // so we can't properly support paging.
+        List<String> queryParams = Lists.newArrayList("_pageSize=" + loadConfig.getLimit());
+
+        AsyncCallbackConverter<String, AstroThesaurusResponse> callbackConverter =
+                new AsyncCallbackConverter<String, AstroThesaurusResponse>(callback) {
+                    @Override
+                    protected AstroThesaurusResponse convertFrom(String response) {
+                        return AutoBeanCodex.decode(factory, AstroThesaurusResponse.class, response).as();
+                    }
+                };
+
+        searchMetadataService(UAT_BASE_URL, queryParams, loadConfig, callbackConverter);
+    }
+
+    private void searchMetadataService(String baseURL,
+                                       List<String> queryParams,
+                                       MetadataTermLoadConfig loadConfig,
+                                       AsyncCallback<String> callback) {
         if (loadConfig.getFilters() != null) {
             queryParams.addAll(loadConfig.getFilters()
                                          .stream()
@@ -43,14 +80,9 @@ public class OntologyLookupServiceFacadeImpl implements OntologyLookupServiceFac
 
         String queryString = Joiner.on('&').join(queryParams);
 
-        String address = OLS_BASE_URL + "?" + queryString;
+        String address = baseURL + "?" + queryString;
 
         ServiceCallWrapper wrapper = new ServiceCallWrapper(GET, address);
-        deService.getServiceData(wrapper, new AsyncCallbackConverter<String, OntologyLookupServiceResponse>(callback) {
-            @Override
-            protected OntologyLookupServiceResponse convertFrom(String response) {
-                return AutoBeanCodex.decode(factory, OntologyLookupServiceResponse.class, response).as();
-            }
-        });
+        deService.getServiceData(wrapper, callback);
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/SearchField.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/widgets/SearchField.java
@@ -12,7 +12,12 @@ import com.google.gwt.event.dom.client.KeyUpHandler;
 
 import com.sencha.gxt.cell.core.client.form.TextInputCell;
 import com.sencha.gxt.core.client.util.DelayedTask;
-import com.sencha.gxt.data.shared.loader.*;
+import com.sencha.gxt.data.shared.loader.FilterConfig;
+import com.sencha.gxt.data.shared.loader.FilterConfigBean;
+import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfig;
+import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfigBean;
+import com.sencha.gxt.data.shared.loader.PagingLoadResult;
+import com.sencha.gxt.data.shared.loader.PagingLoader;
 import com.sencha.gxt.widget.core.client.form.TextField;
 
 import java.util.ArrayList;

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/AstroThesaurusLoadConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/AstroThesaurusLoadConfig.java
@@ -1,0 +1,57 @@
+package org.iplantc.de.diskResource.client.presenters.metadata.proxy;
+
+import com.sencha.gxt.core.shared.FastMap;
+import com.sencha.gxt.data.shared.loader.FilterConfig;
+import com.sencha.gxt.data.shared.loader.FilterConfigBean;
+
+/**
+ * {@link MetadataTermLoadConfig} for the Unified Astronomy Thesaurus `concept` endpoint:
+ * https://documentation.ands.org.au/display/DOC/Linked+Data+API
+ *
+ * @author psarando
+ */
+public class AstroThesaurusLoadConfig extends MetadataTermLoadConfig {
+    private static final String FILTER_FIELD_QUERY = "labelcontains";
+    private static final String FILTER_FIELD_SORT = "_sort";
+
+    private FastMap<FilterConfig> filterConfigMap = new FastMap<>();
+
+    public AstroThesaurusLoadConfig() {
+        filterConfigMap.put(FILTER_FIELD_QUERY, new FilterConfigBean());
+        filterConfigMap.put(FILTER_FIELD_SORT, new FilterConfigBean());
+
+        filterConfigMap.forEach((key, filterConfig) -> filterConfig.setField(key));
+
+        getFilters().addAll(filterConfigMap.values());
+    }
+
+    /**
+     * @return The user's search term.
+     */
+    public String getQuery() {
+        return filterConfigMap.get(FILTER_FIELD_QUERY).getValue();
+    }
+
+    /**
+     * @param query The user's search term.
+     */
+    public void setQuery(String query) {
+        filterConfigMap.get(FILTER_FIELD_QUERY).setValue(query);
+    }
+
+    /**
+     * @return A comma-separated list of property paths to values that should be sorted on.
+     *         A `-` prefix on a property path indicates a descending search.
+     */
+    public String getSort() {
+        return filterConfigMap.get(FILTER_FIELD_QUERY).getValue();
+    }
+
+    /**
+     * @param sort A comma-separated list of property paths to values that should be sorted on.
+     *             A `-` prefix on a property path indicates a descending search.
+     */
+    public void setSort(String sort) {
+        filterConfigMap.get(FILTER_FIELD_QUERY).setValue(sort);
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/AstroThesaurusProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/AstroThesaurusProxy.java
@@ -1,0 +1,77 @@
+package org.iplantc.de.diskResource.client.presenters.metadata.proxy;
+
+import org.iplantc.de.client.models.ontologies.AstroThesaurusDoc;
+import org.iplantc.de.client.models.ontologies.AstroThesaurusResponse;
+import org.iplantc.de.client.models.ontologies.MetadataTermSearchResult;
+import org.iplantc.de.client.services.OntologyLookupServiceFacade;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.inject.Inject;
+
+import com.sencha.gxt.core.shared.FastMap;
+import com.sencha.gxt.data.shared.loader.PagingLoadResult;
+import com.sencha.gxt.data.shared.loader.PagingLoadResultBean;
+
+import java.util.List;
+
+/**
+ * {@link MetadataTermSearchProxy} that calls the Unified Astronomy Thesaurus service.
+ *
+ * @author psarando
+ */
+public class AstroThesaurusProxy extends MetadataTermSearchProxy {
+
+    OntologyLookupServiceFacade svcFacade;
+
+    @Inject
+    public AstroThesaurusProxy(OntologyLookupServiceFacade svcFacade) {
+        this.svcFacade = svcFacade;
+    }
+
+    @Override
+    public void load(MetadataTermLoadConfig loadConfig,
+                     AsyncCallback<PagingLoadResult<MetadataTermSearchResult>> callback) {
+        String queryText = loadConfig.getQuery();
+
+        if (Strings.isNullOrEmpty(queryText)) {
+            // nothing to search
+            callback.onSuccess(new PagingLoadResultBean<>());
+
+            return;
+        }
+
+        AstroThesaurusLoadConfig uatLoadConfig = (AstroThesaurusLoadConfig)loadConfig;
+
+        svcFacade.searchUnifiedAstronomyThesaurus(uatLoadConfig, new AsyncCallback<AstroThesaurusResponse>() {
+            @Override
+            public void onSuccess(AstroThesaurusResponse result) {
+                List<AstroThesaurusDoc> astroTerms = result.getResult().getItems();
+
+                // The UAT service may return duplicates in the results.
+                FastMap<AstroThesaurusDoc> filteredResults = new FastMap<>();
+
+                astroTerms.forEach(item -> {
+                    if (!Strings.isNullOrEmpty(item.getId())) {
+                        filteredResults.put(item.getId(), item);
+
+                        // flatten label
+                        item.setLabel(item.getPrefLabel().getValue());
+                    }
+                });
+
+                List<MetadataTermSearchResult> results = Lists.newArrayList(filteredResults.values());
+
+                // UAT responses do not include a 'total' number of results,
+                // so we can't properly support paging.
+                callback.onSuccess(new PagingLoadResultBean<>(results, results.size(), 0));
+            }
+
+            @Override
+            public void onFailure(Throwable caught) {
+                callback.onFailure(caught);
+            }
+        });
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/MetadataTermLoadConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/MetadataTermLoadConfig.java
@@ -1,0 +1,27 @@
+package org.iplantc.de.diskResource.client.presenters.metadata.proxy;
+
+import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfigBean;
+
+/**
+ * {@link FilterPagingLoadConfigBean} for ontology term search services.
+ *
+ * @author psarando
+ */
+public class MetadataTermLoadConfig extends FilterPagingLoadConfigBean {
+
+    private String query;
+
+    /**
+     * @return The user's search term.
+     */
+    public String getQuery() {
+        return query;
+    }
+
+    /**
+     * @param query The user's search term.
+     */
+    public void setQuery(String query) {
+        this.query = query;
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/MetadataTermSearchProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/MetadataTermSearchProxy.java
@@ -1,0 +1,16 @@
+package org.iplantc.de.diskResource.client.presenters.metadata.proxy;
+
+import org.iplantc.de.client.models.ontologies.MetadataTermSearchResult;
+
+import com.sencha.gxt.data.client.loader.RpcProxy;
+import com.sencha.gxt.data.shared.loader.PagingLoadResult;
+
+/**
+ * Metadata term {@link RpcProxy} that calls a search service with a given
+ * {@link MetadataTermLoadConfig} and {@link PagingLoadResult} callback.
+ *
+ * @author psarando
+ */
+abstract public class MetadataTermSearchProxy
+        extends RpcProxy<MetadataTermLoadConfig, PagingLoadResult<MetadataTermSearchResult>> {
+}

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceLoadConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceLoadConfig.java
@@ -9,18 +9,17 @@ import com.google.common.base.Strings;
 import com.sencha.gxt.core.shared.FastMap;
 import com.sencha.gxt.data.shared.loader.FilterConfig;
 import com.sencha.gxt.data.shared.loader.FilterConfigBean;
-import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfigBean;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Search config for the Ontology Lookup Service `select` endpoint:
+ * {@link MetadataTermLoadConfig} for the Ontology Lookup Service `select` endpoint:
  * http://www.ebi.ac.uk/ols/docs/api#_select_terms
  *
  * @author psarando
  */
-public class OntologyLookupServiceLoadConfig extends FilterPagingLoadConfigBean {
+public class OntologyLookupServiceLoadConfig extends MetadataTermLoadConfig {
     private static final String FILTER_FIELD_QUERY = "q";
     private static final String FILTER_FIELD_RESPONSE_FIELDS = "fieldList";
 
@@ -74,6 +73,7 @@ public class OntologyLookupServiceLoadConfig extends FilterPagingLoadConfigBean 
     /**
      * @return The user's search term.
      */
+    @Override
     public String getQuery() {
         return filterConfigMap.get(FILTER_FIELD_QUERY).getValue();
     }
@@ -81,6 +81,7 @@ public class OntologyLookupServiceLoadConfig extends FilterPagingLoadConfigBean 
     /**
      * @param query The user's search term.
      */
+    @Override
     public void setQuery(String query) {
         filterConfigMap.get(FILTER_FIELD_QUERY).setValue(query);
     }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/metadata/proxy/OntologyLookupServiceProxy.java
@@ -1,24 +1,26 @@
 package org.iplantc.de.diskResource.client.presenters.metadata.proxy;
 
-import org.iplantc.de.client.models.ontologies.OntologyLookupServiceDoc;
+import org.iplantc.de.client.models.ontologies.MetadataTermSearchResult;
 import org.iplantc.de.client.models.ontologies.OntologyLookupServiceResponse;
 import org.iplantc.de.client.models.ontologies.OntologyLookupServiceResults;
 import org.iplantc.de.client.services.OntologyLookupServiceFacade;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
-import com.sencha.gxt.data.client.loader.RpcProxy;
 import com.sencha.gxt.data.shared.loader.PagingLoadResult;
 import com.sencha.gxt.data.shared.loader.PagingLoadResultBean;
 
+import java.util.List;
+
 /**
- * Ontology Lookup Service RPC proxy that calls the OLS with a given LoadConfig and LoadResult callback.
+ * {@link MetadataTermSearchProxy} that calls the Ontology Lookup Service.
  *
  * @author psarando
  */
-public class OntologyLookupServiceProxy extends RpcProxy<OntologyLookupServiceLoadConfig, PagingLoadResult<OntologyLookupServiceDoc>> {
+public class OntologyLookupServiceProxy extends MetadataTermSearchProxy {
 
     OntologyLookupServiceFacade svcFacade;
 
@@ -28,7 +30,8 @@ public class OntologyLookupServiceProxy extends RpcProxy<OntologyLookupServiceLo
     }
 
     @Override
-    public void load(OntologyLookupServiceLoadConfig loadConfig, AsyncCallback<PagingLoadResult<OntologyLookupServiceDoc>> callback) {
+    public void load(MetadataTermLoadConfig loadConfig,
+                     AsyncCallback<PagingLoadResult<MetadataTermSearchResult>> callback) {
         String queryText = loadConfig.getQuery();
 
         if (Strings.isNullOrEmpty(queryText)) {
@@ -38,13 +41,13 @@ public class OntologyLookupServiceProxy extends RpcProxy<OntologyLookupServiceLo
             return;
         }
 
-        svcFacade.searchOntologyLookupService(loadConfig, new AsyncCallback<OntologyLookupServiceResponse>() {
+        OntologyLookupServiceLoadConfig olsLoadConfig = (OntologyLookupServiceLoadConfig)loadConfig;
+        svcFacade.searchOntologyLookupService(olsLoadConfig, new AsyncCallback<OntologyLookupServiceResponse>() {
             @Override
             public void onSuccess(OntologyLookupServiceResponse response) {
                 OntologyLookupServiceResults results = response.getResults();
-                callback.onSuccess(new PagingLoadResultBean<>(results.getClasses(),
-                                                              results.getTotal(),
-                                                              results.getOffset()));
+                List<MetadataTermSearchResult> resultList = Lists.newArrayList(results.getClasses());
+                callback.onSuccess(new PagingLoadResultBean<>(resultList, results.getTotal(), results.getOffset()));
             }
 
             @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/MetadataTemplateView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/MetadataTemplateView.java
@@ -4,8 +4,8 @@ import org.iplantc.de.client.models.avu.Avu;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateAttribute;
 import org.iplantc.de.client.models.diskResources.MetadataTemplateAttributeType;
 import org.iplantc.de.client.models.diskResources.TemplateAttributeSelectionItem;
+import org.iplantc.de.client.models.ontologies.MetadataTermSearchResult;
 import org.iplantc.de.client.models.ontologies.OntologyClass;
-import org.iplantc.de.client.models.ontologies.OntologyLookupServiceDoc;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.validators.UrlValidator;
 import org.iplantc.de.commons.client.widgets.IPlantAnchor;
@@ -316,8 +316,8 @@ public class MetadataTemplateView implements IsWidget {
         return tf;
     }
 
-    private ComboBox<OntologyLookupServiceDoc> buildOntologyField(String tag, MetadataTemplateAttribute attribute) {
-        ComboBox<OntologyLookupServiceDoc> combo = presenter.createMetadataTermSearchField(attribute).asField();
+    private ComboBox<MetadataTermSearchResult> buildOntologyField(String tag, MetadataTemplateAttribute attribute) {
+        ComboBox<MetadataTermSearchResult> combo = presenter.createMetadataTermSearchField(attribute).asField();
 
         combo.setAllowBlank(!attribute.isRequired());
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/MetadataTemplateView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/MetadataTemplateView.java
@@ -460,6 +460,8 @@ public class MetadataTemplateView implements IsWidget {
             return buildURLField(tag, attribute);
         } else if (MetadataTemplateAttributeType.OLS_ONTOLOGY_TERM.toString().equalsIgnoreCase(type)) {
             return buildOntologyField(tag, attribute);
+        } else if (MetadataTemplateAttributeType.UAT_ONTOLOGY_TERM.toString().equalsIgnoreCase(type)) {
+            return buildOntologyField(tag, attribute);
         } else if (MetadataTemplateAttributeType.ENUM.toString().equalsIgnoreCase(type)) {
             return buildListField(tag, attribute);
         } else {

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/search/MetadataTermSearchField.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/search/MetadataTermSearchField.java
@@ -1,9 +1,9 @@
 package org.iplantc.de.diskResource.client.views.search;
 
+import org.iplantc.de.client.models.ontologies.MetadataTermSearchResult;
 import org.iplantc.de.client.models.ontologies.OntologyAutoBeanFactory;
-import org.iplantc.de.client.models.ontologies.OntologyLookupServiceDoc;
-import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceLoadConfig;
-import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceProxy;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.MetadataTermLoadConfig;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.MetadataTermSearchProxy;
 
 import com.google.common.base.Strings;
 import com.google.gwt.cell.client.AbstractCell;
@@ -31,33 +31,33 @@ import java.util.Comparator;
 
 /**
  * A wrapper class for creating a {@link ComboBox} form field that allows the user to enter any text into the field,
- * by creating a new {@link OntologyLookupServiceDoc} as the field's value which has the user's text as a custom label and no IRI,
+ * by creating a new {@link MetadataTermSearchResult} as the field's value which has the user's text as a custom label and no IRI,
  * but it can also autocomplete text with terms found using the Ontology Lookup Service.
  *
  * This class can also be used as a {@link Converter} for the {@link ComboBox} in a
  * {@link GridRowEditing#addEditor(ColumnConfig, Converter, IsField)} call.
  */
-public class MetadataTermSearchField implements Converter<String, OntologyLookupServiceDoc> {
+public class MetadataTermSearchField implements Converter<String, MetadataTermSearchResult> {
 
     public interface MetadataTermSearchFieldAppearance {
-        void render(Context context, OntologyLookupServiceDoc OntologyLookupServiceDoc, SafeHtmlBuilder sb);
+        void render(Context context, MetadataTermSearchResult OntologyLookupServiceDoc, SafeHtmlBuilder sb);
     }
 
     /**
      * A {@link ComboBoxCell} that allows the user to enter any text into a {@link ComboBox} field,
-     * by creating a new {@link OntologyLookupServiceDoc} as the field's value,
+     * by creating a new {@link MetadataTermSearchResult} as the field's value,
      * which has the user's text as a custom label and no IRI.
      */
-    private class FreeTextComboBoxCell extends ComboBoxCell<OntologyLookupServiceDoc> {
-        FreeTextComboBoxCell(ListStore<OntologyLookupServiceDoc> store, ListView<OntologyLookupServiceDoc, OntologyLookupServiceDoc> view) {
-            super(store, OntologyLookupServiceDoc::getLabel, view);
+    private class FreeTextComboBoxCell extends ComboBoxCell<MetadataTermSearchResult> {
+        FreeTextComboBoxCell(ListStore<MetadataTermSearchResult> store, ListView<MetadataTermSearchResult, MetadataTermSearchResult> view) {
+            super(store, MetadataTermSearchResult::getLabel, view);
 
-            setPropertyEditor(new PropertyEditor<OntologyLookupServiceDoc>() {
+            setPropertyEditor(new PropertyEditor<MetadataTermSearchResult>() {
                 @Override
-                public OntologyLookupServiceDoc parse(CharSequence text) throws ParseException {
+                public MetadataTermSearchResult parse(CharSequence text) throws ParseException {
                     String label = text == null ? "" : text.toString();
 
-                    OntologyLookupServiceDoc selectedClass = getByValue(label);
+                    MetadataTermSearchResult selectedClass = getByValue(label);
 
                     if (selectedClass == null) {
                         selectedClass = convertModelValue(label);
@@ -67,7 +67,7 @@ public class MetadataTermSearchField implements Converter<String, OntologyLookup
                 }
 
                 @Override
-                public String render(OntologyLookupServiceDoc object) {
+                public String render(MetadataTermSearchResult object) {
                     return object.getLabel();
                 }
             });
@@ -76,38 +76,38 @@ public class MetadataTermSearchField implements Converter<String, OntologyLookup
 
     private final OntologyAutoBeanFactory factory;
 
-    private ComboBox<OntologyLookupServiceDoc> combo;
-    private ListView<OntologyLookupServiceDoc, OntologyLookupServiceDoc> view;
+    private ComboBox<MetadataTermSearchResult> combo;
+    private ListView<MetadataTermSearchResult, MetadataTermSearchResult> view;
 
     public MetadataTermSearchField(OntologyAutoBeanFactory factory,
-                                   OntologyLookupServiceProxy searchProxy,
-                                   OntologyLookupServiceLoadConfig loadConfig,
+                                   MetadataTermSearchProxy searchProxy,
+                                   MetadataTermLoadConfig loadConfig,
                                    MetadataTermSearchFieldAppearance appearance) {
         this.factory = factory;
 
-        ListStore<OntologyLookupServiceDoc> store = new ListStore<>(OntologyLookupServiceDoc::getId);
-        store.addSortInfo(new Store.StoreSortInfo<>(Comparator.comparing(OntologyLookupServiceDoc::getLabel), SortDir.ASC));
+        ListStore<MetadataTermSearchResult> store = new ListStore<>(MetadataTermSearchResult::getId);
+        store.addSortInfo(new Store.StoreSortInfo<>(Comparator.comparing(MetadataTermSearchResult::getLabel), SortDir.ASC));
 
         createView(store, appearance);
 
         createCombo(store, createLoader(searchProxy, loadConfig, store));
     }
 
-    private void createView(ListStore<OntologyLookupServiceDoc> store, MetadataTermSearchFieldAppearance appearance) {
+    private void createView(ListStore<MetadataTermSearchResult> store, MetadataTermSearchFieldAppearance appearance) {
         view = new ListView<>(store, new IdentityValueProvider<>());
-        view.setCell(new AbstractCell<OntologyLookupServiceDoc>() {
+        view.setCell(new AbstractCell<MetadataTermSearchResult>() {
             @Override
-            public void render(Context context, OntologyLookupServiceDoc value, SafeHtmlBuilder sb) {
+            public void render(Context context, MetadataTermSearchResult value, SafeHtmlBuilder sb) {
                 appearance.render(context, value, sb);
             }
         });
     }
 
-    private PagingLoader<OntologyLookupServiceLoadConfig, PagingLoadResult<OntologyLookupServiceDoc>> createLoader(
-            OntologyLookupServiceProxy searchProxy,
-            OntologyLookupServiceLoadConfig loadConfig,
-            ListStore<OntologyLookupServiceDoc> store) {
-        PagingLoader<OntologyLookupServiceLoadConfig, PagingLoadResult<OntologyLookupServiceDoc>> loader =
+    private PagingLoader<MetadataTermLoadConfig, PagingLoadResult<MetadataTermSearchResult>> createLoader(
+            MetadataTermSearchProxy searchProxy,
+            MetadataTermLoadConfig loadConfig,
+            ListStore<MetadataTermSearchResult> store) {
+        PagingLoader<MetadataTermLoadConfig, PagingLoadResult<MetadataTermSearchResult>> loader =
                 new PagingLoader<>(searchProxy);
 
         loader.useLoadConfig(loadConfig);
@@ -124,8 +124,8 @@ public class MetadataTermSearchField implements Converter<String, OntologyLookup
         return loader;
     }
 
-    private void createCombo(ListStore<OntologyLookupServiceDoc> store,
-                             PagingLoader<OntologyLookupServiceLoadConfig, PagingLoadResult<OntologyLookupServiceDoc>> loader) {
+    private void createCombo(ListStore<MetadataTermSearchResult> store,
+                             PagingLoader<MetadataTermLoadConfig, PagingLoadResult<MetadataTermSearchResult>> loader) {
         combo = new ComboBox<>(new FreeTextComboBoxCell(store, view));
         combo.setLoader(loader);
         combo.setMinChars(3);
@@ -136,19 +136,19 @@ public class MetadataTermSearchField implements Converter<String, OntologyLookup
     }
 
     @Override
-    public String convertFieldValue(OntologyLookupServiceDoc object) {
+    public String convertFieldValue(MetadataTermSearchResult object) {
         return object == null ? null : object.getLabel();
     }
 
     @Override
-    public OntologyLookupServiceDoc convertModelValue(String label) {
-        OntologyLookupServiceDoc customLabel = factory.getOntologyLookupServiceDoc().as();
+    public MetadataTermSearchResult convertModelValue(String label) {
+        MetadataTermSearchResult customLabel = factory.getMetadataTermSearchResult().as();
         customLabel.setLabel(label);
 
         return customLabel;
     }
 
-    public ComboBox<OntologyLookupServiceDoc> asField() {
+    public ComboBox<MetadataTermSearchResult> asField() {
         return combo;
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/server/auth/BaseUrlConnector.java
+++ b/de-lib/src/main/java/org/iplantc/de/server/auth/BaseUrlConnector.java
@@ -14,6 +14,7 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.params.HttpClientParams;
 import org.apache.http.client.utils.URIBuilder;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -25,6 +26,8 @@ import javax.servlet.http.HttpServletRequest;
  * Performs actions common to most URL connectors.
  */
 abstract class BaseUrlConnector implements UrlConnector {
+
+    @Value("${org.iplantc.discoveryenvironment.unprotectedMuleServiceBaseUrl}") private String terrainBaseUrl;
 
     private AppLoggerUtil appLoggerUtil = AppLoggerUtil.getInstance();
 
@@ -120,7 +123,11 @@ abstract class BaseUrlConnector implements UrlConnector {
      * @throws IOException if a URI representation is invalid or an encoding error occurs.
      */
     protected String addIpAddress(String uriString, HttpServletRequest request) throws IOException {
-        return addQueryParam(uriString, "ip-address", request.getRemoteAddr());
+        if (uriString.startsWith(terrainBaseUrl)) {
+            return addQueryParam(uriString, "ip-address", request.getRemoteAddr());
+        }
+
+        return uriString;
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/search/MetadataTermSearchFieldDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/search/MetadataTermSearchFieldDefaultAppearance.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.theme.base.client.diskResource.search;
 
+import org.iplantc.de.client.models.ontologies.MetadataTermSearchResult;
 import org.iplantc.de.client.models.ontologies.OntologyLookupServiceDoc;
 import org.iplantc.de.diskResource.client.views.search.MetadataTermSearchField;
 
@@ -28,7 +29,13 @@ public class MetadataTermSearchFieldDefaultAppearance implements MetadataTermSea
     }
 
     @Override
-    public void render(Context context, OntologyLookupServiceDoc ontologyClass, SafeHtmlBuilder sb) {
-        sb.append(template.render(ontologyClass.getIri(), ontologyClass.getLabel(), ontologyClass.getOntologyPrefix()));
+    public void render(Context context, MetadataTermSearchResult ontologyClass, SafeHtmlBuilder sb) {
+        String ontologyPrefix = null;
+
+        if (ontologyClass instanceof OntologyLookupServiceDoc) {
+            ontologyPrefix = ((OntologyLookupServiceDoc)ontologyClass).getOntologyPrefix();
+        }
+
+        sb.append(template.render(ontologyClass.getIri(), ontologyClass.getLabel(), ontologyPrefix));
     }
 }

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/metadata/MetadataPresenterImplTest.java
@@ -7,6 +7,7 @@ import org.iplantc.de.client.models.avu.Avu;
 import org.iplantc.de.client.models.ontologies.OntologyAutoBeanFactory;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.diskResource.client.MetadataView;
+import org.iplantc.de.diskResource.client.presenters.metadata.proxy.AstroThesaurusProxy;
 import org.iplantc.de.diskResource.client.presenters.metadata.proxy.OntologyLookupServiceProxy;
 import org.iplantc.de.diskResource.client.views.search.MetadataTermSearchField;
 
@@ -31,13 +32,20 @@ public class MetadataPresenterImplTest {
     @Mock  DiskResourceServiceFacade drService;
     @Mock  List<Avu> userMdList;
     @Mock OntologyAutoBeanFactory autoBeanFactory;
-    @Mock OntologyLookupServiceProxy olsProxy;
+    @Mock OntologyLookupServiceProxy olsSearchProxy;
+    @Mock AstroThesaurusProxy uatSearchProxy;
     @Mock MetadataTermSearchField.MetadataTermSearchFieldAppearance appearance;
 
     private MetadataPresenterImpl presenter;
+
     @Before
     public void setUp() {
-        presenter = new MetadataPresenterImpl(view, drService, autoBeanFactory, olsProxy, appearance);
+        presenter = new MetadataPresenterImpl(view,
+                                              drService,
+                                              autoBeanFactory,
+                                              olsSearchProxy,
+                                              uatSearchProxy,
+                                              appearance);
     }
 
     @Test

--- a/de.properties.tmpl
+++ b/de.properties.tmpl
@@ -144,6 +144,7 @@ org.iplantc.services.ontologies = {{ key (printf "%s/terrain/base" $base) }}/ont
 # 3rd Party Service URL/Endpoint Settings
 ###############################################################################
 org.iplantc.services.ontology-lookup-service.base = https://www.ebi.ac.uk/ols/api/select
+org.iplantc.services.unified-astronomy-thesaurus.base = https://vocabs.ands.org.au/repository/api/lda/aas/the-unified-astronomy-thesaurus/current/concept.json
 
 ###############################################################################
 # Default workspace App Categories.


### PR DESCRIPTION
This PR will add [Unified Astronomy Thesaurus](https://vocabs.ands.org.au/the-unified-astronomy-thesaurus) ontology term autocomplete support to DE and Belphegor Metadata Template forms.

This Metadata Template attribute field looks and works similar to the "Ontology Lookup Service" attribute field added by cyverse-de/ui#192, except the UAT search service offers much more limited search parameters, so there are no query param settings available for UAT term attributes in Belphegor.

This PR may be easier to review by each individual commit.