### PR TITLE
CORE-9152 Add missing key to SelectionItem before adding to hierarchi…

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/tree/SelectionItemTree.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/tree/SelectionItemTree.java
@@ -2,6 +2,7 @@ package org.iplantc.de.apps.widgets.client.view.editors.arguments.tree;
 
 import org.iplantc.de.client.models.apps.integration.SelectionItem;
 import org.iplantc.de.client.models.apps.integration.SelectionItemGroup;
+import org.iplantc.de.client.util.AppTemplateUtils;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
@@ -35,9 +36,14 @@ class SelectionItemTree extends Tree<SelectionItem, String> implements HasValueC
     private boolean forceSingleSelection = false;
     private boolean restoreCheckedSelectionFromTree;
     private SelectionItemGroup root;
+    private int uniqueIdNum = 0;
+    private AppTemplateUtils appTemplateUtils;
 
-    SelectionItemTree(TreeStore<SelectionItem> store, ValueProvider<SelectionItem, String> valueProvider) {
+    SelectionItemTree(TreeStore<SelectionItem> store,
+                      ValueProvider<SelectionItem, String> valueProvider,
+                      AppTemplateUtils appTemplateUtils) {
         super(store, valueProvider);
+        this.appTemplateUtils = appTemplateUtils;
 
         setBorders(true);
         setAutoLoad(true);
@@ -273,7 +279,8 @@ class SelectionItemTree extends Tree<SelectionItem, String> implements HasValueC
         if (findModelWithKey != null) {
             store.update(item);
         } else {
-            store.add(item);
+            final SelectionItem taggedItem = appTemplateUtils.addSelectionItemAutoBeanIdTag(item, "tmpId-" + uniqueIdNum++);
+            store.add(taggedItem);
         }
     }
 
@@ -282,7 +289,8 @@ class SelectionItemTree extends Tree<SelectionItem, String> implements HasValueC
         if ((findModelWithKey != null) && (store.getParent(child) == parent)) {
             store.update(child);
         } else {
-            store.add(parent, child);
+            final SelectionItem taggedChild = appTemplateUtils.addSelectionItemAutoBeanIdTag(child, "tmpId-" + uniqueIdNum++);
+            store.add(parent, taggedChild);
         }
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/tree/TreeSelectionEditor.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/tree/TreeSelectionEditor.java
@@ -5,9 +5,9 @@ import static com.sencha.gxt.widget.core.client.form.FormPanel.LabelAlign.TOP;
 import org.iplantc.de.apps.widgets.client.events.ArgumentRequiredChangedEvent;
 import org.iplantc.de.apps.widgets.client.events.ArgumentRequiredChangedEvent.ArgumentRequiredChangedEventHandler;
 import org.iplantc.de.apps.widgets.client.events.ArgumentSelectedEvent;
-import org.iplantc.de.apps.widgets.client.view.AppTemplateForm;
 import org.iplantc.de.apps.widgets.client.models.SelectionItemModelKeyProvider;
 import org.iplantc.de.apps.widgets.client.models.SelectionItemProperties;
+import org.iplantc.de.apps.widgets.client.view.AppTemplateForm;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.LabelLeafEditor;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.VisibilityEditor;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ArgumentEditorConverter;
@@ -21,6 +21,7 @@ import org.iplantc.de.client.models.apps.integration.ArgumentValidator;
 import org.iplantc.de.client.models.apps.integration.SelectionItem;
 import org.iplantc.de.client.models.apps.integration.SelectionItemGroup;
 import org.iplantc.de.client.models.apps.integration.SelectionItemList;
+import org.iplantc.de.client.util.AppTemplateUtils;
 
 import com.google.common.collect.Lists;
 import com.google.gwt.editor.client.EditorDelegate;
@@ -210,12 +211,13 @@ public class TreeSelectionEditor extends Composite implements AppTemplateForm.Ar
     @Inject
     public TreeSelectionEditor(@Assisted AppTemplateWizardAppearance appearance,
                                SelectionItemProperties props,
-                               AppTemplateAutoBeanFactory factory) {
+                               AppTemplateAutoBeanFactory factory,
+                               AppTemplateUtils appTemplateUtils) {
         this.appearance = appearance;
         this.factory = factory;
         TreeStore<SelectionItem> store = new TreeStore<>(new SelectionItemModelKeyProvider());
 
-        tree = new SelectionItemTree(store, props.display());
+        tree = new SelectionItemTree(store, props.display(), appTemplateUtils);
         tree.setHeight(appearance.getDefaultTreeSelectionHeight());
 
         tree.addValueChangeHandler(new TreeValueChangeHandler());


### PR DESCRIPTION
…cal lists TreeStore

When adding an item to the TreeStore, the store uses SelectionItemModelKeyProvider to get the item's key.  This key provider assumes, at some point prior, a SelectionItem.TMP_ID_TAG key has already been set. This fix was copied from SelectionItemPropertyEditor's onAddButtonClicked method.