### PR TITLE
Autocomplete component

### DIFF
--- a/react-components/src/__tests__/apps.js
+++ b/react-components/src/__tests__/apps.js
@@ -5,14 +5,7 @@ import {getDefaultTheme, MuiThemeProvider} from "../lib";
 
 import CategoryTreeTest from '../../stories/apps/details/CategoryTree.stories';
 import ToolDetailsTest from '../../stories/apps/details/ToolDetails.stories';
-import CopyTextAreaTest from '../../stories/util/CopyTextArea.stories';
 import AppStatsTest from '../../stories/apps/admin/AppStats.stories';
-
-it('renders CopyTextArea without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<MuiThemeProvider theme={getDefaultTheme()}><CopyTextAreaTest /></MuiThemeProvider>, div);
-  ReactDOM.unmountComponentAtNode(div);
-});
 
 it('renders CategoryTree without crashing', () => {
   const div = document.createElement('div');

--- a/react-components/src/__tests__/util.js
+++ b/react-components/src/__tests__/util.js
@@ -1,0 +1,33 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import {getDefaultTheme, MuiThemeProvider} from "../lib";
+
+import AutocompleteTest from "../../stories/util/Autocomplete.stories";
+import CopyTextAreaTest from "../../stories/util/CopyTextArea.stories";
+import SearchFieldTest from "../../stories/util/SearchField.stories";
+import TriggerFieldTest from "../../stories/util/TriggerField.stories";
+
+it('renders Autocomplete without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<MuiThemeProvider theme={getDefaultTheme()}><AutocompleteTest /></MuiThemeProvider>, div);
+    ReactDOM.unmountComponentAtNode(div);
+});
+
+it('renders CopyTextArea without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<MuiThemeProvider theme={getDefaultTheme()}><CopyTextAreaTest /></MuiThemeProvider>, div);
+    ReactDOM.unmountComponentAtNode(div);
+});
+
+it('renders SearchField without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<MuiThemeProvider theme={getDefaultTheme()}><SearchFieldTest /></MuiThemeProvider>, div);
+    ReactDOM.unmountComponentAtNode(div);
+});
+
+it('renders TriggerField without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<MuiThemeProvider theme={getDefaultTheme()}><TriggerFieldTest /></MuiThemeProvider>, div);
+    ReactDOM.unmountComponentAtNode(div);
+});

--- a/react-components/src/data/details/TagPanel.js
+++ b/react-components/src/data/details/TagPanel.js
@@ -7,40 +7,10 @@ import withI18N, {getMessage} from "../../util/I18NWrapper";
 import intlData from "../messages";
 import build from "../../util/DebugIDUtil";
 import ids from "../ids";
-import Select from "react-select";
 import exStyle from "../style";
 import injectSheet from "react-jss";
-import {withStyles} from "@material-ui/core/styles";
 import PropTypes from 'prop-types';
-
-const styles = theme => ({
-    // We had to use a lot of global selectors in order to style react-select.
-    // We are waiting on https://github.com/JedWatson/react-select/issues/1679
-    // to provide a much better implementation.
-    // Also, we had to reset the default style injected by the library.
-    '@global': {
-        '.Select-input input': {
-            cursor: 'default',
-            display: 'block',
-            fontFamily: 'inherit',
-            fontSize: 'inherit',
-            margin: 0,
-            outline: 0,
-            width: '100% !important',
-        },
-        '.Select-menu-outer': {
-            backgroundColor: theme.palette.background.paper,
-            boxShadow: theme.shadows[2],
-            width: '100%',
-            zIndex: 2,
-            maxHeight: 100,
-        },
-        '.Select-menu': {
-            maxHeight: 100,
-            overflowY: 'auto',
-        },
-    },
-});
+import Autocomplete from "../../util/Autocomplete";
 
 class TagPanel extends Component {
 
@@ -71,16 +41,16 @@ class TagPanel extends Component {
         let { placeholder } = this.props;
         return (
             <div id={build(this.props.baseID, ids.DETAILS_TAGS_PANEL)}>
-                <Select.Creatable labelKey="value"
-                                  valueKey="id"
-                                  multi={false}
-                                  options={this.props.dataSource}
-                                  onInputChange={this.handleInputChange}
-                                  onChange={this.handleTagSelect}
-                                  placeholder={placeholder}
-                                  promptTextCreator={(tagValue) => {
-                                      return getMessage("newTagPrompt", {values: {tag: tagValue}});
-                                  } }
+                <Autocomplete labelKey="value"
+                              valueKey="id"
+                              multi={false}
+                              options={this.props.dataSource}
+                              onInputChange={this.handleInputChange}
+                              onChange={this.handleTagSelect}
+                              placeholder={placeholder}
+                              promptTextCreator={(tagValue) => {
+                                  return getMessage("newTagPrompt", {values: {tag: tagValue}});
+                              } }
                 />
                 <div id={build(this.props.baseID, ids.DETAILS_TAGS)}
                      className={classes.tagPanelStyle}>
@@ -107,4 +77,4 @@ TagPanel.defaultProps = {
     placeholder: getMessage("searchTags")
 };
 
-export default injectSheet(exStyle)(withStyles(styles)(withI18N(TagPanel, intlData)));
+export default injectSheet(exStyle)(withI18N(TagPanel, intlData));

--- a/react-components/src/util/Autocomplete.js
+++ b/react-components/src/util/Autocomplete.js
@@ -1,0 +1,107 @@
+import MenuItem from "@material-ui/core/MenuItem";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import Select from "react-select";
+import { withStyles } from "@material-ui/core/styles";
+
+/**
+ * @author aramsey
+ * Renders the Select component from react-select with some stylings for material-ui
+ */
+
+// Copied from https://material-ui.com/demos/autocomplete/
+const styles = theme => ({
+    // We had to use a lot of global selectors in order to style react-select.
+    // We are waiting on https://github.com/JedWatson/react-select/issues/1679
+    // to provide a much better implementation.
+    // Also, we had to reset the default style injected by the library.
+    '@global': {
+        '.Select-input input': {
+            cursor: 'default',
+            display: 'block',
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            margin: 0,
+            outline: 0,
+            width: '100% !important',
+        },
+        '.Select-menu-outer': {
+            backgroundColor: theme.palette.background.paper,
+            boxShadow: theme.shadows[2],
+            width: '100%',
+            zIndex: 2,
+            maxHeight: 125,
+        },
+        '.Select-menu': {
+            maxHeight: 125,
+            overflowY: 'auto',
+        },
+
+    }
+});
+
+function Autocomplete(props) {
+    let {
+        variant,
+        ...custom
+    } = props;
+
+    let SelectComponent = null;
+
+    switch (variant) {
+        case 'creatable':
+            SelectComponent = Select.Creatable;
+            break;
+        case 'async':
+            SelectComponent = Select.Async;
+            break;
+        case 'asyncCreatable':
+            SelectComponent = Select.AsyncCreatable;
+            break;
+        default:
+            SelectComponent = Select;
+            break;
+    }
+
+    return (
+        <SelectComponent optionComponent={Option}
+                   {...custom} />
+    )
+}
+
+class Option extends Component {
+    handleClick = event => {
+        this.props.onSelect(this.props.option, event);
+    };
+
+    render() {
+        const {children} = this.props;
+
+        return (
+            <MenuItem onClick={this.handleClick}>
+                {children}
+            </MenuItem>
+        );
+    }
+}
+
+Autocomplete.propTypes = {
+    onInputChange: PropTypes.func, // when the input value updates
+    onChange: PropTypes.func, // when an option is selected
+    options: PropTypes.array, // array of options/suggestions
+    labelKey: PropTypes.string, // label for each option
+    valueKey: PropTypes.string, // value for each option
+    placeholder: PropTypes.any, 
+    variant: PropTypes.oneOf([
+        'creatable',
+        'async',
+        'asyncCreatable',
+        'default'
+    ]).isRequired
+};
+
+Autocomplete.defaultProps = {
+    variant: 'default'
+};
+
+export default withStyles(styles)(Autocomplete);

--- a/react-components/stories/index.stories.js
+++ b/react-components/stories/index.stories.js
@@ -34,5 +34,5 @@ storiesOf('data/TagPanel', module).add('with test diskresource details', () => <
 storiesOf('util', module).add('Autocomplete', () => <AutocompleteTest selectOptionLogger={action('Selected Option')}/>);
 storiesOf('util', module).add('CopyTextArea', () => <CopyTextAreaTest/>);
 storiesOf('util', module).add('DEHyperLink', () => <DEHyperLinkTest/>);
-storiesOf('util', module).add('SearchField', () => <SearchFieldTest logger={action}/>);
-storiesOf('util', module).add('TriggerSearchField', () => <TriggerFieldTest logger={action}/>);
+storiesOf('util', module).add('SearchField', () => <SearchFieldTest logger={action('Search')}/>);
+storiesOf('util', module).add('TriggerSearchField', () => <TriggerFieldTest logger={action('Search')}/>);

--- a/react-components/stories/index.stories.js
+++ b/react-components/stories/index.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
-import {storiesOf} from "@storybook/react";
-import {action} from "@storybook/addon-actions";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 import ToolDetailsTest from "./apps/details/ToolDetails.stories";
 import CategoryTreeTest from "./apps/details/CategoryTree.stories";
 import CopyTextAreaTest from "./util/CopyTextArea.stories";
@@ -16,6 +16,7 @@ import SearchFieldTest from './util/SearchField.stories';
 import SearchFormTest from "./data/search/SearchForm.stories";
 import SearchFormTagPanel from './data/search/SearchFormTagPanel.stories';
 import TriggerFieldTest from './util/TriggerField.stories';
+import AutocompleteTest from "./util/Autocomplete.stories";
 
 storiesOf('apps/admin/AppStats', module).add('with test stats', () => <AppStatsTest/>);
 storiesOf('apps/details', module).add('CategoryTree', () => <CategoryTreeTest logger={action('hierarchy')} />);
@@ -30,6 +31,7 @@ storiesOf('data/search', module).add('SearchFormTagPanel', () => <SearchFormTagP
 storiesOf('data/Tag', module).add('with test diskresource details', () => <TagTest logger={action('tag')}/>);
 storiesOf('data/TagPanel', module).add('with test diskresource details', () => <TagPanelTest logger={action('tagpanel')}/>);
 
+storiesOf('util', module).add('Autocomplete', () => <AutocompleteTest selectOptionLogger={action('Selected Option')}/>);
 storiesOf('util', module).add('CopyTextArea', () => <CopyTextAreaTest/>);
 storiesOf('util', module).add('DEHyperLink', () => <DEHyperLinkTest/>);
 storiesOf('util', module).add('SearchField', () => <SearchFieldTest logger={action}/>);

--- a/react-components/stories/util/Autocomplete.stories.js
+++ b/react-components/stories/util/Autocomplete.stories.js
@@ -1,0 +1,55 @@
+import Autocomplete from "../../src/util/Autocomplete";
+
+import React, { Component } from "react";
+
+/**
+ * @author aramsey
+ */
+class AutocompleteTest extends Component {
+    render() {
+        const selectOptionLogger = this.props.selectOptionLogger || ((selection) => {
+            console.log(selection);
+        });
+
+        let placeholder = 'Search for Fruit';
+
+        let options = [
+            {
+                id: '1',
+                value: 'apples',
+                display: 'Apples - The Staple',
+                description: 'old apples'
+            },
+            {
+                id: '2',
+                value: 'oranges',
+                display: 'Oranges - Meh',
+                description: 'old oranges'
+            },
+            {
+                id: '3',
+                value: 'tangerines',
+                display: 'Tangerines - The Best',
+                description: 'old tangerines'
+            },
+            {
+                id: '4',
+                value: 'kiwis',
+                display: 'Kiwis - The Fuzzy',
+                description: 'old kiwis'
+            }
+        ];
+
+        return (
+            <Autocomplete variant='creatable'
+                          placeholder={placeholder}
+                          labelKey='display'
+                          valueKey='value'
+                          onChange={selectOptionLogger}
+                          options={options}
+            />
+        );
+    }
+}
+
+export default AutocompleteTest;

--- a/react-components/stories/util/SearchField.stories.js
+++ b/react-components/stories/util/SearchField.stories.js
@@ -4,12 +4,15 @@ import React, { Component } from 'react';
 
 class SearchFieldTest extends Component {
     render() {
-        const handleSearch = this.props.logger('Search') || ((selection) => {
+        const handleSearch = this.props.logger || ((selection) => {
             console.log(selection);
         });
 
         return (
-            <SearchField handleSearch={handleSearch} />
+            <div>
+                <label>Type at least 3 characters, then wait a second</label>
+                <SearchField handleSearch={handleSearch}/>
+            </div>
         )
     }
 }

--- a/react-components/stories/util/TriggerField.stories.js
+++ b/react-components/stories/util/TriggerField.stories.js
@@ -5,14 +5,17 @@ import React, { Component } from 'react';
 
 class TriggerFieldTest extends Component {
     render() {
-        const handleSearch = this.props.logger('Search') || ((selection) => {
+        const handleSearch = this.props.logger || ((selection) => {
             console.log(selection);
         });
 
         return (
-            <TriggerField handleSearch={handleSearch}>
-                <Button>Test Success!</Button>
-            </TriggerField>
+            <div>
+                <label>Type at least 3 characters, then wait a second</label>
+                <TriggerField handleSearch={handleSearch}>
+                    <Button>Test Success!</Button>
+                </TriggerField>
+            </div>
         )
     }
 }


### PR DESCRIPTION
I've had this in my querybuilder branch for a while and figured I should probably go ahead and separate this out into its own PR. 
This is mostly just copied over from TagPanel.  I added the styled options (MenuItems), but couldn't figure out how to style the Input component to material-ui.  If you follow the example from material-ui, it looks right but the input component clears its state and loses focus if you receive new options/suggestions for some reason.

![image](https://user-images.githubusercontent.com/8909156/42916820-e67b4794-8abb-11e8-8e87-8871bfa2f115.png)
