### PR TITLE
CORE-5143 Close FileViewer after prompt to save

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/FileViewerWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/FileViewerWindow.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.desktop.client.views.windows;
 
+import org.iplantc.de.client.models.IsHideable;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.WindowState;
 import org.iplantc.de.client.models.diskResources.File;
@@ -27,6 +28,7 @@ import java.util.logging.Logger;
  * @author sriram, jstroot
  */
 public class FileViewerWindow extends IplantWindowBase implements IsMaskable,
+                                                                  IsHideable,
                                                                   DirtyStateChangedEvent.DirtyStateChangedEventHandler {
     private class CriticalPathCallback implements AsyncCallback<String> {
         @Override
@@ -107,7 +109,7 @@ public class FileViewerWindow extends IplantWindowBase implements IsMaskable,
                 public void onDialogHide(DialogHideEvent event) {
                     if (PredefinedButton.YES.equals(event.getHideButton())) {
                         cmb.hide();
-                        presenter.saveFile();
+                        presenter.saveFileAndClose(FileViewerWindow.this);
                     } else if (PredefinedButton.NO.equals(event.getHideButton())) {
                         FileViewerWindow.super.doHide();
                     }

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/FileViewer.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/FileViewer.java
@@ -1,6 +1,7 @@
 package org.iplantc.de.fileViewers.client;
 
 import org.iplantc.de.client.events.FileSavedEvent;
+import org.iplantc.de.client.models.IsHideable;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.client.models.diskResources.Folder;
@@ -96,7 +97,7 @@ public interface FileViewer extends IsWidget, IsMaskable, HasHandlers, FileSaved
 
         void saveFile(FileViewer fileViewer);
 
-        void saveFile();
+        void saveFileAndClose(IsHideable hideable);
 
         void saveFileWithExtension(FileViewer fileViewer, String viewerContent,
                                    String fileExtension);

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/FileSaveCallback.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/callbacks/FileSaveCallback.java
@@ -3,6 +3,7 @@ package org.iplantc.de.fileViewers.client.callbacks;
 import static org.iplantc.de.resources.client.messages.I18N.ERROR;
 
 import org.iplantc.de.client.events.FileSavedEvent;
+import org.iplantc.de.client.models.IsHideable;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.client.services.UserSessionServiceFacade;
@@ -30,19 +31,22 @@ public class FileSaveCallback extends DataCallback<File> {
     private final String fileName;
     private final IsMaskable maskingContainer;
     private final boolean newFile;
+    private IsHideable hideable;
     private UserSessionServiceFacade userSessionService;
 
     public FileSaveCallback(final UserSessionServiceFacade userSessionService,
                             final String path,
                             final boolean newFile,
                             final IsMaskable container,
-                            final HasHandlers hasHandlers) {
+                            final HasHandlers hasHandlers,
+                            IsHideable hideable) {
         this.userSessionService = userSessionService;
         this.hasHandlers = hasHandlers;
         this.fileName = DiskResourceUtil.getInstance().parseNameFromPath(path);
         this.parentFolder = DiskResourceUtil.getInstance().parseParent(path);
         this.maskingContainer = container;
         this.newFile = newFile;
+        this.hideable = hideable;
         errorStrings = ERROR;
     }
 
@@ -55,7 +59,11 @@ public class FileSaveCallback extends DataCallback<File> {
             uch.onCompletion(fileName, fileJson);
         }
 
-        hasHandlers.fireEvent(new FileSavedEvent(result));
+        if (hideable != null) {
+            hideable.hide();
+        } else {
+            hasHandlers.fireEvent(new FileSavedEvent(result));
+        }
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImpl.java
@@ -8,6 +8,7 @@ import static org.iplantc.de.client.services.FileEditorServiceFacade.TAB_DELIMIT
 
 import org.iplantc.de.client.events.FileSavedEvent;
 import org.iplantc.de.client.models.CommonModelAutoBeanFactory;
+import org.iplantc.de.client.models.IsHideable;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.client.models.diskResources.Folder;
@@ -28,8 +29,8 @@ import org.iplantc.de.commons.client.info.ErrorAnnouncementConfig;
 import org.iplantc.de.commons.client.info.IplantAnnouncer;
 import org.iplantc.de.diskResource.client.views.dialogs.SaveAsDialog;
 import org.iplantc.de.fileViewers.client.FileViewer;
-import org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil;
 import org.iplantc.de.fileViewers.client.callbacks.FileSaveCallback;
+import org.iplantc.de.fileViewers.client.callbacks.GenomeBrowserUtil;
 import org.iplantc.de.fileViewers.client.callbacks.TreeUrlCallback;
 import org.iplantc.de.fileViewers.client.events.DirtyStateChangedEvent;
 import org.iplantc.de.fileViewers.client.views.AbstractStructuredTextViewer;
@@ -356,13 +357,13 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
     }
 
     @Override
-    public void saveFile() {
+    public void saveFileAndClose(IsHideable hideable) {
         // Locate any dirty editors
         LOG.fine("no.of viewers:" + viewers.size());
         // assuming the widget that is active is the dirty widget. save it
         for (FileViewer viewer : viewers) {
             if (viewer.isDirty()) {
-                saveFile(viewer);
+                doSaveFile(viewer, hideable);
                 break;
             }
         }
@@ -370,6 +371,10 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
 
     @Override
     public void saveFile(final FileViewer fileViewer) {
+        doSaveFile(fileViewer, null);
+    }
+
+    void doSaveFile(final FileViewer fileViewer, IsHideable hideable) {
         LOG.fine("saving file...");
         if(file == null) {
             saveAsDialogProvider.get(new AsyncCallback<SaveAsDialog>() {
@@ -386,7 +391,8 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
                                                                                                   result,
                                                                                                   appearance.savingMask(),
                                                                                                   fileViewer.getEditorContent(),
-                                                                                                  fileEditorService);
+                                                                                                  fileEditorService,
+                                                                                                  hideable);
                     SaveAsDialogCancelSelectHandler cancelSelectHandler = new SaveAsDialogCancelSelectHandler(fileViewer,
                                                                                                               result);
                     result.addOkButtonSelectHandler(okSelectHandler);
@@ -405,7 +411,8 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
                                                                     file.getPath(),
                                                                     false,
                                                                     asMaskable(simpleContainer),
-                                                                    fileViewer));
+                                                                    fileViewer,
+                                                                    hideable));
         }
     }
 
@@ -437,7 +444,8 @@ public class FileViewerPresenterImpl implements FileViewer.Presenter, FileSavedE
                                                                 destination,
                                                                 true,
                                                                 fileViewer,
-                                                                fileViewer));
+                                                                fileViewer,
+                                                                null));
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/SaveAsDialogOkSelectHandler.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/SaveAsDialogOkSelectHandler.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.fileViewers.client.views;
 
+import org.iplantc.de.client.models.IsHideable;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.services.FileEditorServiceFacade;
 import org.iplantc.de.client.services.UserSessionServiceFacade;
@@ -20,6 +21,7 @@ public final class SaveAsDialogOkSelectHandler implements SelectEvent.SelectHand
     private final String savingMaskText;
     private final String editorContent;
     private final FileEditorServiceFacade fileEditorService;
+    private IsHideable hideable;
     private UserSessionServiceFacade userSessionService;
 
     public SaveAsDialogOkSelectHandler(final UserSessionServiceFacade userSessionService,
@@ -28,7 +30,8 @@ public final class SaveAsDialogOkSelectHandler implements SelectEvent.SelectHand
                                        final SaveAsDialog saveAsDialog,
                                        final String savingMaskText,
                                        final String editorContent,
-                                       final FileEditorServiceFacade fileEditorService) {
+                                       final FileEditorServiceFacade fileEditorService,
+                                       IsHideable hideable) {
         this.userSessionService = userSessionService;
         this.maskable = maskable;
         this.hasHandlers = hasHandlers;
@@ -36,6 +39,7 @@ public final class SaveAsDialogOkSelectHandler implements SelectEvent.SelectHand
         this.savingMaskText = savingMaskText;
         this.editorContent = editorContent;
         this.fileEditorService = fileEditorService;
+        this.hideable = hideable;
     }
 
     @Override
@@ -54,7 +58,8 @@ public final class SaveAsDialogOkSelectHandler implements SelectEvent.SelectHand
                                                                 destination,
                                                                 true,
                                                                 maskable,
-                                                                hasHandlers));
+                                                                hasHandlers,
+                                                                hideable));
         saveAsDialog.hide();
     }
 }

--- a/de-lib/src/test/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImplTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/fileViewers/client/presenter/FileViewerPresenterImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import org.iplantc.de.client.events.FileSavedEvent;
 import org.iplantc.de.client.models.CommonModelAutoBeanFactory;
+import org.iplantc.de.client.models.IsHideable;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.diskResources.File;
 import org.iplantc.de.client.models.diskResources.Folder;
@@ -273,6 +274,7 @@ public class FileViewerPresenterImplTest {
 
     @Test
     public void testSaveFile() {
+        IsHideable hideableMock = mock(IsHideable.class);
         when(structuredTextViewerMock.isDirty()).thenReturn(false);
         when(fileViewerMock.isDirty()).thenReturn(false);
         when(textViewerMock.isDirty()).thenReturn(true);
@@ -280,8 +282,8 @@ public class FileViewerPresenterImplTest {
         FileViewerPresenterImpl spy = spy(uut);
 
         /** CALL METHOD UNDER TEST **/
-        spy.saveFile();
-        verify(spy, times(1)).saveFile(Matchers.<FileViewer> any());
+        spy.saveFileAndClose(hideableMock);
+        verify(spy, times(1)).doSaveFile(Matchers.<FileViewer> any(), eq(hideableMock));
     }
 
     @Test


### PR DESCRIPTION
This is just when the user attempts to close the file with unsaved changes.  If the save is successful, the viewer will close.  