### PR TITLE
core-9155 increase announcer time to 10s

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/commons/client/info/IplantAnnouncementConfig.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/info/IplantAnnouncementConfig.java
@@ -19,8 +19,7 @@ import com.sencha.gxt.widget.core.client.button.IconButton.IconConfig;
  */
 public class IplantAnnouncementConfig {
 
-    // SS updated to 5s from 10s since 5s is seems too long
-    protected static final int DEFAULT_TIMEOUT_ms = 5000;
+    protected static final int DEFAULT_TIMEOUT_ms = 10000;
     protected final IconConfig CLOSER_CFG;
 
     public interface IplantAnnouncementConfigAppearance {


### PR DESCRIPTION
Note: I didn't think any styling changes were necessary. After increasing the time to 10s I was able to read the message without issues.