### PR TITLE
CORE-9157 Enable UI to try to reconnect to AMQP after a failure to connect

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -211,12 +211,12 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
     }
 
     private void initNotificationWebSocket() {
-        notificationWebSocketManager = NotificationWebSocketManager.getInstace();
+        notificationWebSocketManager = NotificationWebSocketManager.getInstance();
         notificationWebSocketManager.openWebSocket(new WebsocketListener() {
 
             @Override
             public void onClose() {
-                GWT.log("Wesbsocket onClose()");
+                GWT.log("WebSocket onClose()");
                 //if websocket connection closed unexpectedly, retry connection!
                 if(!loggedOut) {
                     GWT.log("reconnecting...");
@@ -238,12 +238,12 @@ public class DesktopPresenterImpl implements DesktopView.Presenter {
     }
 
     private void initSystemMessageWebSocket() {
-        systemMessageWebSocketManager = SystemMessageWebSocketManager.getInstace();
+        systemMessageWebSocketManager = SystemMessageWebSocketManager.getInstance();
         systemMessageWebSocketManager.openWebSocket(new WebsocketListener() {
 
             @Override
             public void onClose() {
-                GWT.log("Wesbsocket onClose()");
+                GWT.log("WebSocket onClose()");
                 //if websocket connection closed unexpectedly, retry connection!
                 if(!loggedOut) {
                     GWT.log("reconnecting...");

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/util/NotificationWebSocketManager.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/util/NotificationWebSocketManager.java
@@ -26,7 +26,7 @@ public class NotificationWebSocketManager extends WebSocketManager{
         ws = new Websocket(socketUrl);
     }
 
-    public static NotificationWebSocketManager getInstace() {
+    public static NotificationWebSocketManager getInstance() {
         if(instance == null) {
             instance = new NotificationWebSocketManager();
         }

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/util/SystemMessageWebSocketManager.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/util/SystemMessageWebSocketManager.java
@@ -23,7 +23,7 @@ public class SystemMessageWebSocketManager extends WebSocketManager {
         ws = new Websocket(socketUrl);
     }
 
-    public static SystemMessageWebSocketManager getInstace() {
+    public static SystemMessageWebSocketManager getInstance() {
         if(instance == null) {
             instance = new SystemMessageWebSocketManager();
         }

--- a/de-webapp/src/main/java/org/iplantc/de/server/websocket/MessageHandler.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/websocket/MessageHandler.java
@@ -46,6 +46,11 @@ public abstract class MessageHandler extends WebSocketHandlerAdapter {
         logger.debug("user name:" + username);
 
         final Channel msgChannel = notificationReceiver.createChannel();
+        if (msgChannel == null) {
+            onError(webSocket, new WebSocketProcessor.WebSocketException("AMQP channel was null", null));
+            webSocket.close();
+            return;
+        }
         String queue = bindQueue(username, msgChannel);
         consumeMessage(msgChannel, queue, webSocket);
 

--- a/de-webapp/src/main/java/org/iplantc/de/server/websocket/ReceiveNotificationsDirect.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/websocket/ReceiveNotificationsDirect.java
@@ -28,14 +28,21 @@ public class ReceiveNotificationsDirect {
 
     private final Logger LOG = LoggerFactory.getLogger(ReceiveNotificationsDirect.class);
 
-    private final Connection connection;
+    private Connection connection;
 
     /**
      * Instantiate new
      */
     public ReceiveNotificationsDirect() {
-       connection = AMQPConnectionManager.getInstance().getConnection();
+       connection = getConnection();
        LOG.info("amqp Connection created!");
+    }
+
+    private Connection getConnection() {
+        if (connection == null) {
+            connection = AMQPConnectionManager.getInstance().getConnection();
+        }
+        return connection;
     }
 
     /**
@@ -45,7 +52,7 @@ public class ReceiveNotificationsDirect {
      */
     public Channel createChannel() {
         try {
-            Channel channel = connection.createChannel();
+            Channel channel = getConnection().createChannel();
             LOG.debug("Amqp channel created!");
             return channel;
         } catch (IOException ioe) {
@@ -67,6 +74,9 @@ public class ReceiveNotificationsDirect {
     public String bind(Channel msgChannel, String routing_key) {
         String queueName = null;
         try {
+            if (msgChannel == null) {
+                msgChannel = createChannel();
+            }
             queueName = msgChannel.queueDeclare().getQueue();
             msgChannel.queueBind(queueName,
                                  props.getProperty(
@@ -94,6 +104,9 @@ public class ReceiveNotificationsDirect {
      */
     public void consumeMessage(Channel msgChannel, Consumer consumer, String queueName) {
         try {
+            if (msgChannel == null) {
+                msgChannel = createChannel();
+            }
             msgChannel.basicConsume(queueName, true, consumer);
             LOG.debug("consumer registered ");
         } catch (IOException e) {

--- a/de-webapp/src/main/java/org/iplantc/de/server/websocket/ReceiveNotificationsDirect.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/websocket/ReceiveNotificationsDirect.java
@@ -35,11 +35,11 @@ public class ReceiveNotificationsDirect {
      */
     public ReceiveNotificationsDirect() {
        connection = AMQPConnectionManager.getInstance().getConnection();
-       LOG.info("amqp Connection created created!");
+       LOG.info("amqp Connection created!");
     }
 
     /**
-     * Create a channel for receving the notifications
+     * Create a channel for receiving the notifications
      *
      * @return
      */
@@ -95,7 +95,7 @@ public class ReceiveNotificationsDirect {
     public void consumeMessage(Channel msgChannel, Consumer consumer, String queueName) {
         try {
             msgChannel.basicConsume(queueName, true, consumer);
-            LOG.debug("comsumer reqistered ");
+            LOG.debug("consumer registered ");
         } catch (IOException e) {
             LOG.error("IO Exception when consuming message",e);
         } catch (Exception e) {

--- a/de-webapp/src/main/java/org/iplantc/de/server/websocket/amqp/AMQPConnectionManager.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/websocket/amqp/AMQPConnectionManager.java
@@ -25,11 +25,11 @@ public class AMQPConnectionManager {
 
     private String amqpUri;
 
-    Properties deprops = PropertiesUtil.getDEProperties();
+    Properties deProperties = PropertiesUtil.getDEProperties();
     private Connection connection;
 
     private AMQPConnectionManager() {
-        amqpUri = deprops.getProperty("org.iplantc.discoveryenvironment.notification.amqp.uri");
+        amqpUri = deProperties.getProperty("org.iplantc.discoveryenvironment.notification.amqp.uri");
         ConnectionFactory factory = new ConnectionFactory();
         try {
             factory.setUri(amqpUri);

--- a/de-webapp/src/main/java/org/iplantc/de/server/websocket/amqp/AMQPConnectionManager.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/websocket/amqp/AMQPConnectionManager.java
@@ -30,6 +30,10 @@ public class AMQPConnectionManager {
 
     private AMQPConnectionManager() {
         amqpUri = deProperties.getProperty("org.iplantc.discoveryenvironment.notification.amqp.uri");
+        connection = createConnection();
+    }
+
+    private Connection createConnection() {
         ConnectionFactory factory = new ConnectionFactory();
         try {
             factory.setUri(amqpUri);
@@ -46,6 +50,7 @@ public class AMQPConnectionManager {
             LOG.error("Exception when creating AMQP connection!" + e.getMessage());
         }
 
+        return connection;
     }
 
     public static AMQPConnectionManager getInstance() {
@@ -56,6 +61,9 @@ public class AMQPConnectionManager {
     }
 
     public Connection getConnection() {
+        if (connection == null) {
+            connection = createConnection();
+        }
         return connection;
     }
 }

--- a/de-webapp/src/main/java/org/iplantc/de/server/websocket/amqp/AMQPConnectionManager.java
+++ b/de-webapp/src/main/java/org/iplantc/de/server/websocket/amqp/AMQPConnectionManager.java
@@ -30,10 +30,10 @@ public class AMQPConnectionManager {
 
     private AMQPConnectionManager() {
         amqpUri = deProperties.getProperty("org.iplantc.discoveryenvironment.notification.amqp.uri");
-        connection = createConnection();
+        createConnection();
     }
 
-    private Connection createConnection() {
+    private void createConnection() {
         ConnectionFactory factory = new ConnectionFactory();
         try {
             factory.setUri(amqpUri);
@@ -49,8 +49,6 @@ public class AMQPConnectionManager {
             e.printStackTrace();
             LOG.error("Exception when creating AMQP connection!" + e.getMessage());
         }
-
-        return connection;
     }
 
     public static AMQPConnectionManager getInstance() {
@@ -62,7 +60,7 @@ public class AMQPConnectionManager {
 
     public Connection getConnection() {
         if (connection == null) {
-            connection = createConnection();
+            createConnection();
         }
         return connection;
     }


### PR DESCRIPTION
** Merge only after the 2.19 Release **

If the UI can't connect to AMQP, the `Connection` returned from the `ConnectionFactory` in `AMQPConnectionManager.java` is null. The changes are mostly just making sure we keep doing null checks and trying to get new connections from `ConnectionFactory`.  If despite that, we still end up with a null `Channel` in `MessageHandler.java`, the websocket gets closed.  
From there, [this logic](https://github.com/cyverse-de/ui/blob/master/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java#L221-L224) tries to reopen the websocket and then restarts the cycle in `AMQPConnectionManager`.