### PR TITLE
CORE-9097 Change Multi-input Path Lists and HT Path Lists to delimit …

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/AbstractStructuredTextViewer.java
+++ b/de-lib/src/main/java/org/iplantc/de/fileViewers/client/views/AbstractStructuredTextViewer.java
@@ -6,6 +6,7 @@ import static org.iplantc.de.client.models.viewer.InfoType.CSV;
 import static org.iplantc.de.client.models.viewer.InfoType.GFF;
 import static org.iplantc.de.client.models.viewer.InfoType.GTF;
 import static org.iplantc.de.client.models.viewer.InfoType.HT_ANALYSIS_PATH_LIST;
+import static org.iplantc.de.client.models.viewer.InfoType.MULTI_INPUT_PATH_LIST;
 import static org.iplantc.de.client.models.viewer.InfoType.TSV;
 import static org.iplantc.de.client.models.viewer.InfoType.VCF;
 import static org.iplantc.de.client.services.FileEditorServiceFacade.COMMA_DELIMITER;
@@ -135,15 +136,16 @@ public abstract class AbstractStructuredTextViewer extends AbstractFileViewer {
 
     String getSeparator() {
         InfoType fromTypeString = InfoType.fromTypeString(infoType);
-        if (CSV.equals(fromTypeString)
-            || HT_ANALYSIS_PATH_LIST.equals(fromTypeString)) {
+        if (CSV.equals(fromTypeString)) {
             return COMMA_DELIMITER;
         } else if (TSV.equals(fromTypeString)
                        || VCF.equals(fromTypeString)
                        || GFF.equals(fromTypeString)
                        || BED.equals(fromTypeString)
                        || GTF.equals(fromTypeString)
-                       || BOWTIE.equals(fromTypeString)) {
+                       || BOWTIE.equals(fromTypeString)
+                       || HT_ANALYSIS_PATH_LIST.equals(fromTypeString)
+                       || MULTI_INPUT_PATH_LIST.equals(fromTypeString)) {
             return TAB_DELIMITER;
         } else {
             return SPACE_DELIMITER;


### PR DESCRIPTION
…on tabs.

HT Path Lists were also moved to tab-delimited to accommodate the issue with iRods and commas. (While the DE UI will warn about using commas in filenames, it won't actually stop you.)