### PR TITLE
CORE-9107 Fix Preferences sizing issue

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
@@ -45,124 +45,124 @@
         <tabs:child config="{general}">
             <container:VerticalLayoutContainer adjustForScroll="true"
                                                styleName="{style.user_pref}">
-        <form:FieldSet heading="{appearance.preferences}"
-                       collapsible="true">
-            <container:VerticalLayoutContainer height="135">
-                <container:child layoutData="{preferenceLayoutData}">
-                    <form:CheckBox ui:field="rememberLastPath"
-                                   boxLabel="{appearance.rememberFileSectorPath}"/>
-                </container:child>
-                <container:child layoutData="{preferenceLayoutData}">
-                    <g:HorizontalPanel>
-                        <form:CheckBox ui:field="saveSession"
-                                   debugId="cboSaveSession"
-                                   boxLabel="{appearance.saveSession}"/>
-                        <g:HTML ui:field="savedSessionFailed"
-                                        visible="false"/>
-                        <button:TextButton ui:field="retrySession"
-                                        text="{appearance.retrySessionConnection}"
-                                        visible="false"/>
-                    </g:HorizontalPanel>
-                </container:child>
-                <container:child layoutData="{preferenceLayoutData}">
-                    <form:CheckBox ui:field="enableHPCPrompt"
-                                   debugId="cboEnableHPC"
-                                   boxLabel="{appearance.enableHPCPrompt}"/>
-                </container:child>
-                <container:child layoutData="{preferenceLayoutData}">
-                    <form:CheckBox ui:field="enableWaitTimeMessage"
-                                   debugId="cboWaitTime"
-                                   boxLabel="{appearance.waitTime}"/>
-                </container:child>
-                <container:child layoutData="{fileSelLabel}">
-                    <g:HTML HTML="{appearance.defaultOutputFolder}"/>
-                </container:child>
-                <container:child layoutData="{preferenceLayoutData}">
-                    <selector:FolderSelectorField ui:field="defaultOutputFolder"
-                                                  debugId="idDefaultFolderSelector"
-                                                  validatePermissions="true"/>
-                </container:child>
-            </container:VerticalLayoutContainer>
-        </form:FieldSet>
-        <form:FieldSet heading="{appearance.keyboardShortCut}"
-                       collapsible="true">
-            <container:VerticalLayoutContainer >
-                <form:FieldLabel labelWidth="150"
-                                 text="{appearance.openAppsWindow}">
+                <form:FieldSet heading="{appearance.preferences}"
+                               collapsible="true">
+                    <container:VerticalLayoutContainer height="135">
+                        <container:child layoutData="{preferenceLayoutData}">
+                            <form:CheckBox ui:field="rememberLastPath"
+                                           boxLabel="{appearance.rememberFileSectorPath}"/>
+                        </container:child>
+                        <container:child layoutData="{preferenceLayoutData}">
+                            <g:HorizontalPanel>
+                                <form:CheckBox ui:field="saveSession"
+                                           debugId="cboSaveSession"
+                                           boxLabel="{appearance.saveSession}"/>
+                                <g:HTML ui:field="savedSessionFailed"
+                                                visible="false"/>
+                                <button:TextButton ui:field="retrySession"
+                                                text="{appearance.retrySessionConnection}"
+                                                visible="false"/>
+                            </g:HorizontalPanel>
+                        </container:child>
+                        <container:child layoutData="{preferenceLayoutData}">
+                            <form:CheckBox ui:field="enableHPCPrompt"
+                                           debugId="cboEnableHPC"
+                                           boxLabel="{appearance.enableHPCPrompt}"/>
+                        </container:child>
+                        <container:child layoutData="{preferenceLayoutData}">
+                            <form:CheckBox ui:field="enableWaitTimeMessage"
+                                           debugId="cboWaitTime"
+                                           boxLabel="{appearance.waitTime}"/>
+                        </container:child>
+                        <container:child layoutData="{fileSelLabel}">
+                            <g:HTML HTML="{appearance.defaultOutputFolder}"/>
+                        </container:child>
+                        <container:child layoutData="{preferenceLayoutData}">
+                            <selector:FolderSelectorField ui:field="defaultOutputFolder"
+                                                          debugId="idDefaultFolderSelector"
+                                                          validatePermissions="true"/>
+                        </container:child>
+                    </container:VerticalLayoutContainer>
+                </form:FieldSet>
+                <form:FieldSet heading="{appearance.keyboardShortCut}"
+                               collapsible="true">
+                    <container:VerticalLayoutContainer >
+                        <form:FieldLabel labelWidth="150"
+                                         text="{appearance.openAppsWindow}">
+                            <form:widget>
+                                <g:HorizontalPanel spacing="5">
+                                    <g:Label text="{appearance.kbShortcutMetaKey}"/>
+                                    <form:TextField ui:field="appsShortCut"
+                                                    toolTip="{appearance.oneCharMax}"
+                                                    debugId="appKbSc"
+                                                    allowBlank="false"
+                                                    width="50"/>
+                                </g:HorizontalPanel>
+                            </form:widget>
+                        </form:FieldLabel>
+                        <form:FieldLabel labelWidth="150"
+                                         text="{appearance.openDataWindow}">
+                            <form:widget>
+                                <g:HorizontalPanel spacing="5">
+                                    <g:Label text="{appearance.kbShortcutMetaKey}"/>
+                                    <form:TextField ui:field="dataShortCut"
+                                                    toolTip="{appearance.oneCharMax}"
+                                                    debugId="dataKbSc"
+                                                    allowBlank="false"
+                                                    width="50"/>
+                                </g:HorizontalPanel>
+                            </form:widget>
+                        </form:FieldLabel>
+                        <form:FieldLabel labelWidth="150"
+                                         text="{appearance.openAnalysesWindow}">
+                            <form:widget>
+                                <g:HorizontalPanel spacing="5">
+                                    <g:Label text="{appearance.kbShortcutMetaKey}"/>
+                                    <form:TextField ui:field="analysesShortCut"
+                                                    toolTip="{appearance.oneCharMax}"
+                                                    debugId="anaKbSc"
+                                                    allowBlank="false"
+                                                    width="50"/>
+                                </g:HorizontalPanel>
+                            </form:widget>
+                        </form:FieldLabel>
+                        <form:FieldLabel labelWidth="150"
+                                         text="{appearance.openNotificationsWindow}">
+                            <form:widget>
+                                <g:HorizontalPanel spacing="5">
+                                    <g:Label text="{appearance.kbShortcutMetaKey}"/>
+                                    <form:TextField ui:field="notifyShortCut"
+                                                    toolTip="{appearance.oneCharMax}"
+                                                    debugId="notKbSc"
+                                                    allowBlank="false"
+                                                    width="50"/>
+                                </g:HorizontalPanel>
+                            </form:widget>
+                        </form:FieldLabel>
+                        <form:FieldLabel labelWidth="150"
+                                         text="{appearance.closeActiveWindow}">
+                            <form:widget>
+                                <g:HorizontalPanel spacing="5">
+                                    <g:Label text="{appearance.kbShortcutMetaKey}"/>
+                                    <form:TextField ui:field="closeShortCut"
+                                                    toolTip="{appearance.oneCharMax}"
+                                                    debugId="closeKbSc"
+                                                    allowBlank="false"
+                                                    width="50"/>
+                                </g:HorizontalPanel>
+                            </form:widget>
+                        </form:FieldLabel>
+                    </container:VerticalLayoutContainer>
+                </form:FieldSet>
+                <form:FieldSet heading="{appearance.resetHpc}"
+                               collapsible="true">
                     <form:widget>
-                        <g:HorizontalPanel spacing="5">
-                            <g:Label text="{appearance.kbShortcutMetaKey}"/>
-                            <form:TextField ui:field="appsShortCut"
-                                            toolTip="{appearance.oneCharMax}"
-                                            debugId="appKbSc"
-                                            allowBlank="false"
-                                            width="50"/>
-                        </g:HorizontalPanel>
+                        <g:VerticalPanel spacing="5">
+                        <g:HTML ui:field="resetHpcfield"/>
+                        <button:TextButton text="{appearance.resetHpc}" ui:field="hpcResetBtn" />
+                        </g:VerticalPanel>
                     </form:widget>
-                </form:FieldLabel>
-                <form:FieldLabel labelWidth="150"
-                                 text="{appearance.openDataWindow}">
-                    <form:widget>
-                        <g:HorizontalPanel spacing="5">
-                            <g:Label text="{appearance.kbShortcutMetaKey}"/>
-                            <form:TextField ui:field="dataShortCut"
-                                            toolTip="{appearance.oneCharMax}"
-                                            debugId="dataKbSc"
-                                            allowBlank="false"
-                                            width="50"/>
-                        </g:HorizontalPanel>
-                    </form:widget>
-                </form:FieldLabel>
-                <form:FieldLabel labelWidth="150"
-                                 text="{appearance.openAnalysesWindow}">
-                    <form:widget>
-                        <g:HorizontalPanel spacing="5">
-                            <g:Label text="{appearance.kbShortcutMetaKey}"/>
-                            <form:TextField ui:field="analysesShortCut"
-                                            toolTip="{appearance.oneCharMax}"
-                                            debugId="anaKbSc"
-                                            allowBlank="false"
-                                            width="50"/>
-                        </g:HorizontalPanel>
-                    </form:widget>
-                </form:FieldLabel>
-                <form:FieldLabel labelWidth="150"
-                                 text="{appearance.openNotificationsWindow}">
-                    <form:widget>
-                        <g:HorizontalPanel spacing="5">
-                            <g:Label text="{appearance.kbShortcutMetaKey}"/>
-                            <form:TextField ui:field="notifyShortCut"
-                                            toolTip="{appearance.oneCharMax}"
-                                            debugId="notKbSc"
-                                            allowBlank="false"
-                                            width="50"/>
-                        </g:HorizontalPanel>
-                    </form:widget>
-                </form:FieldLabel>
-                <form:FieldLabel labelWidth="150"
-                                 text="{appearance.closeActiveWindow}">
-                    <form:widget>
-                        <g:HorizontalPanel spacing="5">
-                            <g:Label text="{appearance.kbShortcutMetaKey}"/>
-                            <form:TextField ui:field="closeShortCut"
-                                            toolTip="{appearance.oneCharMax}"
-                                            debugId="closeKbSc"
-                                            allowBlank="false"
-                                            width="50"/>
-                        </g:HorizontalPanel>
-                    </form:widget>
-                </form:FieldLabel>
-            </container:VerticalLayoutContainer>
-        </form:FieldSet>
-        <form:FieldSet heading="{appearance.resetHpc}"
-                       collapsible="true">
-            <form:widget>
-                <g:VerticalPanel spacing="5">
-                <g:HTML ui:field="resetHpcfield"/>
-                <button:TextButton text="{appearance.resetHpc}" ui:field="hpcResetBtn" />
-                </g:VerticalPanel>
-            </form:widget>
-        </form:FieldSet>
+                </form:FieldSet>
             </container:VerticalLayoutContainer>
         </tabs:child>
         <tabs:child config="{notification}">

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
@@ -33,9 +33,15 @@
              type="com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer.VerticalLayoutData">
         <ui:attributes width="1" height="-1" margins="{margin3}"/>
     </ui:with>
+
+
+    <ui:with field="cssLayoutData"
+             type="com.sencha.gxt.widget.core.client.container.CssFloatLayoutContainer.CssFloatData">
+        <ui:attributes size="1" margins="{margin3}"/>
+    </ui:with>
     <ui:with field="fileSelLabel"
-             type="com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer.VerticalLayoutData">
-        <ui:attributes width="1" height="-1" margins="{margins5505}"/>
+             type="com.sencha.gxt.widget.core.client.container.CssFloatLayoutContainer.CssFloatData">
+        <ui:attributes size="1" margins="{margins5505}"/>
     </ui:with>
     <ui:with type="com.sencha.gxt.widget.core.client.container.VerticalLayoutContainer.VerticalLayoutData"
              field="verticalLayoutData">
@@ -44,15 +50,16 @@
     <tabs:TabPanel ui:field="tabs">
         <tabs:child config="{general}">
             <container:VerticalLayoutContainer adjustForScroll="true"
+                                               scrollMode="AUTOY"
                                                styleName="{style.user_pref}">
                 <form:FieldSet heading="{appearance.preferences}"
                                collapsible="true">
-                    <container:VerticalLayoutContainer height="135">
-                        <container:child layoutData="{preferenceLayoutData}">
+                    <container:CssFloatLayoutContainer>
+                        <container:child layoutData="{cssLayoutData}">
                             <form:CheckBox ui:field="rememberLastPath"
                                            boxLabel="{appearance.rememberFileSectorPath}"/>
                         </container:child>
-                        <container:child layoutData="{preferenceLayoutData}">
+                        <container:child layoutData="{cssLayoutData}">
                             <g:HorizontalPanel>
                                 <form:CheckBox ui:field="saveSession"
                                            debugId="cboSaveSession"
@@ -64,25 +71,25 @@
                                                 visible="false"/>
                             </g:HorizontalPanel>
                         </container:child>
-                        <container:child layoutData="{preferenceLayoutData}">
+                        <container:child layoutData="{cssLayoutData}">
                             <form:CheckBox ui:field="enableHPCPrompt"
                                            debugId="cboEnableHPC"
                                            boxLabel="{appearance.enableHPCPrompt}"/>
                         </container:child>
-                        <container:child layoutData="{preferenceLayoutData}">
+                        <container:child layoutData="{cssLayoutData}">
                             <form:CheckBox ui:field="enableWaitTimeMessage"
                                            debugId="cboWaitTime"
                                            boxLabel="{appearance.waitTime}"/>
                         </container:child>
-                        <container:child layoutData="{fileSelLabel}">
+                        <container:child layoutData="{cssLayoutData}">
                             <g:HTML HTML="{appearance.defaultOutputFolder}"/>
                         </container:child>
-                        <container:child layoutData="{preferenceLayoutData}">
+                        <container:child layoutData="{cssLayoutData}">
                             <selector:FolderSelectorField ui:field="defaultOutputFolder"
                                                           debugId="idDefaultFolderSelector"
                                                           validatePermissions="true"/>
                         </container:child>
-                    </container:VerticalLayoutContainer>
+                    </container:CssFloatLayoutContainer>
                 </form:FieldSet>
                 <form:FieldSet heading="{appearance.keyboardShortCut}"
                                collapsible="true">

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesView.ui.xml
@@ -158,7 +158,7 @@
                                collapsible="true">
                     <form:widget>
                         <g:VerticalPanel spacing="5">
-                        <g:HTML ui:field="resetHpcfield"/>
+                        <g:HTML ui:field="resetHpcField"/>
                         <button:TextButton text="{appearance.resetHpc}" ui:field="hpcResetBtn" />
                         </g:VerticalPanel>
                     </form:widget>
@@ -184,7 +184,7 @@
                 <form:FieldSet heading="{appearance.webhooks}" ui:field="hookFieldSet">
                     <form:widget>
                         <g:VerticalPanel spacing="5">
-                            <g:HTML ui:field="webhooksfield"/>
+                            <g:HTML ui:field="webhooksField"/>
                             <g:HorizontalPanel spacing="5">
                                 <form:TextField ui:field="hookUrl" visible="true" enabled="true" width="250"/>
                                 <form:ComboBox ui:field="typeCombo" allowBlank="false"

--- a/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/preferences/client/view/PreferencesViewImpl.java
@@ -86,7 +86,7 @@ public class PreferencesViewImpl extends Composite implements PreferencesView,
 
     @UiField(provided = true)
     @Ignore
-    HTML resetHpcfield;
+    HTML resetHpcField;
 
     @UiField
     @Ignore
@@ -94,7 +94,7 @@ public class PreferencesViewImpl extends Composite implements PreferencesView,
 
     @UiField(provided = true)
     @Ignore
-    HTML webhooksfield;
+    HTML webhooksField;
 
     @UiField
     @Ignore
@@ -146,8 +146,8 @@ public class PreferencesViewImpl extends Composite implements PreferencesView,
         this.defaultOutputFolder = folderSelectorFieldFactory.defaultFolderSelector();
         this.defaultOutputFolder.hideResetButton();
         this.KB_CONSTANTS = kbConstants;
-        this.resetHpcfield = new HTML(appearance.resetHpcPrompt());
-        this.webhooksfield = new HTML(appearance.webhooksPrompt());
+        this.resetHpcField = new HTML(appearance.resetHpcPrompt());
+        this.webhooksField = new HTML(appearance.webhooksPrompt());
 
         ListStore<WebhookType> typeListStore = new ListStore<>(item -> item.getType());
         typeCombo = new ComboBox<>(typeListStore, item -> item.getType());


### PR DESCRIPTION
QA Preferences tests are failing because the Default Output Folder items aren't able to fit in the field set they're in.  I updated that section from having a fixed height to using a CssFloatLayoutContainer so the field set will expand to fit the size of the children.  Also added a scroll bar in case all of the preferences extend beyond the size of the Preferences dialog.