### PR TITLE
CORE-9262 Fix error when creating team with readOptin privilege

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/EditTeamPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/teams/client/presenter/EditTeamPresenterImpl.java
@@ -647,7 +647,14 @@ public class EditTeamPresenterImpl implements EditTeamView.Presenter,
             return null;
         }
         PrivilegeType privilege = publicUserList.get(0).getPrivilegeType();
-        return Lists.newArrayList(privilege);
+        List<PrivilegeType> publicPrivs = Lists.newArrayList();
+        if (PrivilegeType.readOptin.equals(privilege)) {
+            publicPrivs.add(PrivilegeType.read);
+            publicPrivs.add(PrivilegeType.optin);
+        } else {
+            publicPrivs.add(privilege);
+        }
+        return publicPrivs;
     }
 
     List<Privilege> getPublicUserPrivilege(List<Privilege> privileges) {


### PR DESCRIPTION
The readOption privilege is fake and must be separated into 2 privileges: read and optIn