### PR TITLE
CORE-9088 Fix bug where you can't reopen the Data window if you have …

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/WindowType.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/WindowType.java
@@ -11,7 +11,7 @@ public enum WindowType {
     APP_INTEGRATION,
     APP_WIZARD,
     DATA,
-    DATA_VIEWER,
+    FILE_VIEWER,
     HELP,
     NOTIFICATIONS,
     SIMPLE_DOWNLOAD,

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/window/configs/ConfigFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/window/configs/ConfigFactory.java
@@ -96,7 +96,7 @@ public class ConfigFactory {
     }
 
     public static FileViewerWindowConfig fileViewerWindowConfig(File file) {
-        AutoBean<FileViewerWindowConfig> fvwc = applyWindowType(WindowType.DATA_VIEWER,
+        AutoBean<FileViewerWindowConfig> fvwc = applyWindowType(WindowType.FILE_VIEWER,
                 factory.fileViewerWindowConfig());
         fvwc.as().setFile(file);
         if (file != null) {
@@ -112,14 +112,14 @@ public class ConfigFactory {
     }
 
     public static TabularFileViewerWindowConfig newTabularFileViewerWindowConfig() {
-        AutoBean<TabularFileViewerWindowConfig> ab = applyWindowType(WindowType.DATA_VIEWER, factory.newTabularFileViewerWindowConfig());
+        AutoBean<TabularFileViewerWindowConfig> ab = applyWindowType(WindowType.FILE_VIEWER, factory.newTabularFileViewerWindowConfig());
         applyTag("Tabular File-" + DateTimeFormat.getFormat(PredefinedFormat.DATE_TIME_FULL).format(new Date()),
                  ab);
         return ab.as();
     }
 
     public static HTPathListWindowConfig newHTPathListWindowConfig() {
-        AutoBean<HTPathListWindowConfig> ab = applyWindowType(WindowType.DATA_VIEWER, factory.pathListWindowConfig());
+        AutoBean<HTPathListWindowConfig> ab = applyWindowType(WindowType.FILE_VIEWER, factory.pathListWindowConfig());
         applyTag("Path List-" + DateTimeFormat.getFormat(PredefinedFormat.DATE_TIME_FULL).format(new Date()),
                  ab);
         HTPathListWindowConfig config = ab.as();
@@ -131,7 +131,7 @@ public class ConfigFactory {
     }
 
     public static MultiInputPathListWindowConfig newMultiInputPathListWindowConfig() {
-        AutoBean<MultiInputPathListWindowConfig> ab = applyWindowType(WindowType.DATA_VIEWER, factory.multiInputPathListWindowConfig());
+        AutoBean<MultiInputPathListWindowConfig> ab = applyWindowType(WindowType.FILE_VIEWER, factory.multiInputPathListWindowConfig());
         applyTag("Path List-" + DateTimeFormat.getFormat(PredefinedFormat.DATE_TIME_FULL).format(new Date()),
                  ab);
         MultiInputPathListWindowConfig config = ab.as();
@@ -204,7 +204,7 @@ public class ConfigFactory {
 
             case APP_INTEGRATION:
             case APP_WIZARD:
-            case DATA_VIEWER:
+            case FILE_VIEWER:
             case HELP:
             case WORKFLOW_INTEGRATION:
             case MANAGETOOLS:
@@ -246,7 +246,7 @@ public class ConfigFactory {
                         ws.getWindowConfig()).as();
                 break;
 
-            case DATA_VIEWER:
+            case FILE_VIEWER:
                 config = AutoBeanCodex.decode(factory, FileViewerWindowConfig.class,
                         ws.getWindowConfig()).as();
                 break;

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/IplantWindowBase.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/IplantWindowBase.java
@@ -484,7 +484,7 @@ public abstract class IplantWindowBase extends Window implements IPlantWindowInt
                                               AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(config)));
                     break;
 
-                case DATA_VIEWER:
+                case FILE_VIEWER:
                     IntercomFacade.trackEvent(TrackingEventType.DATA_VIEWER_WINDOW_OPEN,
                                               AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(config)));
                     break;
@@ -563,7 +563,7 @@ public abstract class IplantWindowBase extends Window implements IPlantWindowInt
                                               AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(config)));
                     break;
 
-                case DATA_VIEWER:
+                case FILE_VIEWER:
                     IntercomFacade.trackEvent(TrackingEventType.DATA_VIEWER_WINDOW_CLOSED,
                                               AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(config)));
                     break;

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/util/WindowFactory.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/util/WindowFactory.java
@@ -74,7 +74,7 @@ public class WindowFactory {
             case DATA:
                 ret = diskResourceWindowAsyncProvider;
                 break;
-            case DATA_VIEWER:
+            case FILE_VIEWER:
                 ret = fileViewerWindowAsyncProvider;
                 break;
             case HELP:

--- a/de-lib/src/main/java/org/iplantc/de/shared/DataCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/shared/DataCallback.java
@@ -14,7 +14,7 @@ public abstract class DataCallback<T> implements DECallback<T> {
     @Override
     public List<WindowType> getWindowTypes() {
         return Lists.newArrayList(WindowType.DATA,
-                                  WindowType.DATA_VIEWER,
+                                  WindowType.FILE_VIEWER,
                                   WindowType.SIMPLE_DOWNLOAD);
     }
 }


### PR DESCRIPTION
…a file open

In DesktopWindowManager we're checking to see if any of the current open windows has a state ID that starts with the data window's type which is DATA.  Since DATA_VIEWER starts with DATA, DesktopWindowManager would just bring the file viewer window to the front.