### PR TITLE
CORE-4809 Add horizontal scroll to AppLaunch and switch to GWT Checkbox

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/LaunchAnalysisView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/LaunchAnalysisView.ui.xml
@@ -3,6 +3,7 @@
              xmlns:con="urn:import:com.sencha.gxt.widget.core.client.container"
              xmlns:form="urn:import:com.sencha.gxt.widget.core.client.form"
              xmlns:gxt="urn:import:com.sencha.gxt.widget.core.client"
+			 xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
              xmlns:drFields="urn:import:org.iplantc.de.diskResource.client.views.widgets">
 
     <ui:with field="appearance"
@@ -25,7 +26,7 @@
     <gxt:ContentPanel ui:field="contentPanel"
                       collapsible="true"
                       titleCollapse="true">
-		<con:VerticalLayoutContainer scrollMode="AUTOY"
+		<con:VerticalLayoutContainer scrollMode="AUTO"
 	                                 adjustForScroll="true">
 		    <con:child layoutData="{fieldLayoutData}">
 		        <form:FieldLabel text="{appearance.analysisName}"
@@ -53,8 +54,8 @@
 		        </form:FieldLabel> 
 		    </con:child>                    
 		    <con:child layoutData="{fieldLayoutData}">
-		        <form:CheckBox ui:field="retainInputs" 
-		                       boxLabel="{appearance.retainInputs}"/>
+		        <gwt:CheckBox ui:field="retainInputs"
+							  text="{appearance.retainInputs}"/>
 	        </con:child>                    
 	    </con:VerticalLayoutContainer>
     </gxt:ContentPanel>         

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/LaunchAnalysisViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/LaunchAnalysisViewImpl.java
@@ -23,6 +23,7 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.uibinder.client.UiTemplate;
+import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.web.bindery.autobean.shared.AutoBean;
@@ -30,7 +31,6 @@ import com.google.web.bindery.autobean.shared.AutoBean;
 import com.sencha.gxt.data.shared.Converter;
 import com.sencha.gxt.widget.core.client.ContentPanel;
 import com.sencha.gxt.widget.core.client.event.InvalidEvent;
-import com.sencha.gxt.widget.core.client.form.CheckBox;
 import com.sencha.gxt.widget.core.client.form.ConverterEditorAdapter;
 import com.sencha.gxt.widget.core.client.form.TextArea;
 import com.sencha.gxt.widget.core.client.form.TextField;
@@ -109,7 +109,7 @@ public class LaunchAnalysisViewImpl implements LaunchAnalysisView {
     @Override
     public void edit(JobExecution je, String app_type) {
         if (app_type.equalsIgnoreCase(App.EXTERNAL_APP)) {
-            retainInputs.hide();
+            retainInputs.setVisible(false);
         }
         editorDriver.edit(je);
         // Update header on initial binding.


### PR DESCRIPTION
Sencha's Checkbox appearance contains "white-space: nowrap;" with no clear way to change that.  This causes the Retain Inputs text to stretch beyond the window's width.

I didn't immediately see any other elements that didn't adjust with the width of the window, but just in case, I added horizontal scroll support.