### PR TITLE
CORE-9038 Prevent user from seeing default collab list in search results

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/UserSearchRPCProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/util/UserSearchRPCProxy.java
@@ -5,6 +5,7 @@ package org.iplantc.de.collaborators.client.util;
 
 import org.iplantc.de.client.gin.ServicesInjector;
 import org.iplantc.de.client.models.collaborators.Subject;
+import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.collaborators.client.util.UserSearchField.UsersLoadConfig;
 import org.iplantc.de.commons.client.ErrorHandler;
@@ -16,6 +17,7 @@ import com.sencha.gxt.data.shared.loader.PagingLoadResult;
 import com.sencha.gxt.data.shared.loader.PagingLoadResultBean;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author sriram
@@ -48,7 +50,8 @@ public class UserSearchRPCProxy extends RpcProxy<UsersLoadConfig, PagingLoadResu
         serviceFacade.searchCollaborators(lastQueryText, new AsyncCallback<List<Subject>>() {
             @Override
             public void onSuccess(List<Subject> result) {
-                callback.onSuccess(new PagingLoadResultBean<>(result, result.size(), 0));
+                List<Subject> filteredResults = getFilteredResults(result);
+                callback.onSuccess(new PagingLoadResultBean<>(filteredResults, filteredResults.size(), 0));
             }
 
             @Override
@@ -58,6 +61,17 @@ public class UserSearchRPCProxy extends RpcProxy<UsersLoadConfig, PagingLoadResu
             }
         });
 
+    }
+
+    /**
+     * Filter the results so that the user never sees the "default" collaborator list in their search results
+     * @param result
+     * @return
+     */
+    List<Subject> getFilteredResults(List<Subject> result) {
+        return result.stream()
+                     .filter(subject -> !Group.DEFAULT_GROUP.equals(subject.getName()))
+                     .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
There's no real harm in the user seeing the `default` collaborator list, it's just that they also can't really do anything with it.  If they click on it, they get an error message about being unable to add `default` to their collaborators (which makes sense since they're trying to add `default` to `default` without knowing it).