### PR TITLE
CORE-9041 Clear out the teams grid if no search results are returned for clarity

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamSearchRpcProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamSearchRpcProxy.java
@@ -114,7 +114,12 @@ public class TeamSearchRpcProxy extends RpcProxy<FilterPagingLoadConfig, PagingL
     }
 
     void addCreatorToTeams(List<Group> teams, FastMap<Subject> creatorFastMap) {
-        teams.forEach(group -> group.setCreator(creatorFastMap.get(getCreatorId(group)).getSubjectDisplayName()));
+        teams.forEach(group -> {
+            String creatorId = getCreatorId(group);
+            if (!Strings.isNullOrEmpty(creatorId)) {
+                group.setCreator(creatorFastMap.get(creatorId).getSubjectDisplayName());
+            }
+        });
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamSearchRpcProxy.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamSearchRpcProxy.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.teams.client.presenter;
 
+import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
@@ -13,6 +15,7 @@ import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
+import com.sencha.gxt.core.shared.FastMap;
 import com.sencha.gxt.data.client.loader.RpcProxy;
 import com.sencha.gxt.data.shared.loader.FilterConfig;
 import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfig;
@@ -20,12 +23,14 @@ import com.sencha.gxt.data.shared.loader.PagingLoadResult;
 import com.sencha.gxt.data.shared.loader.PagingLoadResultBean;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 public class TeamSearchRpcProxy extends RpcProxy<FilterPagingLoadConfig, PagingLoadResult<Group>> implements TeamSearchResultLoad.HasTeamSearchResultLoadHandlers {
 
     private TeamsView.TeamsViewAppearance appearance;
     private GroupServiceFacade searchFacade;
+    private CollaboratorsServiceFacade collaboratorsFacade;
     private IplantAnnouncer announcer;
     HandlerManager handlerManager;
     String lastQueryText;
@@ -33,9 +38,11 @@ public class TeamSearchRpcProxy extends RpcProxy<FilterPagingLoadConfig, PagingL
     @Inject
     TeamSearchRpcProxy(TeamsView.TeamsViewAppearance appearance,
                        GroupServiceFacade searchFacade,
+                       CollaboratorsServiceFacade collaboratorsFacade,
                        IplantAnnouncer announcer) {
         this.appearance = appearance;
         this.searchFacade = searchFacade;
+        this.collaboratorsFacade = collaboratorsFacade;
         this.announcer = announcer;
     }
 
@@ -65,17 +72,66 @@ public class TeamSearchRpcProxy extends RpcProxy<FilterPagingLoadConfig, PagingL
 
             @Override
             public void onSuccess(List<Group> result) {
-                PagingLoadResultBean<Group> loadResult = getLoadResult(result, loadConfig);
-                ensureHandlers().fireEvent(new TeamSearchResultLoad(result));
-                callback.onSuccess(loadResult);
+                getTeamCreatorNames(result, loadConfig, callback);
             }
         });
+    }
+
+    void getTeamCreatorNames(List<Group> teams, FilterPagingLoadConfig loadConfig, AsyncCallback<PagingLoadResult<Group>> callback) {
+        if (teams != null && !teams.isEmpty()) {
+
+            List<String> subjectIds = getCreatorIds(teams);
+            collaboratorsFacade.getUserInfo(subjectIds, new AsyncCallback<FastMap<Subject>>() {
+                @Override
+                public void onFailure(Throwable throwable) {
+                    announcer.schedule(new ErrorAnnouncementConfig(appearance.getCreatorNamesFailed()));
+                    sendResults(teams, loadConfig, callback);
+                }
+
+                @Override
+                public void onSuccess(FastMap<Subject> creatorFastMap) {
+                    addCreatorToTeams(teams, creatorFastMap);
+                    sendResults(teams, loadConfig, callback);
+                }
+            });
+        } else {
+            sendResults(teams, loadConfig, callback);
+        }
+    }
+
+    void sendResults(List<Group> teams, FilterPagingLoadConfig loadConfig, AsyncCallback<PagingLoadResult<Group>> callback) {
+        PagingLoadResultBean<Group> loadResult = getLoadResult(teams, loadConfig);
+        ensureHandlers().fireEvent(new TeamSearchResultLoad(teams));
+        callback.onSuccess(loadResult);
     }
 
     PagingLoadResultBean<Group> getLoadResult(List<Group> result, FilterPagingLoadConfig loadConfig) {
         return new PagingLoadResultBean<>(result, result.size(), loadConfig.getOffset());
     }
 
+    List<String> getCreatorIds(List<Group> teams) {
+        return teams.stream().map(this::getCreatorId).distinct().collect(Collectors.toList());
+    }
+
+    void addCreatorToTeams(List<Group> teams, FastMap<Subject> creatorFastMap) {
+        teams.forEach(group -> group.setCreator(creatorFastMap.get(getCreatorId(group)).getSubjectDisplayName()));
+    }
+
+    /**
+     * A team name is always in the format of {creator_id}:{team_name}
+     *
+     * @param team
+     * @return
+     */
+    String getCreatorId(Group team) {
+        String teamName = team.getName();
+
+        int lastIndex = teamName.lastIndexOf(Subject.GROUP_NAME_DELIMITER);
+        if (lastIndex > 0) {
+            return teamName.substring(0, lastIndex);
+        }
+        return null;
+    }
 
     protected HandlerManager ensureHandlers() {
         if (handlerManager == null) {

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
@@ -18,6 +18,7 @@ import org.iplantc.de.teams.client.gin.TeamsViewFactory;
 import org.iplantc.de.teams.client.models.TeamsFilter;
 import org.iplantc.de.teams.client.views.dialogs.EditTeamDialog;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
@@ -242,7 +243,12 @@ public class TeamsPresenterImpl implements TeamsView.Presenter, TeamNameSelected
     }
 
     void addCreatorToTeams(List<Group> teams, FastMap<Subject> creatorFastMap) {
-        teams.forEach(group -> group.setCreator(creatorFastMap.get(getCreatorId(group)).getSubjectDisplayName()));
+        teams.forEach(group -> {
+            String creatorId = getCreatorId(group);
+            if (!Strings.isNullOrEmpty(creatorId)) {
+                group.setCreator(creatorFastMap.get(creatorId).getSubjectDisplayName());
+            }
+        });
     }
 
     List<String> getCreatorIds(List<Group> teams) {

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/TeamsPresenterImpl.java
@@ -4,7 +4,6 @@ import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.groups.Group;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
-import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
@@ -237,11 +236,9 @@ public class TeamsPresenterImpl implements TeamsView.Presenter, TeamNameSelected
     @Override
     public void onTeamSearchResultLoad(TeamSearchResultLoad event) {
         List<Group> teams = event.getSearchResults();
-        if (teams != null && !teams.isEmpty()) {
-            currentFilter = null;
-            view.clearTeams();
-            view.addTeams(teams);
-        }
+        currentFilter = null;
+        view.clearTeams();
+        view.addTeams(teams);
     }
 
     void addCreatorToTeams(List<Group> teams, FastMap<Subject> creatorFastMap) {

--- a/de-lib/src/main/java/org/iplantc/de/teams/client/views/TeamsViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/views/TeamsViewImpl.java
@@ -12,10 +12,10 @@ import org.iplantc.de.teams.client.views.cells.TeamNameCell;
 import org.iplantc.de.teams.client.views.widgets.TeamSearchField;
 import org.iplantc.de.teams.shared.Teams;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.logical.shared.SelectionEvent;
-import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
@@ -98,12 +98,9 @@ public class TeamsViewImpl extends Composite implements TeamsView {
         SimpleComboBox<TeamsFilter> combo = new SimpleComboBox<>(new StringLabelProvider<TeamsFilter>());
         combo.add(Lists.newArrayList(TeamsFilter.MY_TEAMS, TeamsFilter.ALL));
         combo.setValue(TeamsFilter.MY_TEAMS);
-        combo.addSelectionHandler(new SelectionHandler<TeamsFilter>() {
-            @Override
-            public void onSelection(SelectionEvent<TeamsFilter> event) {
-                searchField.setValue("");
-                fireEvent(new TeamFilterSelectionChanged(combo.getCurrentValue()));
-            }
+        combo.addSelectionHandler(event -> {
+            searchField.clear();
+            applyFilter(TeamsFilter.MY_TEAMS);
         });
 
         return combo;
@@ -148,9 +145,23 @@ public class TeamsViewImpl extends Composite implements TeamsView {
         fireEvent(new CreateTeamSelected());
     }
 
+    @UiHandler("searchField")
+    void searchFieldKeyUp(KeyUpEvent event) {
+        if (Strings.isNullOrEmpty(searchField.getCurrentValue())) {
+            applyFilter(TeamsFilter.ALL);
+        } else {
+            applyFilter(null);
+        }
+    }
+
+    void applyFilter(TeamsFilter filter) {
+        teamFilter.setValue(filter);
+        fireEvent(new TeamFilterSelectionChanged(filter));
+    }
+
     @Override
     public void onTeamSearchResultLoad(TeamSearchResultLoad event) {
-        teamFilter.setText("");
+        teamFilter.setText(null);
     }
 
     @Override

--- a/de-lib/src/test/java/org/iplantc/de/teams/client/presenter/TeamSearchRpcProxyTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/teams/client/presenter/TeamSearchRpcProxyTest.java
@@ -1,20 +1,22 @@
 package org.iplantc.de.teams.client.presenter;
 
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.iplantc.de.client.models.collaborators.Subject;
 import org.iplantc.de.client.models.groups.Group;
+import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.teams.client.TeamsView;
-import org.iplantc.de.teams.client.events.TeamSearchResultLoad;
 
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 
+import com.sencha.gxt.core.shared.FastMap;
 import com.sencha.gxt.data.shared.loader.FilterConfig;
 import com.sencha.gxt.data.shared.loader.FilterPagingLoadConfig;
 import com.sencha.gxt.data.shared.loader.PagingLoadResult;
@@ -43,8 +45,12 @@ public class TeamSearchRpcProxyTest {
     @Mock List<Group> groupListMock;
     @Mock Group groupMock;
     @Mock PagingLoadResultBean<Group> loadResultMock;
+    @Mock CollaboratorsServiceFacade collabServiceFacadeMock;
+    @Mock List<String> creatorIdsMock;
+    @Mock FastMap<Subject> creatorFastMapMock;
 
     @Captor ArgumentCaptor<AsyncCallback<List<Group>>> groupListCaptor;
+    @Captor ArgumentCaptor<AsyncCallback<FastMap<Subject>>> fastMapCaptor;
 
     TeamSearchRpcProxy uut;
 
@@ -57,11 +63,17 @@ public class TeamSearchRpcProxyTest {
 
         uut = new TeamSearchRpcProxy(appearanceMock,
                                      searchFacadeMock,
+                                     collabServiceFacadeMock,
                                      announcerMock){
             @Override
             PagingLoadResultBean<Group> getLoadResult(List<Group> result,
                                                       FilterPagingLoadConfig loadConfig) {
                 return loadResultMock;
+            }
+
+            @Override
+            List<String> getCreatorIds(List<Group> teams) {
+                return creatorIdsMock;
             }
         };
         uut.handlerManager = handlerManagerMock;
@@ -70,17 +82,31 @@ public class TeamSearchRpcProxyTest {
 
     @Test
     public void load() {
+        TeamSearchRpcProxy spy = spy(uut);
 
         /** CALL METHOD UNDER TEST **/
-        uut.load(loadConfigMock, callbackMock);
+        spy.load(loadConfigMock, callbackMock);
 
         verify(searchFacadeMock).searchTeams(eq("search"),
                                              groupListCaptor.capture());
 
         groupListCaptor.getValue().onSuccess(groupListMock);
 
-        verify(handlerManagerMock).fireEvent(isA(TeamSearchResultLoad.class));
-        verify(callbackMock).onSuccess(eq(loadResultMock));
+        verify(spy).getTeamCreatorNames(eq(groupListMock), eq(loadConfigMock), eq(callbackMock));
+    }
+
+    @Test
+    public void getTeamCreatorNames() {
+        TeamSearchRpcProxy spy = spy(uut);
+
+        /** CALL METHOD UNDER TEST **/
+        spy.getTeamCreatorNames(groupListMock, loadConfigMock, callbackMock);
+
+        verify(collabServiceFacadeMock).getUserInfo(eq(creatorIdsMock), fastMapCaptor.capture());
+        fastMapCaptor.getValue().onSuccess(creatorFastMapMock);
+        verify(spy).addCreatorToTeams(eq(groupListMock), eq(creatorFastMapMock));
+        verify(spy).sendResults(eq(groupListMock), eq(loadConfigMock), eq(callbackMock));
+
     }
 
 }


### PR DESCRIPTION
I also added in a change so that if you clear out the search text, the "All Teams" filter will be applied.
Then I also realized the team creator names were missing when searching, so I added that.