### PR TITLE
Switch to new gradle plugin that supports JsInterop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,10 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
-        maven {
-            url 'http://dl.bintray.com/steffenschaefer/maven'
-        }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.3.RELEASE")
-        classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
+        classpath 'org.wisepersist:gwt-gradle-plugin:1.0.0'
     }
 }
 

--- a/iplant/webapps.gradle
+++ b/iplant/webapps.gradle
@@ -68,6 +68,7 @@ project(':de-webapp') {
 
         superDev { noPrecompile = true }
         maxHeapSize = '2g'
+        generateJsInteropExports = true
         compiler {
 //            enableClosureCompiler = true;
             disableClassMetadata = true;


### PR DESCRIPTION
As I said in chat, I tested this with Paul's React POC PR and everything seemed to work just fine.  SDM is working.  Prod builds seem to be working.

I did see an issue filed in the gradle plugin [repo](https://github.com/jiakuan/gwt-gradle-plugin) about the *nocache.js file not being generated, but I see it getting loaded into the browser when I do a production build so I don't think it's an issue for us.