### PR TITLE
De 1166 Allow users to manually select index file(s) for genome browsers.

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/DiskResourceErrorAutoBeanFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/DiskResourceErrorAutoBeanFactory.java
@@ -7,20 +7,22 @@ import org.iplantc.de.client.models.errors.diskResources.categories.ErrorDiskRes
 import org.iplantc.de.client.models.errors.diskResources.categories.ErrorDiskResourceRenameCategory;
 import org.iplantc.de.client.models.errors.diskResources.categories.ErrorDuplicateDiskResourceCategory;
 import org.iplantc.de.client.models.errors.diskResources.categories.ErrorGetManifestCategory;
+import org.iplantc.de.client.models.errors.diskResources.categories.ErrorGetStatCategory;
 import org.iplantc.de.client.models.errors.diskResources.categories.ErrorUpdateMetadataCategory;
 
 import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanFactory;
 import com.google.web.bindery.autobean.shared.AutoBeanFactory.Category;
 
-@Category({ErrorDiskResourceCategory.class, 
-    ErrorDiskResourceDeleteCategory.class, 
-    ErrorCreateFolderCategory.class,
-    ErrorDiskResourceMoveCategory.class, 
-    ErrorUpdateMetadataCategory.class,
-    ErrorDuplicateDiskResourceCategory.class,
-    ErrorGetManifestCategory.class,
-    ErrorDiskResourceRenameCategory.class})
+@Category({ ErrorDiskResourceCategory.class,
+            ErrorDiskResourceDeleteCategory.class,
+            ErrorCreateFolderCategory.class,
+            ErrorDiskResourceMoveCategory.class,
+            ErrorUpdateMetadataCategory.class,
+            ErrorDuplicateDiskResourceCategory.class,
+            ErrorGetManifestCategory.class,
+            ErrorDiskResourceRenameCategory.class,
+            ErrorGetStatCategory.class })
 public interface DiskResourceErrorAutoBeanFactory extends AutoBeanFactory {
 
     AutoBean<ErrorDiskResource> errorDiskResource();
@@ -38,4 +40,6 @@ public interface DiskResourceErrorAutoBeanFactory extends AutoBeanFactory {
     AutoBean<ErrorDuplicateDiskResource> errorDuplicateDiskResource();
 
     AutoBean<ErrorGetManifest> errorGetManifest();
+
+    AutoBean<ErrorGetStat> errorGetStat();
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/ErrorGetStat.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/ErrorGetStat.java
@@ -1,0 +1,9 @@
+package org.iplantc.de.client.models.errors.diskResources;
+
+import org.iplantc.de.client.models.HasPaths;
+
+/**
+ * Created by sriram on 10/5/17.
+ */
+public interface ErrorGetStat extends ErrorDiskResource, HasPaths {
+}

--- a/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/ErrorGetStat.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/ErrorGetStat.java
@@ -3,6 +3,9 @@ package org.iplantc.de.client.models.errors.diskResources;
 import org.iplantc.de.client.models.HasPaths;
 
 /**
+ *
+ * An interface to autobean error information returned when calling stat endpoints.
+ *
  * Created by sriram on 10/5/17.
  */
 public interface ErrorGetStat extends ErrorDiskResource, HasPaths {

--- a/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/categories/ErrorGetManifestCategory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/categories/ErrorGetManifestCategory.java
@@ -6,6 +6,13 @@ import org.iplantc.de.client.util.DiskResourceUtil;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.web.bindery.autobean.shared.AutoBean;
 
+/**
+ *
+ * A Category class that provides implementation of generateErrorMsg() method.
+ *
+ * Created by sriram on 10/5/17.
+ */
+
 public class ErrorGetManifestCategory {
     private static DiskResourceUtil diskResourceUtil = DiskResourceUtil.getInstance();
 

--- a/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/categories/ErrorGetStatCategory.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/errors/diskResources/categories/ErrorGetStatCategory.java
@@ -1,0 +1,23 @@
+package org.iplantc.de.client.models.errors.diskResources.categories;
+
+import org.iplantc.de.client.models.errors.diskResources.ErrorGetStat;
+import org.iplantc.de.client.util.DiskResourceUtil;
+
+import com.google.common.base.Joiner;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.web.bindery.autobean.shared.AutoBean;
+
+/**
+ * Created by sriram on 10/5/17.
+ */
+public class ErrorGetStatCategory {
+    private static DiskResourceUtil diskResourceUtil = DiskResourceUtil.getInstance();
+
+    public static SafeHtml generateErrorMsg(AutoBean<ErrorGetStat> instance) {
+        ErrorGetStat error = instance.as();
+
+        return ErrorDiskResourceCategory.getErrorMessage(
+                ErrorDiskResourceCategory.getDiskResourceErrorCode(error.getErrorCode()),
+                Joiner.on(',').join(diskResourceUtil.parseNamesFromIdList(error.getPaths())));
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterWindowEventHandler.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterWindowEventHandler.java
@@ -98,11 +98,15 @@ public class DesktopPresenterWindowEventHandler implements EditAppEvent.EditAppE
     @Inject
     AppTemplateAutoBeanFactory templateAutoBeanFactory;
 
+    @Inject
+    EnsemblUtil ensemblUtil;
+
     private DesktopWindowManager desktopWindowManager;
     private DesktopPresenterImpl presenter;
 
     @Inject
     public DesktopPresenterWindowEventHandler() {
+
     }
 
     @Override
@@ -179,7 +183,7 @@ public class DesktopPresenterWindowEventHandler implements EditAppEvent.EditAppE
             showFile((File)resourcesToSend.iterator().next());
         }
 
-        new EnsemblUtil(resourcesToSend, null).sendToEnsembl(diskResourceServiceFacade);
+        ensemblUtil.sendToEnsembl(resourcesToSend, diskResourceServiceFacade, null);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterWindowEventHandler.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterWindowEventHandler.java
@@ -42,7 +42,7 @@ import org.iplantc.de.diskResource.client.events.RequestSimpleDownloadEvent;
 import org.iplantc.de.diskResource.client.events.RequestSimpleUploadEvent;
 import org.iplantc.de.diskResource.client.events.ShowFilePreviewEvent;
 import org.iplantc.de.diskResource.client.views.dialogs.FileUploadByUrlDialog;
-import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
+import org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil;
 import org.iplantc.de.notifications.client.events.WindowShowRequestEvent;
 import org.iplantc.de.systemMessages.client.events.ShowSystemMessagesEvent;
 import org.iplantc.de.tools.client.events.UseToolInNewAppEvent;
@@ -99,7 +99,7 @@ public class DesktopPresenterWindowEventHandler implements EditAppEvent.EditAppE
     AppTemplateAutoBeanFactory templateAutoBeanFactory;
 
     @Inject
-    EnsemblUtil ensemblUtil;
+    GenomeBrowserUtil genomeBrowserUtil;
 
     private DesktopWindowManager desktopWindowManager;
     private DesktopPresenterImpl presenter;
@@ -183,7 +183,7 @@ public class DesktopPresenterWindowEventHandler implements EditAppEvent.EditAppE
             showFile((File)resourcesToSend.iterator().next());
         }
 
-        ensemblUtil.sendToEnsembl(resourcesToSend, diskResourceServiceFacade, null);
+        genomeBrowserUtil.sendToGenomeBrowser(resourcesToSend, null);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileSelectDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FileSelectDialog.java
@@ -91,7 +91,7 @@ public class FileSelectDialog extends IPlantDialog implements TakesValue<List<Fi
     @Inject DiskResourceUtil diskResourceUtil;
 
     @Inject
-    FileSelectDialog(final DiskResourcePresenterFactory presenterFactory,
+    public FileSelectDialog(final DiskResourcePresenterFactory presenterFactory,
                      final FileSelectDialogAppearance appearance) {
 
         this.presenterFactory = presenterFactory;

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/EnsemblUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/EnsemblUtil.java
@@ -3,21 +3,33 @@ package org.iplantc.de.fileViewers.client.callbacks;
 import org.iplantc.de.client.models.HasPaths;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.diskResources.DiskResource;
+import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.client.models.diskResources.TYPE;
+import org.iplantc.de.client.models.errors.diskResources.DiskResourceErrorAutoBeanFactory;
+import org.iplantc.de.client.models.errors.diskResources.ErrorGetStat;
 import org.iplantc.de.client.models.viewer.InfoType;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
-import org.iplantc.de.commons.client.views.dialogs.IplantInfoBox;
+import org.iplantc.de.commons.client.views.dialogs.IPlantDialog;
+import org.iplantc.de.diskResource.client.views.dialogs.FileSelectDialog;
+import org.iplantc.de.shared.AsyncProviderWrapper;
 import org.iplantc.de.shared.DataCallback;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.user.client.TakesValue;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.inject.Inject;
+import com.google.web.bindery.autobean.shared.AutoBeanCodex;
 
 import com.sencha.gxt.core.shared.FastMap;
+import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
+import com.sencha.gxt.widget.core.client.event.HideEvent;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class EnsemblUtil {
 
@@ -28,29 +40,23 @@ public class EnsemblUtil {
         String indexFileMissingError();
     }
 
-    private final IsMaskable container;
-    private final List<DiskResource> resourcesToSend;
-    private final EnsemblUtilAppearance appearance;
-    private final DiskResourceUtil diskResourceUtil;
+    @Inject
+    EnsemblUtilAppearance appearance;
+    @Inject
+    DiskResourceErrorAutoBeanFactory factory;
+    @Inject
+    DiskResourceUtil diskResourceUtil;
+    @Inject
+    AsyncProviderWrapper<FileSelectDialog> dialogAsyncProviderWrapper;
 
-    public EnsemblUtil(final List<DiskResource> resourcesToSend, final IsMaskable container) {
-        this(resourcesToSend,
-             container,
-             DiskResourceUtil.getInstance(),
-             GWT.<EnsemblUtilAppearance>create(EnsemblUtilAppearance.class));
+    @Inject
+    public EnsemblUtil() {
+
     }
 
-    EnsemblUtil(final List<DiskResource> resourcesToSend,
-                final IsMaskable container,
-                final DiskResourceUtil diskResourceUtil,
-                final EnsemblUtilAppearance appearance) {
-        this.resourcesToSend = resourcesToSend;
-        this.container = container;
-        this.appearance = appearance;
-        this.diskResourceUtil = diskResourceUtil;
-    }
-
-    public void sendToEnsembl(final DiskResourceServiceFacade diskResourceServiceFacade) {
+    public void sendToEnsembl(List<DiskResource> resourcesToSend,
+                              final DiskResourceServiceFacade diskResourceServiceFacade,
+                              IsMaskable container) {
         final FastMap<TYPE> pathMap = new FastMap<>();
 
         for (DiskResource resource : resourcesToSend) {
@@ -77,12 +83,27 @@ public class EnsemblUtil {
                                               @Override
                                               public void onFailure(Integer statusCode,
                                                                     Throwable caught) {
-                                                  IplantInfoBox info =
-                                                          new IplantInfoBox(SafeHtmlUtils.fromTrustedString(
-                                                                  appearance.indexFileMissing()),
-                                                                            SafeHtmlUtils.fromTrustedString(
-                                                                                    appearance.indexFileMissingError()));
-                                                  info.show();
+                                                  ErrorGetStat egs = AutoBeanCodex.decode(factory,
+                                                                                          ErrorGetStat.class,
+                                                                                          caught.getMessage())
+                                                                                  .as();
+                                                  IPlantDialog dialog = new IPlantDialog();
+                                                  dialog.setHeading(SafeHtmlUtils.fromTrustedString(
+                                                          appearance.indexFileMissing()));
+                                                  VerticalLayoutContainer vlc =
+                                                          new VerticalLayoutContainer();
+                                                  vlc.add(new HTML(egs.generateErrorMsg()));
+                                                  vlc.add(new HTML(appearance.indexFileMissingError()));
+                                                  dialog.add(vlc);
+                                                  dialog.getOkButton().setText("Select missing files");
+                                                  dialog.getOkButton()
+                                                        .addSelectHandler(event -> dialogAsyncProviderWrapper
+                                                                .get(new FileSelectDialogAsyncCallback(
+                                                                        resourcesToSend,
+                                                                        diskResourceServiceFacade,
+                                                                        container)));
+
+                                                  dialog.show();
                                                   if (container != null) {
                                                       container.unmask();
                                                   }
@@ -90,17 +111,80 @@ public class EnsemblUtil {
 
                                               @Override
                                               public void onSuccess(FastMap<DiskResource> result) {
-                                                  HasPaths diskResourcePaths =
-                                                          diskResourceServiceFacade.getDiskResourceFactory()
-                                                                                   .pathsList()
-                                                                                   .as();
-                                                  diskResourcePaths.setPaths(Lists.newArrayList(pathMap.keySet()));
-
-                                                  diskResourceServiceFacade.shareWithAnonymous(
-                                                          diskResourcePaths,
-                                                          new ShareAnonymousCallback(container, diskResourceUtil));
+                                                  shareWithAnon(diskResourceServiceFacade,
+                                                                Lists.newArrayList(pathMap.keySet()),
+                                                                container);
                                               }
                                           });
     }
 
+    protected void shareWithAnon(DiskResourceServiceFacade diskResourceServiceFacade,
+                                 List<String> paths,
+                                 IsMaskable container) {
+        HasPaths diskResourcePaths = diskResourceServiceFacade.getDiskResourceFactory().pathsList().as();
+        diskResourcePaths.setPaths(paths);
+
+        diskResourceServiceFacade.shareWithAnonymous(diskResourcePaths,
+                                                     new ShareAnonymousCallback(container,
+                                                                                diskResourceUtil));
+    }
+
+    private class FileSelectDialogAsyncCallback implements AsyncCallback<FileSelectDialog> {
+
+
+        private final List<DiskResource> resourcesToSend;
+        private final DiskResourceServiceFacade diskResourceServiceFacade;
+        private final IsMaskable container;
+
+        FileSelectDialogAsyncCallback(List<DiskResource> resourcesToSend,
+                                      final DiskResourceServiceFacade diskResourceServiceFacade,
+                                      IsMaskable container) {
+            this.resourcesToSend = resourcesToSend;
+            this.diskResourceServiceFacade = diskResourceServiceFacade;
+            this.container = container;
+
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+
+        }
+
+        @Override
+        public void onSuccess(FileSelectDialog dialog1) {
+            dialog1.addHideHandler(new FileDialogHideHandler(dialog1, resourcesToSend,
+                                                             diskResourceServiceFacade,
+                                                             container));
+            dialog1.show(false, null, null, null);
+
+
+        }
+    }
+
+    private class FileDialogHideHandler implements HideEvent.HideHandler {
+        private final TakesValue<List<File>> takesValue;
+        private final List<DiskResource> resourceToSend;
+        private final DiskResourceServiceFacade diskResourceServiceFacade;
+        private final IsMaskable container;
+
+        public FileDialogHideHandler(TakesValue<List<File>> dlg, List<DiskResource> resourcesToSend,
+                                     final DiskResourceServiceFacade diskResourceServiceFacade,
+                                     IsMaskable container) {
+            this.takesValue = dlg;
+            this.resourceToSend = resourcesToSend;
+            this.diskResourceServiceFacade = diskResourceServiceFacade;
+            this.container = container;
+        }
+
+        @Override
+        public void onHide(HideEvent event) {
+            if ((takesValue.getValue() == null) || takesValue.getValue().isEmpty()
+                || diskResourceUtil.containsFilteredItems(takesValue.getValue())) {
+                return;
+            }
+            resourceToSend.addAll(takesValue.getValue());
+            List<String> paths = resourceToSend.stream().map(DiskResource ::getPath).collect(Collectors.toList());
+            shareWithAnon(diskResourceServiceFacade, paths, container);
+        }
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/gin/FileViewerGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/gin/FileViewerGinModule.java
@@ -1,7 +1,7 @@
 package org.iplantc.de.fileViewers.client.gin;
 
 import org.iplantc.de.fileViewers.client.FileViewer;
-import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
+import org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil;
 import org.iplantc.de.fileViewers.client.presenter.FileViewerPresenterImpl;
 import org.iplantc.de.fileViewers.client.presenter.MimeTypeViewerResolverFactory;
 
@@ -15,7 +15,7 @@ public class FileViewerGinModule extends AbstractGinModule {
     protected void configure() {
         bind(FileViewer.Presenter.class).to(FileViewerPresenterImpl.class);
         bind(MimeTypeViewerResolverFactory.class);
-        bind(EnsemblUtil.class);
+        bind(GenomeBrowserUtil.class);
     }
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/gin/FileViewerGinModule.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/gin/FileViewerGinModule.java
@@ -1,8 +1,9 @@
 package org.iplantc.de.fileViewers.client.gin;
 
+import org.iplantc.de.fileViewers.client.FileViewer;
+import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
 import org.iplantc.de.fileViewers.client.presenter.FileViewerPresenterImpl;
 import org.iplantc.de.fileViewers.client.presenter.MimeTypeViewerResolverFactory;
-import org.iplantc.de.fileViewers.client.FileViewer;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 
@@ -14,6 +15,7 @@ public class FileViewerGinModule extends AbstractGinModule {
     protected void configure() {
         bind(FileViewer.Presenter.class).to(FileViewerPresenterImpl.class);
         bind(MimeTypeViewerResolverFactory.class);
+        bind(EnsemblUtil.class);
     }
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
@@ -28,6 +28,7 @@ import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.diskResource.client.views.dialogs.SaveAsDialog;
 import org.iplantc.de.fileViewers.client.FileViewer;
+import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
 import org.iplantc.de.fileViewers.client.callbacks.FileSaveCallback;
 import org.iplantc.de.fileViewers.client.callbacks.TreeUrlCallback;
 import org.iplantc.de.fileViewers.client.events.DirtyStateChangedEvent;
@@ -138,6 +139,8 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
     @Inject DiskResourceServiceFacade diskResourceServiceFacade;
     @Inject DiskResourceUtil diskResourceUtil;
     @Inject IplantAnnouncer announcer;
+    @Inject
+    EnsemblUtil ensemblUtil;
 
     private MimeType contentType;
     /**
@@ -487,7 +490,11 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
         boolean ensembleViewer = diskResourceUtil.isEnsemblVizTab(infoTypeSplittable);
 
         if (treeViewer || cogeViewer || ensembleViewer) {
-            FileViewer vizViewer = new ExternalVisualizationURLViewerImpl(file, infoType, fileEditorService, diskResourceServiceFacade);
+            FileViewer vizViewer = new ExternalVisualizationURLViewerImpl(file,
+                                                                          infoType,
+                                                                          fileEditorService,
+                                                                          diskResourceServiceFacade,
+                                                                          ensemblUtil);
             List<VizUrl> urls = manifest.getUrls();
 
             if (urls != null && !urls.isEmpty()) {

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
@@ -28,7 +28,7 @@ import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.diskResource.client.views.dialogs.SaveAsDialog;
 import org.iplantc.de.fileViewers.client.FileViewer;
-import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
+import org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil;
 import org.iplantc.de.fileViewers.client.callbacks.FileSaveCallback;
 import org.iplantc.de.fileViewers.client.callbacks.TreeUrlCallback;
 import org.iplantc.de.fileViewers.client.events.DirtyStateChangedEvent;
@@ -140,7 +140,7 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
     @Inject DiskResourceUtil diskResourceUtil;
     @Inject IplantAnnouncer announcer;
     @Inject
-    EnsemblUtil ensemblUtil;
+    GenomeBrowserUtil genomeBrowserUtil;
 
     private MimeType contentType;
     /**
@@ -494,7 +494,7 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
                                                                           infoType,
                                                                           fileEditorService,
                                                                           diskResourceServiceFacade,
-                                                                          ensemblUtil);
+                                                                          genomeBrowserUtil);
             List<VizUrl> urls = manifest.getUrls();
 
             if (urls != null && !urls.isEmpty()) {

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/MimeTypeViewerResolverFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/MimeTypeViewerResolverFactory.java
@@ -22,6 +22,7 @@ import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.util.WindowUtil;
 import org.iplantc.de.fileViewers.client.FileViewer;
+import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
 import org.iplantc.de.fileViewers.client.views.AbstractFileViewer;
 import org.iplantc.de.fileViewers.client.views.ExternalVisualizationURLViewerImpl;
 import org.iplantc.de.fileViewers.client.views.ImageViewerImpl;
@@ -50,6 +51,8 @@ public class MimeTypeViewerResolverFactory {
     @Inject FileEditorServiceFacade fileEditorService;
     @Inject DiskResourceUtil diskResourceUtil;
     @Inject DiskResourceServiceFacade diskResourceServiceFacade;
+    @Inject
+    EnsemblUtil ensemblUtil;
 
     @Inject
     public MimeTypeViewerResolverFactory() {
@@ -118,7 +121,12 @@ public class MimeTypeViewerResolverFactory {
                 break;
 
             case VIZ:
-                ExternalVisualizationURLViewerImpl vizUrlViewer = new ExternalVisualizationURLViewerImpl(file, infoType, fileEditorService, diskResourceServiceFacade);
+                ExternalVisualizationURLViewerImpl vizUrlViewer = new ExternalVisualizationURLViewerImpl(
+                        file,
+                        infoType,
+                        fileEditorService,
+                        diskResourceServiceFacade,
+                        ensemblUtil);
                 viewers.add(vizUrlViewer);
                 break;
 

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/MimeTypeViewerResolverFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/MimeTypeViewerResolverFactory.java
@@ -22,7 +22,7 @@ import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.util.WindowUtil;
 import org.iplantc.de.fileViewers.client.FileViewer;
-import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
+import org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil;
 import org.iplantc.de.fileViewers.client.views.AbstractFileViewer;
 import org.iplantc.de.fileViewers.client.views.ExternalVisualizationURLViewerImpl;
 import org.iplantc.de.fileViewers.client.views.ImageViewerImpl;
@@ -52,7 +52,7 @@ public class MimeTypeViewerResolverFactory {
     @Inject DiskResourceUtil diskResourceUtil;
     @Inject DiskResourceServiceFacade diskResourceServiceFacade;
     @Inject
-    EnsemblUtil ensemblUtil;
+    GenomeBrowserUtil genomeBrowserUtil;
 
     @Inject
     public MimeTypeViewerResolverFactory() {
@@ -126,7 +126,7 @@ public class MimeTypeViewerResolverFactory {
                         infoType,
                         fileEditorService,
                         diskResourceServiceFacade,
-                        ensemblUtil);
+                        genomeBrowserUtil);
                 viewers.add(vizUrlViewer);
                 break;
 

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/ExternalVisualizationURLViewerImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/ExternalVisualizationURLViewerImpl.java
@@ -108,15 +108,18 @@ public class ExternalVisualizationURLViewerImpl extends AbstractFileViewer imple
     private final FileEditorServiceFacade fileEditorService;
     private final DiskResourceServiceFacade diskResourceServiceFacade;
     private final DiskResourceUtil diskResourceUtil;
+    private final EnsemblUtil ensemblUtil;
 
     public ExternalVisualizationURLViewerImpl(final File file,
                                               final String infoType,
                                               final FileEditorServiceFacade fileEditorService,
-                                              final DiskResourceServiceFacade diskResourceServiceFacade) {
+                                              final DiskResourceServiceFacade diskResourceServiceFacade,
+                                              final EnsemblUtil ensemblUtil) {
         super(file, infoType);
         this.fileEditorService = fileEditorService;
         this.diskResourceServiceFacade = diskResourceServiceFacade;
         this.diskResourceUtil = DiskResourceUtil.getInstance();
+        this.ensemblUtil = ensemblUtil;
         initWidget(uiBinder.createAndBindUi(this));
         gridView.setAutoExpandColumn(cm.getColumn(1));
         buildToolBar(diskResourceUtil.createInfoTypeSplittable(infoType));
@@ -191,9 +194,10 @@ public class ExternalVisualizationURLViewerImpl extends AbstractFileViewer imple
             @Override
             public void onSelect(SelectEvent event) {
                 mask(appearance.sendToEnsemblLoadingMask());
-                EnsemblUtil util = new EnsemblUtil(Collections.singletonList(file),
-                                                   ExternalVisualizationURLViewerImpl.this);
-                util.sendToEnsembl(diskResourceServiceFacade);
+                ensemblUtil.sendToEnsembl(Collections.singletonList(file),
+                                          diskResourceServiceFacade,
+                                          ExternalVisualizationURLViewerImpl.this);
+
             }
         });
         return button;

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/ExternalVisualizationURLViewerImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/ExternalVisualizationURLViewerImpl.java
@@ -9,7 +9,7 @@ import org.iplantc.de.client.models.viewer.VizUrl;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.services.FileEditorServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
-import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
+import org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil;
 import org.iplantc.de.fileViewers.client.callbacks.LoadGenomeInCoGeCallback;
 import org.iplantc.de.fileViewers.client.callbacks.TreeUrlCallback;
 import org.iplantc.de.fileViewers.client.views.cells.TreeUrlCell;
@@ -108,18 +108,18 @@ public class ExternalVisualizationURLViewerImpl extends AbstractFileViewer imple
     private final FileEditorServiceFacade fileEditorService;
     private final DiskResourceServiceFacade diskResourceServiceFacade;
     private final DiskResourceUtil diskResourceUtil;
-    private final EnsemblUtil ensemblUtil;
+    private final GenomeBrowserUtil genomeBrowserUtil;
 
     public ExternalVisualizationURLViewerImpl(final File file,
                                               final String infoType,
                                               final FileEditorServiceFacade fileEditorService,
                                               final DiskResourceServiceFacade diskResourceServiceFacade,
-                                              final EnsemblUtil ensemblUtil) {
+                                              final GenomeBrowserUtil genomeBrowserUtil) {
         super(file, infoType);
         this.fileEditorService = fileEditorService;
         this.diskResourceServiceFacade = diskResourceServiceFacade;
         this.diskResourceUtil = DiskResourceUtil.getInstance();
-        this.ensemblUtil = ensemblUtil;
+        this.genomeBrowserUtil = genomeBrowserUtil;
         initWidget(uiBinder.createAndBindUi(this));
         gridView.setAutoExpandColumn(cm.getColumn(1));
         buildToolBar(diskResourceUtil.createInfoTypeSplittable(infoType));
@@ -194,9 +194,8 @@ public class ExternalVisualizationURLViewerImpl extends AbstractFileViewer imple
             @Override
             public void onSelect(SelectEvent event) {
                 mask(appearance.sendToEnsemblLoadingMask());
-                ensemblUtil.sendToEnsembl(Collections.singletonList(file),
-                                          diskResourceServiceFacade,
-                                          ExternalVisualizationURLViewerImpl.this);
+                genomeBrowserUtil.sendToGenomeBrowser(Collections.singletonList(file),
+                                                      ExternalVisualizationURLViewerImpl.this);
 
             }
         });

--- a/de-lib/src/main/java/org/iplantc/de/resources/client/messages/IplantDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/resources/client/messages/IplantDisplayStrings.java
@@ -2985,4 +2985,6 @@ public interface IplantDisplayStrings extends com.google.gwt.i18n.client.Message
     String analysisHelp();
 
     String manageTools();
+
+    String selectIndexFile();
 }

--- a/de-lib/src/main/java/org/iplantc/de/shared/AsyncProviderWrapper.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/AsyncProviderWrapper.java
@@ -34,6 +34,7 @@ public class AsyncProviderWrapper<T> {
     Logger LOG = Logger.getLogger(AsyncProviderWrapper.class.getName());
     
     @Inject AsyncProvider<T> provider;
+
     public AsyncProviderWrapper() {
 
     }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerErrorStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerErrorStrings.properties
@@ -1,4 +1,4 @@
 analysisFailureWarning = Your input contains spaces and/or special characters ({0}) in the path. Please replace all spaces and special characters with an underscore ( _ ) or a dash ( - ).
-indexFileMissingError =  Index file (.bai for .bam (or) .vci for .vcf) is missing. <b>Note:</b> Both genome and index file must be present in the same folder.
+indexFileMissingError =  Unable to locate index file. <b>Note:</b> Both genome and index file must be preset in the same folder.
 cogeError = Unable to load genome in CoGe. Please try again later.
 unableToRetrieveTreeUrls = Unable to retrieve URLs for the tree file {0}.

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerErrorStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerErrorStrings.properties
@@ -1,4 +1,4 @@
 analysisFailureWarning = Your input contains spaces and/or special characters ({0}) in the path. Please replace all spaces and special characters with an underscore ( _ ) or a dash ( - ).
-indexFileMissingError =  Unable to locate index file. <b>Note:</b> Both genome and index file must be preset in the same folder.
+indexFileMissingError =  Unable to locate index file. <b>Note:</b> Both genome and index file must be present in the same folder.
 cogeError = Unable to load genome in CoGe. Please try again later.
 unableToRetrieveTreeUrls = Unable to retrieve URLs for the tree file {0}.

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewers.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewers.gwt.xml
@@ -49,8 +49,8 @@
         <when-type-is class="org.iplantc.de.fileViewers.client.views.cells.TreeUrlCell.TreeUrlCellAppearance" />
     </replace-with>
 
-    <replace-with class="org.iplantc.de.theme.base.client.fileViewers.callbacks.EnsemblUtilDefaultAppearance">
-        <when-type-is class="org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil.EnsemblUtilAppearance" />
+    <replace-with class="org.iplantc.de.theme.base.client.fileViewers.callbacks.GenomeBrowserUtilDefaultAppearance">
+        <when-type-is class="org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil.GenomeBrowserUtilAppearance" />
     </replace-with>
 
     <replace-with class="org.iplantc.de.theme.base.client.fileViewers.callbacks.LoadGenomeInCogeCallbackDefaultAppearance">

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/callbacks/GenomeBrowserUtilDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/callbacks/GenomeBrowserUtilDefaultAppearance.java
@@ -1,6 +1,6 @@
 package org.iplantc.de.theme.base.client.fileViewers.callbacks;
 
-import org.iplantc.de.fileViewers.client.callbacks.EnsemblUtil;
+import org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 import org.iplantc.de.theme.base.client.fileViewers.FileViewerErrorStrings;
 
@@ -10,17 +10,17 @@ import com.google.gwt.core.client.GWT;
  * Created by jstroot on 1/15/15.
  * @author jstroot
  */
-public class EnsemblUtilDefaultAppearance implements EnsemblUtil.EnsemblUtilAppearance {
+public class GenomeBrowserUtilDefaultAppearance implements GenomeBrowserUtil.GenomeBrowserUtilAppearance {
     final IplantDisplayStrings displayStrings;
     final FileViewerErrorStrings fileViewerErrorStrings;
 
-    public EnsemblUtilDefaultAppearance() {
+    public GenomeBrowserUtilDefaultAppearance() {
         this(GWT.<IplantDisplayStrings> create(IplantDisplayStrings.class),
              GWT.<FileViewerErrorStrings> create(FileViewerErrorStrings.class));
     }
 
-    EnsemblUtilDefaultAppearance(final IplantDisplayStrings displayStrings,
-                                 final FileViewerErrorStrings fileViewerErrorStrings) {
+    GenomeBrowserUtilDefaultAppearance(final IplantDisplayStrings displayStrings,
+                                       final FileViewerErrorStrings fileViewerErrorStrings) {
         this.displayStrings = displayStrings;
         this.fileViewerErrorStrings = fileViewerErrorStrings;
     }
@@ -33,5 +33,10 @@ public class EnsemblUtilDefaultAppearance implements EnsemblUtil.EnsemblUtilAppe
     @Override
     public String indexFileMissingError() {
         return fileViewerErrorStrings.indexFileMissingError();
+    }
+
+    @Override
+    public String selectIndexFile() {
+        return displayStrings.selectIndexFile();
     }
 }

--- a/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantDisplayStrings.properties
+++ b/de-lib/src/main/resources/org/iplantc/de/resources/client/messages/IplantDisplayStrings.properties
@@ -336,3 +336,5 @@ paramUnit = Unit
 userSupport= Support
 analysisHelp= Help me with this analysis
 
+selectIndexFile = Select index file(s)...
+


### PR DESCRIPTION
- Also renamed `EnsemblUtil` to `GenomeBrowserUtil` because Ensembl is a genome browser by itself and this class is a generic util.