### PR TITLE
core-8350 Proof-of-Concept: Use Web local storage to store app and data window preferences

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/AnalysesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/AnalysesView.java
@@ -146,6 +146,12 @@ public interface AnalysesView extends IsWidget,
         String stepInfoDialogHeight();
 
         int dotMenuWidth();
+
+        String windowWidth();
+
+        String windowHeight();
+
+        int windowMinWidth();
     }
 
     interface Presenter {

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
@@ -25,6 +25,19 @@ public interface AppsView extends IsWidget,
 
     interface AppsViewAppearance {
         String viewCategoriesHeader();
+
+        String appsWindowWidth();
+
+        String appsWindowHeight();
+
+        String pipelineEdWindowWidth();
+
+        String pipelineEdWindowHeight();
+
+        int pipelineEdWindowMinWidth();
+
+        int pipelineEdWindowMinHeight();
+
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/AppLaunchView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/AppLaunchView.java
@@ -56,6 +56,10 @@ public interface AppLaunchView extends IsWidget, Editor<AppTemplate>, HasRequest
         String launchPreviewHeader(AppTemplate appTemplate);
 
         String launchAnalysis();
+
+        String windowHeight();
+
+        String windowWidth();
     }
 
     public interface Presenter extends AppTemplateFetched.HasAppTemplateFetchedHandlers {

--- a/de-lib/src/main/java/org/iplantc/de/client/util/WebStorageUtil.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/util/WebStorageUtil.java
@@ -1,0 +1,49 @@
+package org.iplantc.de.client.util;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.storage.client.Storage;
+
+/**
+ * A util class to interact with web storage
+ *
+ * Created by sriram on 1/2/18.
+ */
+public class WebStorageUtil {
+
+
+    private static Storage store = Storage.getLocalStorageIfSupported();
+
+    /**
+     * Write key/value to web storage
+     *
+     * @param key
+     * @param value
+     */
+    public static void writeToStorage(String key, String value) {
+        if (store != null) {
+            store.setItem(key, value);
+            return;
+        }
+
+        GWT.log("Web storage not supported!");
+    }
+
+
+    /**
+     * Read value for the given key from web storage
+     *
+     * @param key
+     * @return
+     */
+    public static String readFromStorage(String key) {
+        if (store == null) {
+            GWT.log("Web storage not supported!");
+            return null;
+        }
+
+        return store.getItem(key);
+    }
+
+
+}
+

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/views/window/configs/AppsWindowConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/views/window/configs/AppsWindowConfig.java
@@ -11,8 +11,4 @@ public interface AppsWindowConfig extends WindowConfig {
     void setSelectedAppCategory(HasQualifiedId appGroup);
 
     void setSelectedApp(HasQualifiedId app);
-
-    void setView(String lastViewSelected);
-
-    String getView();
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AboutApplicationWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AboutApplicationWindow.java
@@ -43,6 +43,10 @@ public class AboutApplicationWindow extends IplantWindowBase {
         ImageResource iplantAbout();
 
         String iplantcAboutPadText();
+
+        String windowWidth();
+
+        String windowHeight();
     }
     private final AboutApplicationServiceAsync aboutApplicationService;
     private final AboutApplicationAppearance appearance;
@@ -57,7 +61,8 @@ public class AboutApplicationWindow extends IplantWindowBase {
 
         String width = getSavedWidth(WindowType.ABOUT.toString());
         String height = getSavedHeight(WindowType.ABOUT.toString());
-        setSize((width == null) ? "320" : width, (height == null) ? "260" : height);
+        setSize((width == null) ? appearance.windowWidth() : width,
+                (height == null) ? appearance.windowHeight() : height);
 
         setHeading(appearance.headingText());
         ensureDebugId(DeModule.WindowIds.ABOUT_WINDOW);

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AboutApplicationWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AboutApplicationWindow.java
@@ -2,7 +2,9 @@ package org.iplantc.de.desktop.client.views.windows;
 
 import org.iplantc.de.client.models.AboutApplicationData;
 import org.iplantc.de.client.models.CommonModelAutoBeanFactory;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.commons.client.ErrorHandler;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
 import org.iplantc.de.desktop.shared.DeModule;
@@ -48,10 +50,15 @@ public class AboutApplicationWindow extends IplantWindowBase {
 
     @Inject
     AboutApplicationWindow(final AboutApplicationServiceAsync aboutApplicationService,
-                           final AboutApplicationAppearance appearance) {
+                           final AboutApplicationAppearance appearance, final UserInfo userInfo) {
         this.aboutApplicationService = aboutApplicationService;
         this.appearance = appearance;
-        setSize("320", "260");
+        this.userInfo = userInfo;
+
+        String width = getSavedWidth(WindowType.ABOUT.toString());
+        String height = getSavedHeight(WindowType.ABOUT.toString());
+        setSize((width == null) ? "320" : width, (height == null) ? "260" : height);
+
         setHeading(appearance.headingText());
         ensureDebugId(DeModule.WindowIds.ABOUT_WINDOW);
         executeServiceCall();
@@ -103,5 +110,12 @@ public class AboutApplicationWindow extends IplantWindowBase {
                 compose();
             }
         });
+    }
+
+    @Override
+    public void hide() {
+        saveHeight(WindowType.ABOUT.toString());
+        saveWidth(WindowType.ABOUT.toString());
+        super.hide();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AppEditorWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AppEditorWindow.java
@@ -109,6 +109,10 @@ public class AppEditorWindow extends IplantWindowBase implements AppPublishedEve
         int minWidth();
 
         String unableToRetrieveWorkflowGuide();
+
+        String windowWidth();
+
+        String windowHeight();
     }
 
     final AppEditorAppearance appearance;
@@ -153,7 +157,8 @@ public class AppEditorWindow extends IplantWindowBase implements AppPublishedEve
 
         String width = getSavedWidth(WindowType.APP_INTEGRATION.toString());
         String height = getSavedHeight(WindowType.APP_INTEGRATION.toString());
-        setSize((width == null) ? "800" : width, (height == null) ? "480" : height);
+        setSize((width == null) ? appearance.windowWidth() : width,
+                (height == null) ? appearance.windowHeight() : height);
         setMinWidth(appearance.minWidth());
         setMinHeight(appearance.minHeight());
     }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AppEditorWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AppEditorWindow.java
@@ -7,7 +7,9 @@ import org.iplantc.de.apps.integration.shared.AppIntegrationModule;
 import org.iplantc.de.apps.widgets.client.view.AppLaunchView.RenameWindowHeaderCommand;
 import org.iplantc.de.client.events.EventBus;
 import org.iplantc.de.client.models.HasQualifiedId;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.integration.AppTemplate;
 import org.iplantc.de.client.models.apps.integration.AppTemplateAutoBeanFactory;
@@ -119,6 +121,7 @@ public class AppEditorWindow extends IplantWindowBase implements AppPublishedEve
     private final RenameWindowHeaderCmdImpl renameCmd;
     private final AppTemplateServices templateService;
     private final ContextualHelpToolButton editPublicAppContextHlpTool;
+
     Logger LOG = Logger.getLogger("App Editor window");
 
     @Inject
@@ -130,7 +133,8 @@ public class AppEditorWindow extends IplantWindowBase implements AppPublishedEve
                     final ToolServices dcServices,
                     final AppTemplateAutoBeanFactory factory,
                     final AppsWidgetsContextualHelpMessages helpMessages,
-                    final EventBus eventBus) {
+                    final EventBus eventBus,
+                    final UserInfo userInfo) {
         this.appearance = appearance;
         this.appTemplateUtils = appTemplateUtils;
         this.presenter = presenter;
@@ -139,12 +143,17 @@ public class AppEditorWindow extends IplantWindowBase implements AppPublishedEve
         this.dcServices = dcServices;
         this.factory = factory;
         this.eventBus = eventBus;
+        this.userInfo  = userInfo;
 
         editPublicAppContextHlpTool = new ContextualHelpToolButton(new HTML(helpMessages.editPublicAppHelp()));
         renameCmd = new RenameWindowHeaderCmdImpl(this);
 
         setHeading(appearance.headingText());
-        setSize("800", "480");
+
+
+        String width = getSavedWidth(WindowType.APP_INTEGRATION.toString());
+        String height = getSavedHeight(WindowType.APP_INTEGRATION.toString());
+        setSize((width == null) ? "800" : width, (height == null) ? "480" : height);
         setMinWidth(appearance.minWidth());
         setMinHeight(appearance.minHeight());
     }
@@ -310,6 +319,14 @@ public class AppEditorWindow extends IplantWindowBase implements AppPublishedEve
                         }
                     });
         }
+    }
+
+
+    @Override
+    public void hide() {
+        saveHeight(WindowType.APP_INTEGRATION.toString());
+        saveWidth(WindowType.APP_INTEGRATION.toString());
+        super.hide();
     }
 
     private void setEditPublicAppHeader(String appName) {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AppLaunchWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/AppLaunchWindow.java
@@ -6,7 +6,9 @@ import org.iplantc.de.apps.widgets.client.events.AppTemplateFetched;
 import org.iplantc.de.apps.widgets.client.view.AppLaunchView;
 import org.iplantc.de.client.DEClientConstants;
 import org.iplantc.de.client.models.HasQualifiedId;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.client.models.apps.integration.AppTemplate;
 import org.iplantc.de.commons.client.views.window.configs.AppWizardConfig;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
@@ -36,12 +38,16 @@ public class AppLaunchWindow extends IplantWindowBase implements AnalysisLaunchE
     @Inject
     AppLaunchWindow(final AppLaunchView.Presenter presenter,
                     final DEClientConstants deClientConstants,
-                    AppLaunchView.AppLaunchViewAppearance appearance) {
+                    AppLaunchView.AppLaunchViewAppearance appearance,
+                    final UserInfo userInfo) {
         this.presenter = presenter;
         this.deClientConstants = deClientConstants;
         this.appearance = appearance;
+        this.userInfo = userInfo;
 
-        setSize("640", "375");
+        String width = getSavedWidth(WindowType.APP_WIZARD.toString());
+        String height = getSavedHeight(WindowType.APP_WIZARD.toString());
+        setSize((width == null) ? "640" : width, (height == null) ? "375" : height);
         setMinWidth(300);
         setMinHeight(350);
         setBorders(false);
@@ -102,5 +108,12 @@ public class AppLaunchWindow extends IplantWindowBase implements AnalysisLaunchE
             fireEvent(new WindowHeadingUpdatedEvent());
         }
         forceLayout();
+    }
+
+    @Override
+    public void hide() {
+        saveHeight(WindowType.APP_WIZARD.toString());
+        saveWidth(WindowType.APP_WIZARD.toString());
+        super.hide();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/CollaborationWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/CollaborationWindow.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.desktop.client.views.windows;
 
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.shared.CollaboratorsModule;
@@ -24,12 +26,16 @@ public class CollaborationWindow extends IplantWindowBase {
 
     @Inject
     CollaborationWindow(final CollaborationView.Presenter presenter,
-                        ManageCollaboratorsView.Appearance appearance) {
+                        ManageCollaboratorsView.Appearance appearance,
+                        UserInfo userInfo) {
         this.presenter = presenter;
         this.appearance = appearance;
+        this.userInfo = userInfo;
 
-        // This must be set before we render view
-        setSize(appearance.windowWidth(), appearance.windowHeight());
+
+        String width = getSavedWidth(WindowType.COLLABORATION.toString());
+        String height = getSavedHeight(WindowType.COLLABORATION.toString());
+        setSize((width == null) ? appearance.windowWidth() : width, (height == null) ? appearance.windowHeight() : height);
         setMinWidth(appearance.windowMinWidth());
         setHeading(appearance.windowHeading());
 
@@ -62,5 +68,12 @@ public class CollaborationWindow extends IplantWindowBase {
 
         presenter.setViewDebugId(baseID);
         btnHelp.ensureDebugId(baseID + CollaboratorsModule.Ids.HELP_BTN);
+    }
+
+    @Override
+    public void hide() {
+        saveWidth(WindowType.COLLABORATION.toString());
+        saveHeight(WindowType.COLLABORATION.toString());
+        super.hide();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
@@ -4,6 +4,7 @@ import org.iplantc.de.apps.client.AppsView;
 import org.iplantc.de.apps.shared.AppsModule;
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.client.util.WebStorageUtil;
 import org.iplantc.de.commons.client.util.WindowUtil;
 import org.iplantc.de.commons.client.views.window.configs.AppsWindowConfig;
@@ -25,19 +26,21 @@ public class DEAppsWindow extends IplantWindowBase {
 
     public static final String APPS = "#apps";
     public static final String DE_APPS_ACTIVEVIEW = "de.apps.activeview#";
+
     private final AppsView.Presenter presenter;
 
     @Inject
-    UserInfo userInfo;
-
-
-    @Inject
-    DEAppsWindow(final AppsView.Presenter presenter, final IplantDisplayStrings displayStrings) {
+    DEAppsWindow(final AppsView.Presenter presenter,
+                 final IplantDisplayStrings displayStrings,
+                 final UserInfo userInfo) {
         this.presenter = presenter;
+        this.userInfo = userInfo;
 
         // This must be set before we render view
         ensureDebugId(DeModule.WindowIds.APPS_WINDOW);
-        setSize("820", "400");
+        String width = getSavedWidth(WindowType.APPS.toString());
+        String height = getSavedHeight(WindowType.APPS.toString());
+        setSize((width == null) ? "820" : width, (height == null) ? "400" : height);
         setMinWidth(540);
         setHeading(displayStrings.applications());
     }
@@ -71,10 +74,12 @@ public class DEAppsWindow extends IplantWindowBase {
     }
 
     @Override
-    public void doHide() {
+    public void hide() {
         WebStorageUtil.writeToStorage(DE_APPS_ACTIVEVIEW + userInfo.getUsername(),
                                       presenter.getActiveView());
-        super.doHide();
+        saveHeight(WindowType.APPS.toString());
+        saveWidth(WindowType.APPS.toString());
+        super.hide();
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
@@ -2,7 +2,9 @@ package org.iplantc.de.desktop.client.views.windows;
 
 import org.iplantc.de.apps.client.AppsView;
 import org.iplantc.de.apps.shared.AppsModule;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.util.WebStorageUtil;
 import org.iplantc.de.commons.client.util.WindowUtil;
 import org.iplantc.de.commons.client.views.window.configs.AppsWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
@@ -22,6 +24,7 @@ import com.sencha.gxt.widget.core.client.event.SelectEvent;
 public class DEAppsWindow extends IplantWindowBase {
 
     public static final String APPS = "#apps";
+    public static final String DE_APPS_ACTIVEVIEW = "de.apps.activeview#";
     private final AppsView.Presenter presenter;
 
     @Inject
@@ -43,7 +46,8 @@ public class DEAppsWindow extends IplantWindowBase {
         presenter.go(this,
                      appsWindowConfig.getSelectedAppCategory(),
                      appsWindowConfig.getSelectedApp(),
-                     appsWindowConfig.getView());
+                     WebStorageUtil.readFromStorage(
+                             DE_APPS_ACTIVEVIEW + UserInfo.getInstance().getUsername()));
         super.show(windowConfig, tag, isMaximizable);
         btnHelp = createHelpButton();
         getHeader().insertTool(btnHelp,0);
@@ -64,6 +68,8 @@ public class DEAppsWindow extends IplantWindowBase {
 
     @Override
     public void doHide() {
+        WebStorageUtil.writeToStorage(DE_APPS_ACTIVEVIEW + UserInfo.getInstance().getUsername(),
+                                      presenter.getActiveView());
         super.doHide();
     }
 
@@ -72,7 +78,6 @@ public class DEAppsWindow extends IplantWindowBase {
         AppsWindowConfig config = ConfigFactory.appsWindowConfig();
         config.setSelectedApp(presenter.getSelectedApp());
         config.setSelectedAppCategory(presenter.getSelectedAppCategory());
-        config.setView(presenter.getActiveView());
         return createWindowState(config);
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
@@ -32,7 +32,8 @@ public class DEAppsWindow extends IplantWindowBase {
     @Inject
     DEAppsWindow(final AppsView.Presenter presenter,
                  final IplantDisplayStrings displayStrings,
-                 final UserInfo userInfo) {
+                 final UserInfo userInfo,
+                 final AppsView.AppsViewAppearance appsViewAppearance) {
         this.presenter = presenter;
         this.userInfo = userInfo;
 
@@ -40,7 +41,8 @@ public class DEAppsWindow extends IplantWindowBase {
         ensureDebugId(DeModule.WindowIds.APPS_WINDOW);
         String width = getSavedWidth(WindowType.APPS.toString());
         String height = getSavedHeight(WindowType.APPS.toString());
-        setSize((width == null) ? "820" : width, (height == null) ? "400" : height);
+        setSize((width == null) ? appsViewAppearance.appsWindowWidth() : width,
+                (height == null) ? appsViewAppearance.appsWindowHeight() : height);
         setMinWidth(540);
         setHeading(displayStrings.applications());
     }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DEAppsWindow.java
@@ -28,6 +28,10 @@ public class DEAppsWindow extends IplantWindowBase {
     private final AppsView.Presenter presenter;
 
     @Inject
+    UserInfo userInfo;
+
+
+    @Inject
     DEAppsWindow(final AppsView.Presenter presenter, final IplantDisplayStrings displayStrings) {
         this.presenter = presenter;
 
@@ -47,7 +51,7 @@ public class DEAppsWindow extends IplantWindowBase {
                      appsWindowConfig.getSelectedAppCategory(),
                      appsWindowConfig.getSelectedApp(),
                      WebStorageUtil.readFromStorage(
-                             DE_APPS_ACTIVEVIEW + UserInfo.getInstance().getUsername()));
+                             DE_APPS_ACTIVEVIEW + userInfo.getUsername()));
         super.show(windowConfig, tag, isMaximizable);
         btnHelp = createHelpButton();
         getHeader().insertTool(btnHelp,0);
@@ -68,7 +72,7 @@ public class DEAppsWindow extends IplantWindowBase {
 
     @Override
     public void doHide() {
-        WebStorageUtil.writeToStorage(DE_APPS_ACTIVEVIEW + UserInfo.getInstance().getUsername(),
+        WebStorageUtil.writeToStorage(DE_APPS_ACTIVEVIEW + userInfo.getUsername(),
                                       presenter.getActiveView());
         super.doHide();
     }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
@@ -1,8 +1,10 @@
 package org.iplantc.de.desktop.client.views.windows;
 
 import org.iplantc.de.client.models.HasId;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
 import org.iplantc.de.client.models.diskResources.Folder;
+import org.iplantc.de.client.util.WebStorageUtil;
 import org.iplantc.de.commons.client.util.WindowUtil;
 import org.iplantc.de.commons.client.views.window.configs.DiskResourceWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
@@ -35,6 +37,7 @@ import java.util.List;
 public class DeDiskResourceWindow extends IplantWindowBase implements FolderSelectionEvent.FolderSelectionEventHandler {
 
     public static final String DATA = "#data";
+    public static final String DE_DATA_DETAILSPANEL_COLLAPSE = "de.data.detailspanel.collapse#";
     private final DiskResourcePresenterFactory presenterFactory;
     private final IplantDisplayStrings displayStrings;
     private DiskResourceView.Presenter presenter;
@@ -69,7 +72,10 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
                                                                 resourcesToSelect);
         final String uniqueWindowTag = (diskResourceWindowConfig.getTag() == null) ? "" : "." + diskResourceWindowConfig.getTag();
         ensureDebugId(DeModule.WindowIds.DISK_RESOURCE_WINDOW + uniqueWindowTag);
-        presenter.go(this);
+        String minimizeDeatils  = WebStorageUtil.readFromStorage(
+                DE_DATA_DETAILSPANEL_COLLAPSE + UserInfo
+                .getInstance().getUsername());
+        presenter.go(this, (minimizeDeatils == null)? false: Boolean.valueOf(minimizeDeatils));
         initHandlers();
         super.show(windowConfig, tag, isMaximizable);
         btnHelp = createHelpButton();
@@ -98,6 +104,7 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
         if (!isMinimized()) {
             presenter.cleanUp();
         }
+        WebStorageUtil.writeToStorage(DE_DATA_DETAILSPANEL_COLLAPSE + UserInfo.getInstance().getUsername(), presenter.isDetailsCollapsed() + "");
         super.hide();
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
@@ -72,10 +72,10 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
                                                                 resourcesToSelect);
         final String uniqueWindowTag = (diskResourceWindowConfig.getTag() == null) ? "" : "." + diskResourceWindowConfig.getTag();
         ensureDebugId(DeModule.WindowIds.DISK_RESOURCE_WINDOW + uniqueWindowTag);
-        String minimizeDeatils  = WebStorageUtil.readFromStorage(
+        String minimizeDetails  = WebStorageUtil.readFromStorage(
                 DE_DATA_DETAILSPANEL_COLLAPSE + UserInfo
                 .getInstance().getUsername());
-        presenter.go(this, (minimizeDeatils == null)? false: Boolean.valueOf(minimizeDeatils));
+        presenter.go(this, (minimizeDetails == null)? false: Boolean.valueOf(minimizeDetails));
         initHandlers();
         super.show(windowConfig, tag, isMaximizable);
         btnHelp = createHelpButton();

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
@@ -3,6 +3,7 @@ package org.iplantc.de.desktop.client.views.windows;
 import org.iplantc.de.client.models.HasId;
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.client.models.diskResources.Folder;
 import org.iplantc.de.client.util.WebStorageUtil;
 import org.iplantc.de.commons.client.util.WindowUtil;
@@ -38,21 +39,22 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
 
     public static final String DATA = "#data";
     public static final String DE_DATA_DETAILSPANEL_COLLAPSE = "de.data.detailspanel.collapse#";
+
+
     private final DiskResourcePresenterFactory presenterFactory;
     private final IplantDisplayStrings displayStrings;
     private DiskResourceView.Presenter presenter;
 
     @Inject
-    UserInfo userInfo;
-
-
-    @Inject
     DeDiskResourceWindow(final DiskResourcePresenterFactory presenterFactory,
-                         final IplantDisplayStrings displayStrings) {
+                         final IplantDisplayStrings displayStrings, final  UserInfo userInfo) {
         this.presenterFactory = presenterFactory;
         this.displayStrings = displayStrings;
+        this.userInfo = userInfo;
         setHeading(displayStrings.data());
-        setSize("900", "480");
+        String width = getSavedWidth(WindowType.DATA.toString());
+        String height = getSavedHeight(WindowType.DATA.toString());
+        setSize((width == null) ? "820" : width, (height == null) ? "400" : height);
         setMinWidth(900);
         setMinHeight(480);
     }
@@ -106,6 +108,8 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
         if (!isMinimized()) {
             presenter.cleanUp();
         }
+        saveHeight(WindowType.DATA.toString());
+        saveWidth(WindowType.DATA.toString());
         WebStorageUtil.writeToStorage(DE_DATA_DETAILSPANEL_COLLAPSE + userInfo.getUsername(), presenter.isDetailsCollapsed() + "");
         super.hide();
     }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
@@ -42,6 +42,9 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
     private final IplantDisplayStrings displayStrings;
     private DiskResourceView.Presenter presenter;
 
+    @Inject
+    UserInfo userInfo;
+
 
     @Inject
     DeDiskResourceWindow(final DiskResourcePresenterFactory presenterFactory,
@@ -73,8 +76,7 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
         final String uniqueWindowTag = (diskResourceWindowConfig.getTag() == null) ? "" : "." + diskResourceWindowConfig.getTag();
         ensureDebugId(DeModule.WindowIds.DISK_RESOURCE_WINDOW + uniqueWindowTag);
         String minimizeDetails  = WebStorageUtil.readFromStorage(
-                DE_DATA_DETAILSPANEL_COLLAPSE + UserInfo
-                .getInstance().getUsername());
+                DE_DATA_DETAILSPANEL_COLLAPSE + userInfo.getUsername());
         presenter.go(this, (minimizeDetails == null)? false: Boolean.valueOf(minimizeDetails));
         initHandlers();
         super.show(windowConfig, tag, isMaximizable);
@@ -104,7 +106,7 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
         if (!isMinimized()) {
             presenter.cleanUp();
         }
-        WebStorageUtil.writeToStorage(DE_DATA_DETAILSPANEL_COLLAPSE + UserInfo.getInstance().getUsername(), presenter.isDetailsCollapsed() + "");
+        WebStorageUtil.writeToStorage(DE_DATA_DETAILSPANEL_COLLAPSE + userInfo.getUsername(), presenter.isDetailsCollapsed() + "");
         super.hide();
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/DeDiskResourceWindow.java
@@ -47,16 +47,19 @@ public class DeDiskResourceWindow extends IplantWindowBase implements FolderSele
 
     @Inject
     DeDiskResourceWindow(final DiskResourcePresenterFactory presenterFactory,
-                         final IplantDisplayStrings displayStrings, final  UserInfo userInfo) {
+                         final IplantDisplayStrings displayStrings,
+                         final UserInfo userInfo,
+                         final DiskResourceView.DiskResourceViewAppearance appearance) {
         this.presenterFactory = presenterFactory;
         this.displayStrings = displayStrings;
         this.userInfo = userInfo;
         setHeading(displayStrings.data());
         String width = getSavedWidth(WindowType.DATA.toString());
         String height = getSavedHeight(WindowType.DATA.toString());
-        setSize((width == null) ? "820" : width, (height == null) ? "400" : height);
-        setMinWidth(900);
-        setMinHeight(480);
+        setSize((width == null) ? appearance.windowWidth() : width,
+                (height == null) ? appearance.windowHeight() : height);
+        setMinWidth(Integer.parseInt(appearance.windowWidth()));
+        setMinHeight(Integer.parseInt(appearance.windowHeight()));
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/FileViewerWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/FileViewerWindow.java
@@ -1,11 +1,13 @@
 package org.iplantc.de.desktop.client.views.windows;
 
 import org.iplantc.de.client.models.IsMaskable;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.commons.client.views.window.configs.FileViewerWindowConfig;
-import org.iplantc.de.commons.client.views.window.configs.MultiInputPathListWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.HTPathListWindowConfig;
+import org.iplantc.de.commons.client.views.window.configs.MultiInputPathListWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.TabularFileViewerWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
 import org.iplantc.de.fileViewers.client.FileViewer;
@@ -46,17 +48,19 @@ public class FileViewerWindow extends IplantWindowBase implements IsMaskable,
     private final IplantDisplayStrings displayStrings;
     private final FileViewer.Presenter presenter;
 
+
     @Inject
     FileViewerWindow(final IplantDisplayStrings displayStrings,
-                     final FileViewer.Presenter presenter) {
+                     final FileViewer.Presenter presenter,
+                     final UserInfo userInfo) {
         this.displayStrings = displayStrings;
-
+        this.userInfo = userInfo;
         this.presenter = presenter;
         this.presenter.addDirtyStateChangedEventHandler(this);
-
-        setSize("800", "480");
-
-    }
+        String width = getSavedWidth(WindowType.FILE_VIEWER.toString());
+        String height = getSavedHeight(WindowType.FILE_VIEWER.toString());
+        setSize((width == null) ? "800" : width, (height == null) ? "480" : height);
+   }
 
     @Override
     public <C extends WindowConfig> void show(C windowConfig, String tag,
@@ -98,7 +102,9 @@ public class FileViewerWindow extends IplantWindowBase implements IsMaskable,
     }
 
     @Override
-    public void doHide() {
+    public void hide() {
+        saveHeight(WindowType.FILE_VIEWER.toString());
+        saveWidth(WindowType.FILE_VIEWER.toString());
         if (presenter.isDirty() && configAB.isEditing()) {
             final MessageBox cmb = new MessageBox(displayStrings.save(), displayStrings.unsavedChanges());
             cmb.setPredefinedButtons(PredefinedButton.YES, PredefinedButton.NO, PredefinedButton.CANCEL);
@@ -109,14 +115,14 @@ public class FileViewerWindow extends IplantWindowBase implements IsMaskable,
                         cmb.hide();
                         presenter.saveFile();
                     } else if (PredefinedButton.NO.equals(event.getHideButton())) {
-                        FileViewerWindow.super.doHide();
+                        FileViewerWindow.super.hide();
                     }
 
                 }
             });
             cmb.show();
         } else {
-            super.doHide();
+            super.hide();
         }
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/FileViewerWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/FileViewerWindow.java
@@ -52,14 +52,16 @@ public class FileViewerWindow extends IplantWindowBase implements IsMaskable,
     @Inject
     FileViewerWindow(final IplantDisplayStrings displayStrings,
                      final FileViewer.Presenter presenter,
-                     final UserInfo userInfo) {
+                     final UserInfo userInfo,
+                     final FileViewer.FileViewerAppearance appearance) {
         this.displayStrings = displayStrings;
         this.userInfo = userInfo;
         this.presenter = presenter;
         this.presenter.addDirtyStateChangedEventHandler(this);
         String width = getSavedWidth(WindowType.FILE_VIEWER.toString());
         String height = getSavedHeight(WindowType.FILE_VIEWER.toString());
-        setSize((width == null) ? "800" : width, (height == null) ? "480" : height);
+        setSize((width == null) ? appearance.windowWidth() : width,
+                (height == null) ? appearance.windowHeight() : height);
    }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/IplantWindowBase.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/IplantWindowBase.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.desktop.client.views.windows;
 
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.util.WebStorageUtil;
 import org.iplantc.de.commons.client.CommonUiConstants;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
 import org.iplantc.de.desktop.client.views.widgets.ServiceDownPanel;
@@ -126,6 +128,10 @@ public abstract class IplantWindowBase extends Window implements IPlantWindowInt
     protected CommonUiConstants constants = GWT.create(CommonUiConstants.class);
     protected Widget currentWidget;
     protected ServiceDownPanel serviceDownPanel;
+    UserInfo userInfo;
+    protected final String LOCAL_STORAGE_PREFIX = "de.";
+    protected final String SAVED_WIDTH = ".saved.width";
+    protected final String SAVED_HEIGHT = ".saved.height";
 
     public IplantWindowBase() {
         this(GWT.<IplantWindowAppearance> create(IplantWindowAppearance.class));
@@ -267,12 +273,8 @@ public abstract class IplantWindowBase extends Window implements IPlantWindowInt
             minimized = false;
             manager.unregister(this);
         }
-        super.hide();
-    }
-
-    protected void doHide() {
-        hide();
         logWindowCloseToIntercom(config);
+        super.hide();
     }
 
     @Override
@@ -303,7 +305,7 @@ public abstract class IplantWindowBase extends Window implements IPlantWindowInt
         newCloseBtn.addSelectHandler(new SelectHandler() {
             @Override
             public void onSelect(SelectEvent event) {
-                doHide();
+                hide();
             }
         });
         return newCloseBtn;
@@ -616,6 +618,28 @@ public abstract class IplantWindowBase extends Window implements IPlantWindowInt
 
             }
         }
+    }
+
+    protected String getSavedHeight(String windowType) {
+        return WebStorageUtil.readFromStorage(
+                LOCAL_STORAGE_PREFIX + windowType + SAVED_HEIGHT + "#"
+                + userInfo.getUsername());
+    }
+
+    protected String getSavedWidth(String windowType) {
+        return WebStorageUtil.readFromStorage(
+                LOCAL_STORAGE_PREFIX + windowType + SAVED_WIDTH + "#"
+                + userInfo.getUsername());
+    }
+
+    protected void saveHeight(String windowType) {
+      WebStorageUtil.writeToStorage(LOCAL_STORAGE_PREFIX + windowType + SAVED_HEIGHT + "#"
+                                    + userInfo.getUsername(), getOffsetHeight() + "");
+    }
+
+    protected void saveWidth(String windowType) {
+         WebStorageUtil.writeToStorage(LOCAL_STORAGE_PREFIX + windowType + SAVED_WIDTH + "#"
+                                       + userInfo.getUsername(), getOffsetWidth() + "");
     }
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/ManageToolsWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/ManageToolsWindow.java
@@ -23,12 +23,14 @@ public class ManageToolsWindow extends IplantWindowBase {
     @Inject
     public ManageToolsWindow(ManageToolsView.Presenter toolsPresenter,
                              final IplantDisplayStrings displayStrings,
-                             final UserInfo userInfo) {
+                             final UserInfo userInfo,
+                             final ManageToolsView.ManageToolsViewAppearance appearance) {
         this.toolsPresenter = toolsPresenter;
         this.userInfo = userInfo;
         String width = getSavedWidth(WindowType.MANAGETOOLS.toString());
         String height = getSavedWidth(WindowType.MANAGETOOLS.toString());
-        setSize((width == null) ? "800" : width, (height == null) ? "600" : height);
+        setSize((width == null) ? appearance.windowWidth() : width,
+                (height == null) ? appearance.windowHeight() : height);
 
         setHeading(displayStrings.manageTools());
         ensureDebugId(DeModule.WindowIds.MANAGE_TOOLS_WINDOW);

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/ManageToolsWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/ManageToolsWindow.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.desktop.client.views.windows;
 
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
 import org.iplantc.de.desktop.shared.DeModule;
@@ -20,9 +22,14 @@ public class ManageToolsWindow extends IplantWindowBase {
 
     @Inject
     public ManageToolsWindow(ManageToolsView.Presenter toolsPresenter,
-                             final IplantDisplayStrings displayStrings) {
+                             final IplantDisplayStrings displayStrings,
+                             final UserInfo userInfo) {
         this.toolsPresenter = toolsPresenter;
-        setSize("800px", "600px");
+        this.userInfo = userInfo;
+        String width = getSavedWidth(WindowType.MANAGETOOLS.toString());
+        String height = getSavedWidth(WindowType.MANAGETOOLS.toString());
+        setSize((width == null) ? "800" : width, (height == null) ? "600" : height);
+
         setHeading(displayStrings.manageTools());
         ensureDebugId(DeModule.WindowIds.MANAGE_TOOLS_WINDOW);
     }
@@ -44,6 +51,13 @@ public class ManageToolsWindow extends IplantWindowBase {
     protected void onEnsureDebugId(String baseID) {
         super.onEnsureDebugId(baseID);
         toolsPresenter.setViewDebugId(baseID + ToolsModule.ToolIds.TOOLS_VIEW);
+    }
+
+    @Override
+    public void hide() {
+        saveHeight(WindowType.MANAGETOOLS.toString());
+        saveWidth(WindowType.MANAGETOOLS.toString());
+        super.hide();
     }
 
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/MyAnalysesWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/MyAnalysesWindow.java
@@ -2,7 +2,9 @@ package org.iplantc.de.desktop.client.views.windows;
 
 import org.iplantc.de.analysis.client.AnalysesView;
 import org.iplantc.de.analysis.shared.AnalysisModule;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.client.models.analysis.Analysis;
 import org.iplantc.de.commons.client.util.WindowUtil;
 import org.iplantc.de.commons.client.views.window.configs.AnalysisWindowConfig;
@@ -28,14 +30,19 @@ public class MyAnalysesWindow extends IplantWindowBase {
     public static final String ANALYSES = "#analyses";
     private final AnalysesView.Presenter presenter;
 
+
     @Inject
     MyAnalysesWindow(final AnalysesView.Presenter presenter,
-                     final IplantDisplayStrings displayStrings) {
+                     final IplantDisplayStrings displayStrings,
+                     final UserInfo userInfo) {
         this.presenter = presenter;
+        this.userInfo = userInfo;
 
         ensureDebugId(DeModule.WindowIds.ANALYSES_WINDOW);
         setHeading(displayStrings.analyses());
-        setSize("670", "375");
+        String width = getSavedWidth(WindowType.ANALYSES.toString());
+        String height = getSavedHeight(WindowType.ANALYSES.toString());
+        setSize((width == null) ? "670" : width, (height == null) ? "375" : height);
         setMinWidth(590);
     }
 
@@ -80,5 +87,12 @@ public class MyAnalysesWindow extends IplantWindowBase {
     protected void onEnsureDebugId(String baseID) {
         super.onEnsureDebugId(baseID);
         presenter.setViewDebugId(baseID + AnalysisModule.Ids.ANALYSES_VIEW);
+    }
+
+    @Override
+    public void hide() {
+        saveWidth(WindowType.ANALYSES.toString());
+        saveHeight(WindowType.ANALYSES.toString());
+        super.hide();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/MyAnalysesWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/MyAnalysesWindow.java
@@ -34,7 +34,8 @@ public class MyAnalysesWindow extends IplantWindowBase {
     @Inject
     MyAnalysesWindow(final AnalysesView.Presenter presenter,
                      final IplantDisplayStrings displayStrings,
-                     final UserInfo userInfo) {
+                     final UserInfo userInfo,
+                     final AnalysesView.Appearance appearance) {
         this.presenter = presenter;
         this.userInfo = userInfo;
 
@@ -42,8 +43,9 @@ public class MyAnalysesWindow extends IplantWindowBase {
         setHeading(displayStrings.analyses());
         String width = getSavedWidth(WindowType.ANALYSES.toString());
         String height = getSavedHeight(WindowType.ANALYSES.toString());
-        setSize((width == null) ? "670" : width, (height == null) ? "375" : height);
-        setMinWidth(590);
+        setSize((width == null) ? appearance.windowWidth() : width,
+                (height == null) ? appearance.windowHeight() : height);
+        setMinWidth(appearance.windowMinWidth());
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/NotificationWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/NotificationWindow.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.desktop.client.views.windows;
 
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
 import org.iplantc.de.commons.client.views.window.configs.NotifyWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
@@ -19,12 +21,16 @@ public class NotificationWindow extends IplantWindowBase {
 
     @Inject
     NotificationWindow(NotificationView.Presenter presenter,
-                       NotificationView.NotificationViewAppearance appearance) {
+                       NotificationView.NotificationViewAppearance appearance,
+                       UserInfo userInfo) {
         this.presenter = presenter;
         this.appearance = appearance;
+        this.userInfo = userInfo;
         setHeading(appearance.notifications());
         ensureDebugId(DeModule.WindowIds.NOTIFICATION);
-        setSize("600", "375");
+        String width = getSavedWidth(WindowType.NOTIFICATIONS.toString());
+        String height = getSavedHeight(WindowType.NOTIFICATIONS.toString());
+        setSize((width == null) ? "600" : width, (height == null) ? "375" : height);
     }
 
     @Override
@@ -43,6 +49,13 @@ public class NotificationWindow extends IplantWindowBase {
     public WindowState getWindowState() {
         NotifyWindowConfig config = ConfigFactory.notifyWindowConfig(presenter.getCurrentCategory());
         return createWindowState(config);
+    }
+
+    @Override
+    public void hide() {
+        saveHeight(WindowType.NOTIFICATIONS.toString());
+        saveWidth(WindowType.NOTIFICATIONS.toString());
+        super.hide();
     }
 
 }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/NotificationWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/NotificationWindow.java
@@ -30,7 +30,8 @@ public class NotificationWindow extends IplantWindowBase {
         ensureDebugId(DeModule.WindowIds.NOTIFICATION);
         String width = getSavedWidth(WindowType.NOTIFICATIONS.toString());
         String height = getSavedHeight(WindowType.NOTIFICATIONS.toString());
-        setSize((width == null) ? "600" : width, (height == null) ? "375" : height);
+        setSize((width == null) ? appearance.windowWidth() : width,
+                (height == null) ? appearance.windowHeight() : height);
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/PipelineEditorWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/PipelineEditorWindow.java
@@ -53,15 +53,17 @@ public class PipelineEditorWindow extends IplantWindowBase {
 
     @Inject
     PipelineEditorWindow(final IplantDisplayStrings displayStrings,
-                         UserInfo userInfo) {
+                         UserInfo userInfo,
+                         final AppsView.AppsViewAppearance appsViewAppearance) {
         this.displayStrings = displayStrings;
         this.userInfo = userInfo;
         setHeading(displayStrings.pipeline());
         String width = getSavedWidth(WindowType.WORKFLOW_INTEGRATION.toString());
         String height = getSavedHeight(WindowType.WORKFLOW_INTEGRATION.toString());
-        setSize((width == null) ? "900" : width, (height == null) ? "500" : height);
-        setMinWidth(640);
-        setMinHeight(440);
+        setSize((width == null) ? appsViewAppearance.pipelineEdWindowWidth() : width,
+                (height == null) ? appsViewAppearance.pipelineEdWindowHeight() : height);
+        setMinWidth(appsViewAppearance.pipelineEdWindowMinWidth());
+        setMinHeight(appsViewAppearance.pipelineEdWindowMinHeight());
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/PipelineEditorWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/PipelineEditorWindow.java
@@ -1,7 +1,9 @@
 package org.iplantc.de.desktop.client.views.windows;
 
 import org.iplantc.de.apps.client.AppsView;
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.client.models.pipelines.Pipeline;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.commons.client.info.SuccessAnnouncementConfig;
@@ -50,11 +52,14 @@ public class PipelineEditorWindow extends IplantWindowBase {
     private PipelineView view;
 
     @Inject
-    PipelineEditorWindow(final IplantDisplayStrings displayStrings) {
+    PipelineEditorWindow(final IplantDisplayStrings displayStrings,
+                         UserInfo userInfo) {
         this.displayStrings = displayStrings;
-
+        this.userInfo = userInfo;
         setHeading(displayStrings.pipeline());
-        setSize("900", "500");
+        String width = getSavedWidth(WindowType.WORKFLOW_INTEGRATION.toString());
+        String height = getSavedHeight(WindowType.WORKFLOW_INTEGRATION.toString());
+        setSize((width == null) ? "900" : width, (height == null) ? "500" : height);
         setMinWidth(640);
         setMinHeight(440);
     }
@@ -99,6 +104,8 @@ public class PipelineEditorWindow extends IplantWindowBase {
 
     @Override
     public void hide() {
+        saveHeight(WindowType.WORKFLOW_INTEGRATION.toString());
+        saveWidth(WindowType.WORKFLOW_INTEGRATION.toString());
         if (!isMinimized()) {
             if (initPipelineJson != null
                     && !initPipelineJson.equals(presenter.getPublishJson(presenter.getPipeline()))) {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/SimpleDownloadWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/SimpleDownloadWindow.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.desktop.client.views.windows;
 
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.client.models.diskResources.DiskResource;
 import org.iplantc.de.client.services.DiskResourceServiceFacade;
 import org.iplantc.de.client.util.DiskResourceUtil;
@@ -31,12 +33,17 @@ public class SimpleDownloadWindow extends IplantWindowBase {
 
     @Inject
     SimpleDownloadWindow(final IplantDisplayStrings displayStrings,
-                         final DiskResourceServiceFacade diskResourceServiceFacade) {
+                         final DiskResourceServiceFacade diskResourceServiceFacade,
+                         final UserInfo userInfo) {
         this.displayStrings = displayStrings;
         this.diskResourceServiceFacade = diskResourceServiceFacade;
-
+        this.userInfo = userInfo;
         setHeading(displayStrings.download());
-        setSize("320", "320");
+
+        String width = getSavedWidth(WindowType.SIMPLE_DOWNLOAD.toString());
+        String height = getSavedHeight(WindowType.SIMPLE_DOWNLOAD.toString());
+        setSize((width == null) ? "320" : width, (height == null) ? "320" : height);
+
         ensureDebugId(DeModule.WindowIds.SIMPLE_DOWNLOAD);
     }
 
@@ -52,6 +59,13 @@ public class SimpleDownloadWindow extends IplantWindowBase {
     public WindowState getWindowState() {
         SimpleDownloadWindowConfig config = ConfigFactory.simpleDownloadWindowConfig();
         return createWindowState(config);
+    }
+
+    @Override
+    public void hide() {
+        saveHeight(WindowType.SIMPLE_DOWNLOAD.toString());
+        saveWidth(WindowType.SIMPLE_DOWNLOAD.toString());
+        super.hide();
     }
 
     private void buildLinks(SimpleDownloadWindowConfig config, VerticalLayoutContainer vlc) {

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/SimpleDownloadWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/SimpleDownloadWindow.java
@@ -28,6 +28,13 @@ import com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer;
  */
 public class SimpleDownloadWindow extends IplantWindowBase {
 
+
+    public interface SimpleDownloadWindowAppearance {
+        String windowWidth();
+
+        String windowHeight();
+    }
+
     private final DiskResourceServiceFacade diskResourceServiceFacade;
     private final IplantDisplayStrings displayStrings;
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/SystemMessagesWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/SystemMessagesWindow.java
@@ -9,6 +9,7 @@ import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
 import org.iplantc.de.desktop.shared.DeModule;
 import org.iplantc.de.resources.client.messages.IplantDisplayStrings;
 import org.iplantc.de.systemMessages.client.presenter.MessagesPresenter;
+import org.iplantc.de.systemMessages.client.view.MessagesView;
 import org.iplantc.de.systemMessages.shared.SystemMessages;
 
 import com.google.gwt.user.client.Window;
@@ -25,15 +26,14 @@ public final class SystemMessagesWindow extends IplantWindowBase {
 
     @Inject
     SystemMessagesWindow(final IplantDisplayStrings displayStrings,
-                         final UserInfo userInfo) {
+                         final UserInfo userInfo,
+                         final MessagesView.MessagesAppearance appearance) {
         this.userInfo = userInfo;
         setHeading(displayStrings.systemMessagesLabel());
         String width = getSavedWidth(WindowType.SYSTEM_MESSAGES.toString());
         String height = getSavedHeight(WindowType.SYSTEM_MESSAGES.toString());
-        setSize((width == null) ? computeDefaultWidth() + "" : width, (height == null) ? computeDefaultHeight() + "" : height);
-
-        setWidth(computeDefaultWidth());
-        setHeight(computeDefaultHeight());
+        setSize((width == null) ? computeDefaultWidth(appearance) + "" : width,
+                (height == null) ? computeDefaultHeight(appearance) + "" : height);
     }
 
     @Override
@@ -45,12 +45,12 @@ public final class SystemMessagesWindow extends IplantWindowBase {
         ensureDebugId(DeModule.WindowIds.SYSTEM_MESSAGES);
     }
 
-    private static int computeDefaultHeight() {
-        return Math.max(400, Window.getClientHeight() / 3);
+    private static int computeDefaultHeight(MessagesView.MessagesAppearance appearance) {
+        return Math.max(Integer.parseInt(appearance.windowHeight()), Window.getClientHeight() / 3);
     }
 
-    private static int computeDefaultWidth() {
-        return Math.max(600, Window.getClientWidth() / 3);
+    private static int computeDefaultWidth(MessagesView.MessagesAppearance appearance) {
+        return Math.max(Integer.parseInt(appearance.windowWidth()), Window.getClientWidth() / 3);
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/SystemMessagesWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/SystemMessagesWindow.java
@@ -1,6 +1,8 @@
 package org.iplantc.de.desktop.client.views.windows;
 
+import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.WindowState;
+import org.iplantc.de.client.models.WindowType;
 import org.iplantc.de.commons.client.views.window.configs.ConfigFactory;
 import org.iplantc.de.commons.client.views.window.configs.SystemMessagesWindowConfig;
 import org.iplantc.de.commons.client.views.window.configs.WindowConfig;
@@ -20,9 +22,16 @@ public final class SystemMessagesWindow extends IplantWindowBase {
 
     private MessagesPresenter presenter;
 
+
     @Inject
-    SystemMessagesWindow(final IplantDisplayStrings displayStrings) {
+    SystemMessagesWindow(final IplantDisplayStrings displayStrings,
+                         final UserInfo userInfo) {
+        this.userInfo = userInfo;
         setHeading(displayStrings.systemMessagesLabel());
+        String width = getSavedWidth(WindowType.SYSTEM_MESSAGES.toString());
+        String height = getSavedHeight(WindowType.SYSTEM_MESSAGES.toString());
+        setSize((width == null) ? computeDefaultWidth() + "" : width, (height == null) ? computeDefaultHeight() + "" : height);
+
         setWidth(computeDefaultWidth());
         setHeight(computeDefaultHeight());
     }
@@ -53,19 +62,18 @@ public final class SystemMessagesWindow extends IplantWindowBase {
         return createWindowState(ConfigFactory.systemMessagesWindowConfig(selMsg));
     }
 
-    /**
-     * @see IplantWindowBase#doHide()
-     */
-    @Override
-    protected void doHide() {
-        presenter.stop();
-        super.doHide();
-    }
-
     @Override
     protected void onEnsureDebugId(String baseID) {
         super.onEnsureDebugId(baseID);
 
         presenter.setViewDebugId(baseID + SystemMessages.Ids.VIEW);
+    }
+
+    @Override
+    public void hide() {
+        saveHeight(WindowType.SYSTEM_MESSAGES.toString());
+        saveWidth(WindowType.SYSTEM_MESSAGES.toString());
+        presenter.stop();
+        super.hide();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/DiskResourceView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/DiskResourceView.java
@@ -32,6 +32,11 @@ public interface DiskResourceView extends IsWidget,
                                           IsMaskable {
 
 
+    interface DiskResourceViewAppearance {
+        String windowHeight();
+
+        String windowWidth();
+    }
 
     boolean isDetailsCollapsed();
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/DiskResourceView.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/DiskResourceView.java
@@ -31,6 +31,12 @@ import java.util.List;
 public interface DiskResourceView extends IsWidget,
                                           IsMaskable {
 
+
+
+    boolean isDetailsCollapsed();
+
+    void setDetailsCollapsed(boolean collapsed);
+
     /**
      * A dataproxy used by the <code>Presenter</code> to fetch <code>DiskResource</code> data from the
      * {@link DiskResourceServiceFacade}.
@@ -48,12 +54,13 @@ public interface DiskResourceView extends IsWidget,
     }
 
 
-    interface Presenter extends org.iplantc.de.commons.client.presenter.Presenter,
-                                IsMaskable,
+    interface Presenter extends IsMaskable,
                                 HasDiskResourceSelectionChangedEventHandlers,
                                 HasFolderSelectionEventHandlers,
                                 RefreshFolderSelected.RefreshFolderSelectedHandler,
                                 CreateNewFolderConfirmed.CreateNewFolderConfirmedHandler {
+
+        boolean isDetailsCollapsed();
 
         interface Appearance {
 
@@ -125,6 +132,8 @@ public interface DiskResourceView extends IsWidget,
         List<DiskResource> getSelectedDiskResources();
 
         Folder getSelectedFolder();
+
+        void  go(HasOneWidget container, boolean collapseDetailsPanel);
 
         void go(HasOneWidget container, HasPath folderToSelect,
                 List<? extends HasId> diskResourcesToSelect);

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/DiskResourcePresenterImpl.java
@@ -631,11 +631,12 @@ public class DiskResourcePresenterImpl implements
     }
 
     @Override
-    public void go(HasOneWidget container) {
+    public void go(HasOneWidget container, boolean collapseDetailsPanel) {
         container.setWidget(view);
         // JDS Re-select currently selected folder in order to load center
         // panel.
         navigationPresenter.setSelectedFolder(navigationPresenter.getSelectedFolder());
+        view.setDetailsCollapsed(collapseDetailsPanel);
     }
 
     @Override
@@ -644,12 +645,17 @@ public class DiskResourcePresenterImpl implements
                    final List<? extends HasId> diskResourcesToSelect) {
 
         if ((folderToSelect == null) || Strings.isNullOrEmpty(folderToSelect.getPath())) {
-            go(container);
+            go(container, true);
         } else {
             container.setWidget(view);
             navigationPresenter.setSelectedFolder(folderToSelect);
             setSelectedDiskResourcesById(diskResourcesToSelect);
         }
+    }
+
+    @Override
+    public boolean isDetailsCollapsed() {
+      return view.isDetailsCollapsed();
     }
 
     @Override
@@ -770,4 +776,5 @@ public class DiskResourcePresenterImpl implements
         return new ConfirmMessageBox(title,
                                      appearance.emptyTrashWarning());
     }
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/DiskResourceView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/DiskResourceView.ui.xml
@@ -67,7 +67,7 @@
 
         <!-- Details Panel -->
         <container:east layoutData="{eastData}">
-            <gxt:ContentPanel heading="{appearance.details}">
+            <gxt:ContentPanel ui:field="detailsPanel" heading="{appearance.details}">
                 <views:DetailsView ui:field="detailsView" />
             </gxt:ContentPanel>
         </container:east>

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/DiskResourceViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/DiskResourceViewImpl.java
@@ -8,6 +8,7 @@ import org.iplantc.de.diskResource.client.ToolbarView;
 import org.iplantc.de.diskResource.share.DiskResourceModule;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiTemplate;
@@ -17,6 +18,7 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
 import com.sencha.gxt.widget.core.client.Composite;
+import com.sencha.gxt.widget.core.client.ContentPanel;
 import com.sencha.gxt.widget.core.client.container.BorderLayoutContainer;
 import com.sencha.gxt.widget.core.client.container.BorderLayoutContainer.BorderLayoutData;
 
@@ -37,6 +39,8 @@ public class DiskResourceViewImpl extends Composite implements DiskResourceView 
     @UiField BorderLayoutData eastData;
     @UiField BorderLayoutData northData;
     @UiField BorderLayoutData southData;
+    @UiField
+    ContentPanel detailsPanel;
 
     @UiField(provided = true) final NavigationView navigationView;
     @UiField(provided = true) final GridView centerGridView;
@@ -98,4 +102,25 @@ public class DiskResourceViewImpl extends Composite implements DiskResourceView 
     public void unmask() {
         con.unmask();
     }
+
+
+    @Override
+    public boolean isDetailsCollapsed() {
+        return detailsPanel.isCollapsed();
+    }
+
+    @Override
+    public void setDetailsCollapsed(boolean collapsed) {
+        if(collapsed) {
+            Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+                @Override
+                public void execute() {
+                    detailsPanel.collapse();
+                }
+            });
+        } else {
+            detailsPanel.expand();
+        }
+    }
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FolderSelectDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/FolderSelectDialog.java
@@ -145,7 +145,7 @@ public class FolderSelectDialog extends IPlantDialog implements TakesValue<Folde
         presenter.addDiskResourceSelectionChangedEventHandler(new DiskResourceSelectionChangedHandler(presenter,
                                                                                                       this,
                                                                                                       infoTypeFilters));
-        presenter.go(this);
+        presenter.go(this, true);
         super.show();
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/SaveAsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/dialogs/SaveAsDialog.java
@@ -115,7 +115,7 @@ public class SaveAsDialog extends IPlantDialog {
                                                                          vlc,
                                                                          60);
         presenter.addFolderSelectedEventHandler(new FolderSelectionChangedHandler());
-        presenter.go(this);
+        presenter.go(this, true);
         super.show();
 
         ensureDebugId(DiskResourceModule.Ids.SAVE_AS_DIALOG);

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/FileViewer.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/FileViewer.java
@@ -34,6 +34,12 @@ public interface FileViewer extends IsWidget, IsMaskable, HasHandlers, FileSaved
         void save();
     }
 
+    interface FileViewerAppearance {
+       String windowWidth();
+
+       String windowHeight();
+    }
+
     interface FileViewerPresenterAppearance {
 
         String fileOpenMsg(); // display strings with same name

--- a/de-lib/src/main/java/org/iplantc/de/notifications/client/views/NotificationView.java
+++ b/de-lib/src/main/java/org/iplantc/de/notifications/client/views/NotificationView.java
@@ -42,6 +42,10 @@ public interface NotificationView extends IsWidget,
 
         int createdDateColumnWidth();
 
+        String windowWidth();
+
+        String windowHeight();
+
     }
 
     public interface Presenter extends org.iplantc.de.commons.client.presenter.Presenter {

--- a/de-lib/src/main/java/org/iplantc/de/systemMessages/client/view/MessagesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/systemMessages/client/view/MessagesView.java
@@ -20,6 +20,13 @@ import java.util.Date;
  */
 public interface MessagesView<M> extends IsWidget {
 
+
+    public interface MessagesAppearance {
+        String windowHeight();
+
+        String windowWidth();
+    }
+
     /**
      * The properties of the messages used by the view
      */

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/AnalysesViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/AnalysesViewDefaultAppearance.java
@@ -308,4 +308,19 @@ public class AnalysesViewDefaultAppearance implements AnalysesView.Appearance {
     public int dotMenuWidth() {
         return 40;
     }
+
+    @Override
+    public String windowWidth() {
+        return "670";
+    }
+
+    @Override
+    public String windowHeight() {
+        return "375";
+    }
+
+    @Override
+    public int windowMinWidth() {
+        return 590;
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/AppsViewDefaultAppearance.java
@@ -22,4 +22,34 @@ public class AppsViewDefaultAppearance implements AppsView.AppsViewAppearance {
     public String viewCategoriesHeader() {
         return appsMessages.viewCategoriesHeader();
     }
+
+    @Override
+    public String appsWindowWidth() {
+        return "820";
+    }
+
+    @Override
+    public String appsWindowHeight() {
+        return "400";
+    }
+
+    @Override
+    public String pipelineEdWindowWidth() {
+        return "900";
+    }
+
+    @Override
+    public String pipelineEdWindowHeight() {
+        return "500";
+    }
+
+    @Override
+    public int pipelineEdWindowMinWidth() {
+        return 640;
+    }
+
+    @Override
+    public int pipelineEdWindowMinHeight() {
+        return 440;
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/widgets/AppLaunchViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/apps/widgets/AppLaunchViewDefaultAppearance.java
@@ -119,4 +119,14 @@ public class AppLaunchViewDefaultAppearance implements AppLaunchView.AppLaunchVi
     public String launchAnalysis() {
         return iplantDisplayStrings.launchAnalysis();
     }
+
+    @Override
+    public String windowHeight() {
+        return "350";
+    }
+
+    @Override
+    public String windowWidth() {
+        return "300";
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/Desktop.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/Desktop.gwt.xml
@@ -49,4 +49,9 @@
         <when-type-is class="org.iplantc.de.desktop.client.views.widgets.ServiceDownPanel.ServiceDownPanelAppearance"/>
     </replace-with>
 
+    <replace-with class="org.iplantc.de.theme.base.client.desktop.window.SystemMessagesDefaultAppearance">
+        <when-type-is
+                class="org.iplantc.de.systemMessages.client.view.MessagesView.MessagesAppearance"/>
+    </replace-with>
+
 </module>

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/AboutApplicationDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/AboutApplicationDefaultAppearance.java
@@ -85,4 +85,14 @@ public class AboutApplicationDefaultAppearance implements AboutApplicationWindow
         return resources.css().iplantAboutPadText();
     }
 
+    @Override
+    public String windowWidth() {
+        return "320";
+    }
+
+    @Override
+    public String windowHeight() {
+        return "260";
+    }
+
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/AppEditorWindowBaseAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/AppEditorWindowBaseAppearance.java
@@ -97,4 +97,14 @@ public class AppEditorWindowBaseAppearance implements AppEditorWindow.AppEditorA
     public String unableToRetrieveWorkflowGuide() {
         return "Unable to open the selected App";
     }
+
+    @Override
+    public String windowWidth() {
+        return "800";
+    }
+
+    @Override
+    public String windowHeight() {
+        return "480";
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/SystemMessagesDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/desktop/window/SystemMessagesDefaultAppearance.java
@@ -1,0 +1,24 @@
+package org.iplantc.de.theme.base.client.desktop.window;
+
+import org.iplantc.de.systemMessages.client.view.MessagesView;
+
+/**
+ * Created by sriram on 1/8/18.
+ */
+public class SystemMessagesDefaultAppearance implements MessagesView.MessagesAppearance {
+
+
+    public SystemMessagesDefaultAppearance() {
+        
+    }
+
+    @Override
+    public String windowHeight() {
+        return "400";
+    }
+
+    @Override
+    public String windowWidth() {
+        return "600";
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/DiskResource.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/DiskResource.gwt.xml
@@ -166,4 +166,13 @@
     <replace-with class="org.iplantc.de.theme.base.client.diskResource.toolbar.PathListAutomationDefaultAppearance">
         <when-type-is class="org.iplantc.de.diskResource.client.PathListAutomationView.PathListAutomationAppearance"/>
     </replace-with>
+
+    <replace-with class="org.iplantc.de.theme.base.client.diskResource.view.DiskResourceViewDeafultAppearance">
+        <when-type-is class="org.iplantc.de.diskResource.client.DiskResourceView.DiskResourceViewAppearance"></when-type-is>
+    </replace-with>
+
+    <replace-with class="org.iplantc.de.desktop.client.views.windows.SimpleDownloadWindow.SimpleDownloadWindowAppearance">
+        <when-type-is class="org.iplantc.de.theme.base.client.diskResource.view.SimpleDownloadWindowDefaultAppearance"></when-type-is>
+    </replace-with>
+    
 </module>

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/view/DiskResourceViewDeafultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/view/DiskResourceViewDeafultAppearance.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.theme.base.client.diskResource.view;
+
+import org.iplantc.de.diskResource.client.DiskResourceView;
+
+/**
+ * Created by sriram on 1/8/18.
+ */
+public class DiskResourceViewDeafultAppearance implements DiskResourceView.DiskResourceViewAppearance {
+    @Override
+    public String windowHeight() {
+        return "480";
+    }
+
+    @Override
+    public String windowWidth() {
+        return "900";
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/view/SimpleDownloadWindowDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/diskResource/view/SimpleDownloadWindowDefaultAppearance.java
@@ -1,0 +1,24 @@
+package org.iplantc.de.theme.base.client.diskResource.view;
+
+import org.iplantc.de.desktop.client.views.windows.SimpleDownloadWindow;
+
+/**
+ * Created by sriram on 1/8/18.
+ */
+public class SimpleDownloadWindowDefaultAppearance
+        implements SimpleDownloadWindow.SimpleDownloadWindowAppearance {
+
+    public SimpleDownloadWindowDefaultAppearance() {
+        
+    }
+
+    @Override
+    public String windowWidth() {
+        return "320";
+    }
+
+    @Override
+    public String windowHeight() {
+        return "320";
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewerDefaultAppearance.java
@@ -1,0 +1,18 @@
+package org.iplantc.de.theme.base.client.fileViewers;
+
+import org.iplantc.de.fileViewers.client.FileViewer;
+
+/**
+ * Created by sriram on 1/8/18.
+ */
+public class FileViewerDefaultAppearance implements FileViewer.FileViewerAppearance {
+    @Override
+    public String windowWidth() {
+        return "800";
+    }
+
+    @Override
+    public String windowHeight() {
+        return "480";
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewers.gwt.xml
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/fileViewers/FileViewers.gwt.xml
@@ -64,4 +64,9 @@
     <replace-with class="org.iplantc.de.theme.base.client.fileViewers.callbacks.TreeUrlCallbackDefaultAppearance">
         <when-type-is class="org.iplantc.de.fileViewers.client.callbacks.TreeUrlCallback.TreeUrlCallbackAppearance"/>
     </replace-with>
+
+    <replace-with class="org.iplantc.de.theme.base.client.fileViewers.FileViewerDefaultAppearance">
+        <when-type-is class="org.iplantc.de.fileViewers.client.FileViewer.FileViewerAppearance" />
+    </replace-with>
 </module>
+

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/notifications/NotificationViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/notifications/NotificationViewDefaultAppearance.java
@@ -79,4 +79,14 @@ public class NotificationViewDefaultAppearance implements NotificationView.Notif
     public int createdDateColumnWidth() {
         return 170;
     }
+
+    @Override
+    public String windowWidth() {
+        return "600";
+    }
+
+    @Override
+    public String windowHeight() {
+        return "375";
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/tools/ManageToolsViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/tools/ManageToolsViewDefaultAppearance.java
@@ -184,6 +184,16 @@ public class ManageToolsViewDefaultAppearance implements ManageToolsToolbarView.
     }
 
     @Override
+    public String windowWidth() {
+        return "600";
+    }
+
+    @Override
+    public String windowHeight() {
+        return "500";
+    }
+
+    @Override
     public String submitForPublicUse() {
         return toolMessages.submitForUse();
     }

--- a/de-lib/src/main/java/org/iplantc/de/tools/client/views/manage/ManageToolsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/tools/client/views/manage/ManageToolsView.java
@@ -82,6 +82,10 @@ public interface ManageToolsView extends IsWidget,
         String done();
 
         String toolInfoError();
+
+        String windowWidth();
+
+        String windowHeight();
     }
 
 


### PR DESCRIPTION
Previously I attempted to fix this issue by storing these preferences in de user session. But It wont work because we use session only to restore previous workspace configuration (re-open windows that were open during last login) and not when opening a windows subsequently.  So I wanted to give Web local storage a try.

There is a downside to using Web local storage. These preferences won't persist across computers / workstations / laptops. But I guess most of our users use their own laptop / workstation ?!? If this approach is acceptable, then we can expand this solution to store other window level preferences like preferred window height and width for each window.