### PR TITLE
CORE-9087 Fix bug where closing previously minimized windows does not…

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/DesktopViewImpl.java
@@ -159,6 +159,9 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
         final Widget eventItem = event.getItem();
         if(eventItem instanceof IPlantWindowInterface) {
             IPlantWindowInterface iplantWindow = (IPlantWindowInterface) eventItem;
+            if (iplantWindow.isMinimized()) {
+                return;
+            }
             TaskButton taskButton = null;
             for(TaskButton btn : taskBar.getButtons()){
                 if(btn.getWindow() == iplantWindow){
@@ -168,11 +171,6 @@ public class DesktopViewImpl implements DesktopView, UnregisterEvent.UnregisterH
             }
 
             Preconditions.checkNotNull(taskButton, "TaskButton should not be null");
-            if(iplantWindow.isMinimized()){
-                // Re register
-                windowManager.register(eventItem);
-                return;
-            }
             // remove corresponding task button
             taskBar.removeTaskButton(taskButton);
         }

--- a/de-lib/src/test/java/org/iplantc/de/desktop/client/views/DesktopViewImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/desktop/client/views/DesktopViewImplTest.java
@@ -1,5 +1,13 @@
 package org.iplantc.de.desktop.client.views;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
 import org.iplantc.de.desktop.client.views.widgets.TaskBar;
 import org.iplantc.de.desktop.client.views.widgets.TaskButton;
 import org.iplantc.de.desktop.client.views.windows.IPlantWindowInterface;
@@ -15,8 +23,6 @@ import com.sencha.gxt.widget.core.client.WindowManager;
 import com.sencha.gxt.widget.core.client.event.RegisterEvent;
 import com.sencha.gxt.widget.core.client.event.UnregisterEvent;
 
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -66,29 +72,6 @@ public class DesktopViewImplTest {
         uut.onRegister(registerEventMock);
         verify(uut.taskBar, never()).addTaskButton(eq(window));
         verifyNoMoreInteractions(windowManagerMock);
-    }
-
-    @Test public void taskButtonNotRemovedWhenWindowIsUnregisteredAndMinimized() {
-        DesktopViewImpl uut = new DesktopViewImpl(tourStringsMock, windowManagerMock);
-        verifyViewInit(uut);
-        uut.taskBar = mock(TaskBar.class);
-
-        TaskButton mockTaskButton = mock(TaskButton.class);
-        List<TaskButton> tbList = Lists.newArrayList(mockTaskButton);
-        when(uut.taskBar.getButtons()).thenReturn(tbList);
-
-        final Window window = mock(Window.class, withSettings().extraInterfaces(IPlantWindowInterface.class));
-        when(((IPlantWindowInterface) window).isMinimized()).thenReturn(true);
-        when(unregisterEventMock.getItem()).thenReturn(window);
-        when(mockTaskButton.getWindow()).thenReturn(window);
-
-
-        uut.onUnregister(unregisterEventMock);
-        verify(mockTaskButton).getWindow();
-        // Verify that window is re-registered with the window manager when the window is minimized
-        verify(windowManagerMock).register(eq(window));
-        verify(uut.taskBar, never()).removeTaskButton(any(TaskButton.class));
-        verifyNoMoreInteractions(mockTaskButton, windowManagerMock);
     }
 
     @Test public void taskButtonRemovedWhenWindowIsUnregisteredAndNotMinimized() {


### PR DESCRIPTION
… clear their state

Sencha does not actually have a minimize method that does anything and also does not have any checks that a window is already registered with the singleton WindowManager class before registering it again in the show() method.  In the DE, when a minimize button was clicked, the hide() method was actually called which tries to unregister the window, but then IplantWindowBase was configured to re-register the window so WindowManager could still keep track of it.  When the window was restored, the show() method was called which then re-registered the window, creating a duplicate in WindowManager.  Any time the user then tried to close the window, the duplicate would still exist.  Trying to open a new window of the same type would then result in the DE's DesktopWindowManager class to fetch the duplicate window which contained the old state.

NOTE: This is an existing bug which doesn't need to go into the 12/12 release.