### PR TITLE
Add class for http DELETE with a body attached

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/server/auth/BaseUrlConnector.java
+++ b/de-lib/src/main/java/org/iplantc/de/server/auth/BaseUrlConnector.java
@@ -79,8 +79,8 @@ abstract class BaseUrlConnector implements UrlConnector {
      * @param url the URL to connect to.
      * @return the request.
      */
-    protected HttpDelete createHttpDelete(String url) {
-        return disableRedirects(new HttpDelete(url));
+    protected HttpDeleteWithBody createHttpDelete(String url) {
+        return disableRedirects(new HttpDeleteWithBody(url));
     }
 
     /**

--- a/de-lib/src/main/java/org/iplantc/de/server/auth/HttpDeleteWithBody.java
+++ b/de-lib/src/main/java/org/iplantc/de/server/auth/HttpDeleteWithBody.java
@@ -1,0 +1,35 @@
+package org.iplantc.de.server.auth;
+
+import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
+
+/**
+ * @author aramsey
+ *
+ * This is basically a copy of {@link org.apache.http.client.methods.HttpPut} but
+ * with the appropriate METHOD_NAME
+ */
+@NotThreadSafe
+class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
+    public static final String METHOD_NAME = "DELETE";
+
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+
+    public HttpDeleteWithBody(final String uri) {
+        super();
+        setURI(URI.create(uri));
+    }
+
+    public HttpDeleteWithBody(final URI uri) {
+        super();
+        setURI(uri);
+    }
+
+    public HttpDeleteWithBody() {
+        super();
+    }
+}

--- a/de-lib/src/main/java/org/iplantc/de/server/auth/JwtUrlConnector.java
+++ b/de-lib/src/main/java/org/iplantc/de/server/auth/JwtUrlConnector.java
@@ -7,6 +7,9 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.iplantc.de.server.AppLoggerConstants;
+
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +47,10 @@ public class JwtUrlConnector extends BaseUrlConnector implements UrlConnector {
     }
 
     @Override
-    public HttpDelete deleteRequest(HttpServletRequest request, String address) throws IOException {
-        return addHeaders(request, createHttpDelete(addIpAddress(address, request)));
+    public HttpDeleteWithBody deleteRequest(HttpServletRequest request, String address, String body) throws IOException {
+        HttpDeleteWithBody httpDelete = addHeaders(request, createHttpDelete(addIpAddress(address, request)));
+        httpDelete.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+        return httpDelete;
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/server/auth/UrlConnector.java
+++ b/de-lib/src/main/java/org/iplantc/de/server/auth/UrlConnector.java
@@ -1,6 +1,5 @@
 package org.iplantc.de.server.auth;
 
-import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
@@ -54,7 +53,7 @@ public interface UrlConnector {
      * @return the request.
      * @throws IOException if the connection can't be established.
      */
-    HttpDelete deleteRequest(HttpServletRequest request, String address) throws IOException;
+    HttpDeleteWithBody deleteRequest(HttpServletRequest request, String address, String body) throws IOException;
 
     /**
      * Obtains an HTTP PATCH request object.

--- a/de-lib/src/main/java/org/iplantc/de/server/services/DEServiceImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/server/services/DEServiceImpl.java
@@ -2,6 +2,7 @@ package org.iplantc.de.server.services;
 
 import static org.iplantc.de.server.AppLoggerConstants.REQUEST_KEY;
 import static org.iplantc.de.server.AppLoggerConstants.RESPONSE_KEY;
+
 import org.iplantc.de.server.AppLoggerConstants;
 import org.iplantc.de.server.AppLoggerUtil;
 import org.iplantc.de.server.ServiceCallResolver;
@@ -38,7 +39,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -226,7 +226,7 @@ public class DEServiceImpl implements DEService,
                     break;
 
                 case DELETE:
-                    request = urlConnector.deleteRequest(getRequest(), resolvedAddress);
+                    request = urlConnector.deleteRequest(getRequest(), resolvedAddress, body);
                     break;
 
                 case PATCH:


### PR DESCRIPTION
I tested this with a DELETE request that contained an actual body and one that had a blank `{}` body like we've used in the past, and it seems to work.