### PR TITLE
CORE-9224 Update analysis reference genome dropdown with latest genomes

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/ReferenceAnnotationEditor.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/ReferenceAnnotationEditor.java
@@ -5,6 +5,7 @@ import static com.sencha.gxt.cell.core.client.form.ComboBoxCell.TriggerAction.AL
 import org.iplantc.de.apps.shared.AppsModule;
 import org.iplantc.de.apps.widgets.client.models.ReferenceGenomeProperties;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ArgumentEditorConverter;
+import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ReferenceGenomeEditorConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.SplittableToReferenceGenomeConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.style.AppTemplateWizardAppearance;
 import org.iplantc.de.client.models.apps.refGenome.ReferenceGenome;
@@ -35,7 +36,7 @@ public class ReferenceAnnotationEditor extends AbstractArgumentEditor implements
         ClearComboBoxSelectionKeyDownHandler handler = new ClearComboBoxSelectionKeyDownHandler(comboBox);
         comboBox.addKeyDownHandler(handler);
 
-        editorAdapter = new ArgumentEditorConverter<ReferenceGenome>(comboBox, new SplittableToReferenceGenomeConverter());
+        editorAdapter = new ReferenceGenomeEditorConverter<>(comboBox, new SplittableToReferenceGenomeConverter());
 
         argumentLabel.setWidget(editorAdapter);
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/ReferenceGenomeEditor.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/ReferenceGenomeEditor.java
@@ -5,6 +5,7 @@ import static com.sencha.gxt.cell.core.client.form.ComboBoxCell.TriggerAction.AL
 import org.iplantc.de.apps.shared.AppsModule;
 import org.iplantc.de.apps.widgets.client.models.ReferenceGenomeProperties;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ArgumentEditorConverter;
+import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ReferenceGenomeEditorConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.SplittableToReferenceGenomeConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.style.AppTemplateWizardAppearance;
 import org.iplantc.de.client.models.apps.refGenome.ReferenceGenome;
@@ -35,7 +36,7 @@ public class ReferenceGenomeEditor extends AbstractArgumentEditor implements Has
         ClearComboBoxSelectionKeyDownHandler handler = new ClearComboBoxSelectionKeyDownHandler(comboBox);
         comboBox.addKeyDownHandler(handler);
 
-        editorAdapter = new ArgumentEditorConverter<ReferenceGenome>(comboBox, new SplittableToReferenceGenomeConverter());
+        editorAdapter = new ReferenceGenomeEditorConverter<>(comboBox, new SplittableToReferenceGenomeConverter());
 
         argumentLabel.setWidget(editorAdapter);
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/ReferenceSequenceEditor.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/ReferenceSequenceEditor.java
@@ -5,6 +5,7 @@ import static com.sencha.gxt.cell.core.client.form.ComboBoxCell.TriggerAction.AL
 import org.iplantc.de.apps.shared.AppsModule;
 import org.iplantc.de.apps.widgets.client.models.ReferenceGenomeProperties;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ArgumentEditorConverter;
+import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.ReferenceGenomeEditorConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.arguments.converters.SplittableToReferenceGenomeConverter;
 import org.iplantc.de.apps.widgets.client.view.editors.style.AppTemplateWizardAppearance;
 import org.iplantc.de.client.models.apps.refGenome.ReferenceGenome;
@@ -35,7 +36,7 @@ public class ReferenceSequenceEditor extends AbstractArgumentEditor implements H
         ClearComboBoxSelectionKeyDownHandler handler = new ClearComboBoxSelectionKeyDownHandler(comboBox);
         comboBox.addKeyDownHandler(handler);
 
-        editorAdapter = new ArgumentEditorConverter<ReferenceGenome>(comboBox, new SplittableToReferenceGenomeConverter());
+        editorAdapter = new ReferenceGenomeEditorConverter<>(comboBox, new SplittableToReferenceGenomeConverter());
 
         argumentLabel.setWidget(editorAdapter);
     }

--- a/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/converters/ReferenceGenomeEditorConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/widgets/client/view/editors/arguments/converters/ReferenceGenomeEditorConverter.java
@@ -1,0 +1,52 @@
+package org.iplantc.de.apps.widgets.client.view.editors.arguments.converters;
+
+import org.iplantc.de.client.models.apps.refGenome.ReferenceGenome;
+import org.iplantc.de.shared.DECallback;
+
+import com.google.web.bindery.autobean.shared.Splittable;
+
+import com.sencha.gxt.data.shared.Converter;
+import com.sencha.gxt.data.shared.ListStore;
+import com.sencha.gxt.widget.core.client.form.ComboBox;
+import com.sencha.gxt.widget.core.client.form.IsField;
+
+/**
+ * This is a slight modification to {@link ArgumentEditorConverter} and is specifically for
+ * Reference Genome|Annotation|Sequence editors.  The intention is to make sure a
+ * reference genome is always selected from the most up to date genome list
+ * {@link org.iplantc.de.client.services.AppBuilderMetadataServiceFacade#getReferenceGenomes(DECallback)}
+ * instead of auto-populating from a relaunch request, which may have stale data.
+ *
+ * See: CORE-9224
+ * @param <T>
+ */
+public class ReferenceGenomeEditorConverter<T> extends ArgumentEditorConverter<T> {
+
+    private final ListStore<ReferenceGenome> store;
+    private IsField<T> field;
+
+    public ReferenceGenomeEditorConverter(IsField<T> field, Converter<Splittable, T> converter) {
+        super(field, converter);
+
+        this.field = field;
+        ComboBox<ReferenceGenome> comboBox = (ComboBox<ReferenceGenome>)field;
+        this.store = comboBox.getListView().getStore();
+        store.addStoreAddHandler(event -> {
+            updateValueFromStore();
+        });
+    }
+
+    @Override
+    public void setValue(Splittable value) {
+        super.setValue(value);
+        updateValueFromStore();
+    }
+
+    void updateValueFromStore() {
+        ReferenceGenome selectedGenome = ((ComboBox<ReferenceGenome>)field).getCurrentValue();
+        if (selectedGenome != null) {
+            ((ComboBox<ReferenceGenome>)field).setValue(store.findModelWithKey(selectedGenome.getId()));
+        }
+    }
+
+}


### PR DESCRIPTION
It seems that the editor will fill the combobox with whatever was supplied to it, regardless of what's actually in the ListStore. So for this, I'm forcing the value to be chosen from the store, and in the case where the store is initially empty, I pick a value after the store has been populated.