### PR TITLE
CORE-25 Replace redux-form with Formik in EditMetadataTemplate

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/EditMetadataTemplateViewImpl.java
@@ -22,7 +22,7 @@ public class EditMetadataTemplateViewImpl implements EditMetadataTemplateView {
     public void edit(EditMetadataTemplateView.Presenter presenter, Splittable metadataTemplate) {
         Scheduler.get().scheduleFinally(() -> {
             props.presenter = presenter;
-            props.initialValues = metadataTemplate;
+            props.template = metadataTemplate;
             props.open = true;
 
             CyVerseReactComponents.render(ReactMetadataAdminViews.EditMetadataTemplate, props, container.getElement());

--- a/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/ReactMetadataAdminViews.java
+++ b/de-lib/src/main/java/org/iplantc/de/admin/desktop/client/metadata/view/ReactMetadataAdminViews.java
@@ -17,7 +17,7 @@ public class ReactMetadataAdminViews {
     @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
     public static class EditMetadataTemplateProps extends BaseProps {
         public EditMetadataTemplateView.Presenter presenter;
-        public Splittable initialValues;
+        public Splittable template;
         public Boolean open;
     }
 }

--- a/react-components/package-lock.json
+++ b/react-components/package-lock.json
@@ -8833,9 +8833,9 @@
       }
     },
     "formik": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-1.4.3.tgz",
-      "integrity": "sha512-rwwcCPhidgiACnh1RBY8vp+Zp9ompHxezuGeIqmOh9RvmNCB8GCupoCWdDkWB0DZ1MBoDl76swB2v/FbMxeEmw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-1.5.0.tgz",
+      "integrity": "sha512-xSrikKwW2lcnOo4m0qe0GJZo4owclEHAsRzfYuzHL6coeAKDE80UjVwaRf5SdOhA3ac6/w/0jelzh5zDeJMZdQ==",
       "requires": {
         "create-react-context": "^0.2.2",
         "deepmerge": "^2.1.1",
@@ -8930,7 +8930,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8948,11 +8949,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8965,15 +8968,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9076,7 +9082,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9086,6 +9093,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9098,17 +9106,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9125,6 +9136,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9197,7 +9209,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9207,6 +9220,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9282,7 +9296,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9312,6 +9327,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9329,6 +9345,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9367,11 +9384,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/react-components/package.json
+++ b/react-components/package.json
@@ -19,7 +19,7 @@
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
     "classnames": "^2.2.6",
-    "formik": "^1.0.3",
+    "formik": "^1.5.0",
     "intro.js": "^2.9.3",
     "jss": "^9.8.7",
     "moment": "^2.22.1",

--- a/react-components/src/metadata/AstroThesaurusSearchField.js
+++ b/react-components/src/metadata/AstroThesaurusSearchField.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from "prop-types";
 
 import { getMessage } from "../util/I18NWrapper";
-import { FormikSearchField } from "../util/FormField";
+import { FormSearchField } from "../util/FormField";
 
 import ListItemText from '@material-ui/core/ListItemText';
 import MenuItem from "@material-ui/core/MenuItem";
@@ -59,14 +59,14 @@ class AstroThesaurusSearchField extends Component {
         const { presenter, ...props } = this.props;
 
         return (
-            <FormikSearchField loadOptions={this.loadOptions}
-                               variant="asyncCreatable"
-                               labelKey="label"
-                               valueKey="label"
-                               CustomOption={AstroThesaurusOption}
-                               formatCreateLabel={this.formatCreateLabel}
-                               styles={customStyles}
-                               {...props}
+            <FormSearchField loadOptions={this.loadOptions}
+                             variant="asyncCreatable"
+                             labelKey="label"
+                             valueKey="label"
+                             CustomOption={AstroThesaurusOption}
+                             formatCreateLabel={this.formatCreateLabel}
+                             styles={customStyles}
+                             {...props}
             />
         );
     }

--- a/react-components/src/metadata/MetadataTemplateView.js
+++ b/react-components/src/metadata/MetadataTemplateView.js
@@ -17,14 +17,14 @@ import styles from "./style";
 
 import ConfirmCloseDialog from "../util/ConfirmCloseDialog";
 import {
-    FormikCheckbox,
-    FormikIntegerField,
-    FormikNumberField,
-    FormikSelectField,
-    FormikTextField,
+    FormCheckbox,
+    FormIntegerField,
     FormMultilineTextField,
+    FormNumberField,
+    FormSelectField,
+    FormTextField,
     FormTimestampField,
-    getFormikError,
+    getFormError,
 } from "../util/FormField";
 
 import AstroThesaurusSearchField from "./AstroThesaurusSearchField";
@@ -142,13 +142,13 @@ class MetadataTemplateAttributeView extends Component {
 
                                 switch (attribute.type) {
                                     case "Boolean":
-                                        FieldComponent = FormikCheckbox;
+                                        FieldComponent = FormCheckbox;
                                         break;
                                     case "Number":
-                                        FieldComponent = FormikNumberField;
+                                        FieldComponent = FormNumberField;
                                         break;
                                     case "Integer":
-                                        FieldComponent = FormikIntegerField;
+                                        FieldComponent = FormIntegerField;
                                         break;
                                     case "Multiline Text":
                                         FieldComponent = FormMultilineTextField;
@@ -158,7 +158,7 @@ class MetadataTemplateAttributeView extends Component {
                                         break;
 
                                     case "Enum":
-                                        FieldComponent = FormikSelectField;
+                                        FieldComponent = FormSelectField;
                                         fieldProps = {
                                             ...fieldProps,
                                             children: attribute.values &&
@@ -194,7 +194,7 @@ class MetadataTemplateAttributeView extends Component {
                                         break;
 
                                     default:
-                                        FieldComponent = FormikTextField;
+                                        FieldComponent = FormTextField;
                                         break;
                                 }
 
@@ -204,7 +204,7 @@ class MetadataTemplateAttributeView extends Component {
                                     }
 
                                     let avuFieldName = `${field}.avus[${index}]`;
-                                    const avuError = getFormikError(avuFieldName, touched, errors);
+                                    const avuError = getFormError(avuFieldName, touched, errors);
                                     attrErrors = attrErrors || avuError;
 
                                     const rowID = build(ids.METADATA_TEMPLATE_VIEW, avuFieldName);

--- a/react-components/src/metadata/OntologyLookupServiceSearchField.js
+++ b/react-components/src/metadata/OntologyLookupServiceSearchField.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from "prop-types";
 
 import { getMessage } from "../util/I18NWrapper";
-import { FormikSearchField } from "../util/FormField";
+import { FormSearchField } from "../util/FormField";
 
 import ListItemText from '@material-ui/core/ListItemText';
 import MenuItem from "@material-ui/core/MenuItem";
@@ -66,14 +66,14 @@ class OntologyLookupServiceSearchField extends Component {
         const { attrTemplate, presenter, ...props } = this.props;
 
         return (
-            <FormikSearchField loadOptions={this.loadOptions}
-                               variant="asyncCreatable"
-                               labelKey="label"
-                               valueKey="label"
-                               CustomOption={OLSOption}
-                               formatCreateLabel={this.formatCreateLabel}
-                               styles={customStyles}
-                               {...props}
+            <FormSearchField loadOptions={this.loadOptions}
+                             variant="asyncCreatable"
+                             labelKey="label"
+                             valueKey="label"
+                             CustomOption={OLSOption}
+                             formatCreateLabel={this.formatCreateLabel}
+                             styles={customStyles}
+                             {...props}
             />
         );
     }

--- a/react-components/src/metadata/admin/EditMetadataTemplate.js
+++ b/react-components/src/metadata/admin/EditMetadataTemplate.js
@@ -3,13 +3,12 @@
  */
 import React, { Component } from "react";
 
+import { FastField, FieldArray, withFormik } from 'formik';
 import PropTypes from "prop-types";
-import { Field, FieldArray, reduxForm } from "redux-form";
 import { injectIntl } from "react-intl";
 
 import build from "../../util/DebugIDUtil";
 import withI18N, { formatMessage, getMessage } from "../../util/I18NWrapper";
-import withStoreProvider from "../../util/StoreProvider";
 import intlData from "../messages";
 import styles from "../style";
 import ids from "./ids";
@@ -38,7 +37,6 @@ class EditMetadataTemplate extends Component {
         this.state = { showConfirmationDialog: false };
 
         [
-            "onSaveTemplate",
             "closeMetadataTemplateDialog",
             "closeConfirmationDialog",
         ].forEach(methodName => (this[methodName] = this[methodName].bind(this)));
@@ -49,26 +47,6 @@ class EditMetadataTemplate extends Component {
             onSaveTemplate: PropTypes.func.isRequired,
             closeMetadataTemplateDialog: PropTypes.func.isRequired,
         }),
-    };
-
-    onSaveTemplate({name, description, deleted, attributes}) {
-        this.closeConfirmationDialog();
-
-        return new Promise((resolve, reject) => {
-            const { id } = this.props.initialValues;
-
-            this.props.presenter.onSaveTemplate(
-                {
-                    id,
-                    name,
-                    description,
-                    deleted,
-                    attributes,
-                },
-                resolve,
-                (httpStatusCode, errorMessage) => reject(errorMessage),
-            );
-        });
     };
 
     closeMetadataTemplateDialog() {
@@ -85,8 +63,8 @@ class EditMetadataTemplate extends Component {
             classes,
             intl,
             open,
-            // from redux-form
-            handleSubmit, pristine, submitting, error, change,
+            // from formik
+            handleSubmit, dirty, isSubmitting, error,
         } = this.props;
 
         const dialogTitleID = build(ids.METADATA_TEMPLATE_FORM, ids.TITLE);
@@ -105,9 +83,9 @@ class EditMetadataTemplate extends Component {
                         <IconButton id={build(ids.METADATA_TEMPLATE_FORM, ids.BUTTONS.CLOSE)}
                                     aria-label={formatMessage(intl, "close")}
                                     onClick={() => (
-                                        pristine ?
-                                            this.props.presenter.closeMetadataTemplateDialog() :
-                                            this.setState({showConfirmationDialog: true})
+                                        dirty ?
+                                            this.setState({showConfirmationDialog: true}) :
+                                            this.props.presenter.closeMetadataTemplateDialog()
                                     )}
                                     color="inherit"
                         >
@@ -117,8 +95,8 @@ class EditMetadataTemplate extends Component {
                             {getMessage("dialogTitleEditMetadataTemplate")}
                         </Typography>
                         <Button id={build(ids.METADATA_TEMPLATE_FORM, ids.BUTTONS.SAVE)}
-                                disabled={pristine || submitting || error}
-                                onClick={handleSubmit(this.onSaveTemplate)}
+                                disabled={!dirty || isSubmitting || error}
+                                onClick={handleSubmit}
                                 color="inherit"
                         >
                             {getMessage("save")}
@@ -127,38 +105,37 @@ class EditMetadataTemplate extends Component {
                 </AppBar>
 
                 <DialogContent>
-                    <Field name="name"
-                           label={getMessage("templateNameLabel")}
-                           id={build(ids.METADATA_TEMPLATE_FORM, ids.TEMPLATE_NAME)}
-                           required={true}
-                           autoFocus
-                           margin="dense"
-                           component={FormTextField}
+                    <FastField name="name"
+                               label={getMessage("templateNameLabel")}
+                               id={build(ids.METADATA_TEMPLATE_FORM, ids.TEMPLATE_NAME)}
+                               required={true}
+                               autoFocus
+                               margin="dense"
+                               component={FormTextField}
                     />
-                    <Field name="description"
-                           label={getMessage("description")}
-                           id={build(ids.METADATA_TEMPLATE_FORM, ids.TEMPLATE_DESCRIPTION)}
-                           component={FormTextField}
+                    <FastField name="description"
+                               label={getMessage("description")}
+                               id={build(ids.METADATA_TEMPLATE_FORM, ids.TEMPLATE_DESCRIPTION)}
+                               component={FormTextField}
                     />
 
-                    <Field name="deleted"
-                           label={getMessage("markAsDeleted")}
-                           id={build(ids.METADATA_TEMPLATE_FORM, ids.CHECK_DELETED)}
-                           color="primary"
-                           component={FormCheckbox}
+                    <FastField name="deleted"
+                               label={getMessage("markAsDeleted")}
+                               id={build(ids.METADATA_TEMPLATE_FORM, ids.CHECK_DELETED)}
+                               color="primary"
+                               component={FormCheckbox}
                     />
 
                     <Divider />
 
                     <FieldArray name="attributes"
                                 component={EditAttributeFormList}
-                                change={change}
                     />
                 </DialogContent>
 
                 <ConfirmCloseDialog open={this.state.showConfirmationDialog}
                                     parentId={ids.METADATA_TEMPLATE_FORM}
-                                    onConfirm={handleSubmit(this.onSaveTemplate)}
+                                    onConfirm={handleSubmit}
                                     onClose={this.closeMetadataTemplateDialog}
                                     onCancel={this.closeConfirmationDialog}
                                     title={getMessage("save")}
@@ -174,7 +151,6 @@ class EditMetadataTemplate extends Component {
 
 const validateAttributes = attributes => {
     const attributesArrayErrors = [];
-    const _error = [];
 
     attributes.forEach((attr, attrIndex) => {
         const attrErrors = {};
@@ -182,11 +158,13 @@ const validateAttributes = attributes => {
 
         if (!name) {
             attrErrors.name = getMessage("required");
+            attrErrors.error = getMessage("errAttrHasErrors");
             attributesArrayErrors[attrIndex] = attrErrors;
         } else {
             const namesMatch = attr => (attr.name === name);
             if (attributes.slice(0, attrIndex).some(namesMatch) || attributes.slice(attrIndex + 1).some(namesMatch)) {
                 attrErrors.name = getMessage("errAttrNameMustBeUnique");
+                attrErrors.error = attrErrors.error ? getMessage("errAttrHasErrors") : getMessage("errAttrNameMustBeUnique");
                 attributesArrayErrors[attrIndex] = attrErrors;
             }
         }
@@ -194,18 +172,21 @@ const validateAttributes = attributes => {
         // Validate Enum values
         if (attr.type === "Enum") {
             if (!attr.values || attr.values.length < 1) {
-                // Setting an attrErrors.values["_error"] message allows the error to be displayed in the table header.
-                attrErrors.values = [];
-                attrErrors.values["_error"] = getMessage("errEnumValueRequired");
+                // Setting an attrErrors.values message allows the error to be displayed in the table header,
+                // but that component will have to check first if attrErrors.values is an array or not.
+                attrErrors.values = getMessage("errEnumValueRequired");
+                attrErrors.error = attrErrors.error ? getMessage("errAttrHasErrors") : getMessage("errEnumValueRequired");
                 attributesArrayErrors[attrIndex] = attrErrors;
             } else {
                 const enumArrayErrors = [];
                 attr.values.forEach((enumOption, valIndex) => {
                     if (!enumOption.value) {
-                        enumArrayErrors[valIndex] = {value: getMessage("required")};
-                        // Setting an enumArrayErrors["_error"] message allows the error to be displayed in the table header,
-                        // and also allows the dialog close button to be disabled.
-                        enumArrayErrors["_error"] = getMessage("errEnumOptionValueRequired");
+                        enumArrayErrors[valIndex] = {
+                            // Setting enumArrayErrors.error allows the dialog close button to be disabled.
+                            error: true,
+                            value: getMessage("required"),
+                        };
+                        attrErrors.error = attrErrors.error ? getMessage("errAttrHasErrors") : getMessage("errEnumOptionValueRequired");
                         attrErrors.values = enumArrayErrors;
                         attributesArrayErrors[attrIndex] = attrErrors;
                     }
@@ -217,13 +198,9 @@ const validateAttributes = attributes => {
             const subAttrErros = validateAttributes(attr.attributes);
             if (subAttrErros.length > 0) {
                 attrErrors.attributes = subAttrErros;
+                attrErrors.error = getMessage("errAttrHasErrors");
                 attributesArrayErrors[attrIndex] = attrErrors;
             }
-        }
-
-        if (attributesArrayErrors[attrIndex]) {
-            _error[attrIndex] = getMessage("errAttrHasErrors");
-            attributesArrayErrors["_error"] = _error;
         }
     });
 
@@ -235,25 +212,57 @@ const validate = values => {
 
     if (!values.name) {
         errors.name = getMessage("required");
-        errors._error = true;
+        errors.error = true;
     }
 
     if (values.attributes && values.attributes.length > 0) {
         const attributesArrayErrors = validateAttributes(values.attributes);
         if (attributesArrayErrors.length > 0) {
             errors.attributes = attributesArrayErrors;
-            errors._error = true;
+            errors.error = true;
         }
     }
 
     return errors;
 };
 
-export default withStoreProvider(
-    reduxForm(
+const handleSubmit = ({ name, description, deleted, attributes },
+                      { props, setSubmitting, setStatus }) => {
+    const resolve = (template) => {
+        setSubmitting(false);
+        setStatus({ success: true, template });
+    };
+    const errorCallback = (httpStatusCode, errorMessage) => {
+        setSubmitting(false);
+        setStatus({ success: false, errorMessage });
+    };
+
+    const { id } = props.template;
+
+    props.presenter.onSaveTemplate(
         {
-            form: ids.METADATA_TEMPLATE_FORM,
-            enableReinitialize: true,
-            validate,
-        }
-    )(withStyles(styles)(withI18N(injectIntl(EditMetadataTemplate), intlData))));
+            id,
+            name,
+            description,
+            deleted,
+            attributes,
+        },
+        resolve,
+        errorCallback,
+    );
+};
+
+const mapPropsToValues = props => {
+    const { template } = props;
+
+    return { ...template };
+};
+
+export default withFormik(
+    {
+        enableReinitialize: true,
+        mapPropsToValues,
+        validate,
+        handleSubmit,
+    }
+)(withStyles(styles)(withI18N(injectIntl(EditMetadataTemplate), intlData)));

--- a/react-components/src/metadata/admin/OntologyLookupServiceSettings.js
+++ b/react-components/src/metadata/admin/OntologyLookupServiceSettings.js
@@ -2,7 +2,7 @@
  * @author psarando
  */
 import React, { Component } from "react";
-import { Field, FieldArray } from "redux-form";
+import { FastField, FieldArray } from 'formik';
 
 import build from "../../util/DebugIDUtil";
 import withI18N, { getMessage } from "../../util/I18NWrapper";
@@ -29,7 +29,7 @@ const OLSEntityTypeMenuItems = OLSEntityTypes.map((type, index) => (<MenuItem ke
 
 class OntologyLookupServiceSettings extends Component {
     render() {
-        const { parentID } = this.props;
+        const { field, parentID } = this.props;
         const formID = build(parentID, ids.OLS_PARAMS_EDIT_DIALOG);
 
         return (
@@ -43,43 +43,52 @@ class OntologyLookupServiceSettings extends Component {
                     <fieldset>
                         <legend>{getMessage("olsSettingTypeTitle")}</legend>
 
-                        <Field name="type"
-                               id={build(formID, ids.ONTOLOGY_ENTITY_TYPE)}
-                               label={getMessage("olsSettingTypeLabel")}
-                               component={FormSelectField}
+                        <FastField name={`${field}.type`}
+                                   id={build(formID, ids.ONTOLOGY_ENTITY_TYPE)}
+                                   label={getMessage("olsSettingTypeLabel")}
+                                   component={FormSelectField}
                         >
                             {OLSEntityTypeMenuItems}
-                        </Field>
+                        </FastField>
                     </fieldset>
                 </Grid>
 
                 <Grid item>
-                    <FieldArray name="ontology"
-                                component={StringListEditor}
-                                parentID={build(formID, ids.ONTOLOGIES)}
-                                title={getMessage("olsSettingOntologyTitle")}
-                                helpLabel={getMessage("olsSettingOntologyHelpLabel")}
-                                columnLabel={getMessage("olsSettingOntologyColumnLabel")}
+                    <FieldArray name={`${field}.ontology`}
+                                render={arrayHelpers =>
+                                    <StringListEditor
+                                        {...arrayHelpers}
+                                        parentID={build(formID, ids.ONTOLOGIES)}
+                                        title={getMessage("olsSettingOntologyTitle")}
+                                        helpLabel={getMessage("olsSettingOntologyHelpLabel")}
+                                        columnLabel={getMessage("olsSettingOntologyColumnLabel")}
+                                    />}
                     />
                 </Grid>
 
                 <Grid item>
-                    <FieldArray name="childrenOf"
-                                component={StringListEditor}
-                                parentID={build(formID, ids.ONTOLOGY_CHILDREN)}
-                                title={getMessage("olsSettingChildrenOfTitle")}
-                                helpLabel={getMessage("olsSettingChildrenOfHelpLabel")}
-                                columnLabel={getMessage("olsSettingIRIColumnLabel")}
+                    <FieldArray name={`${field}.childrenOf`}
+                                render={arrayHelpers =>
+                                    <StringListEditor
+                                        {...arrayHelpers}
+                                        parentID={build(formID, ids.ONTOLOGY_CHILDREN)}
+                                        title={getMessage("olsSettingChildrenOfTitle")}
+                                        helpLabel={getMessage("olsSettingChildrenOfHelpLabel")}
+                                        columnLabel={getMessage("olsSettingIRIColumnLabel")}
+                                    />}
                     />
                 </Grid>
 
                 <Grid item>
-                    <FieldArray name="allChildrenOf"
-                                component={StringListEditor}
-                                parentID={build(formID, ids.ONTOLOGY_ALL_CHILDREN)}
-                                title={getMessage("olsSettingAllChildrenOfTitle")}
-                                helpLabel={getMessage("olsSettingAllChildrenOfHelpLabel")}
-                                columnLabel={getMessage("olsSettingIRIColumnLabel")}
+                    <FieldArray name={`${field}.allChildrenOf`}
+                                render={arrayHelpers =>
+                                    <StringListEditor
+                                        {...arrayHelpers}
+                                        parentID={build(formID, ids.ONTOLOGY_ALL_CHILDREN)}
+                                        title={getMessage("olsSettingAllChildrenOfTitle")}
+                                        helpLabel={getMessage("olsSettingAllChildrenOfHelpLabel")}
+                                        columnLabel={getMessage("olsSettingIRIColumnLabel")}
+                                    />}
                     />
                 </Grid>
             </Grid>

--- a/react-components/src/util/FormField.js
+++ b/react-components/src/util/FormField.js
@@ -18,21 +18,21 @@ import Select from "@material-ui/core/Select";
 import TableCell from "@material-ui/core/TableCell";
 import TextField from "@material-ui/core/TextField";
 
-const getFormikError = (name, touched, errors) => {
+const getFormError = (name, touched, errors) => {
     const error = getIn(errors, name);
     const touch = getIn(touched, name);
 
     return touch && error ? error : null;
 };
 
-const FormikTextField = ({
+const FormTextField = ({
     field,
     label,
     required,
     form: { touched, errors },
     ...custom
 }) => {
-    const errorMsg = getFormikError(field.name, touched, errors);
+    const errorMsg = getFormError(field.name, touched, errors);
     return (
         <TextField
             label={label}
@@ -46,14 +46,14 @@ const FormikTextField = ({
     )
 };
 
-const FormikSearchField = ({
+const FormSearchField = ({
     field: { value, onBlur, onChange, ...field },
     label,
     required,
     form: { touched, errors, setFieldTouched, setFieldValue },
     ...props
 }) => {
-    const errorMsg = getFormikError(field.name, touched, errors);
+    const errorMsg = getFormError(field.name, touched, errors);
     const onOptionSelected = option => {
         setFieldValue(field.name, option ? option[props.valueKey] : "");
     };
@@ -83,7 +83,7 @@ const onCheckboxChange = (setFieldValue, fieldName) => (event, checked) => {
     setFieldValue(fieldName, checked);
 };
 
-const FormikCheckbox = ({
+const FormCheckbox = ({
     label,
     field: { value, onChange, ...field },
     form: { setFieldValue },
@@ -99,6 +99,21 @@ const FormikCheckbox = ({
         }
         label={label}
     />
+);
+
+const FormCheckboxTableCell = ({
+    field: { value, onChange, ...field },
+    form: { setFieldValue },
+    ...custom
+}) => (
+    <TableCell padding="checkbox">
+        <Checkbox color="primary"
+                  checked={!!value}
+                  onClick={event => event.stopPropagation()}
+                  onChange={onCheckboxChange(setFieldValue, field.name)}
+                  {...custom}
+        />
+    </TableCell>
 );
 
 const onNumberChange = onChange => (event) => {
@@ -117,34 +132,34 @@ const onIntegerChange = onChange => (event) => {
     }
 };
 
-const FormikNumberField = ({
+const FormNumberField = ({
     field: { onChange, ...field },
     ...props
 }) => (
-    <FormikTextField type="number"
-                     step="any"
-                     onChange={onNumberChange(onChange)}
-                     field={field}
-                     {...props}
+    <FormTextField type="number"
+                   step="any"
+                   onChange={onNumberChange(onChange)}
+                   field={field}
+                   {...props}
     />
 );
 
-const FormikIntegerField = ({
+const FormIntegerField = ({
     field: { onChange, ...field },
     ...props
 }) => (
-    <FormikTextField type="number"
-                     step={1}
-                     onChange={onIntegerChange(onChange)}
-                     field={field}
-                     {...props}
+    <FormTextField type="number"
+                   step={1}
+                   onChange={onIntegerChange(onChange)}
+                   field={field}
+                   {...props}
     />
 );
 
 const FormMultilineTextField = (props) => (
-    <FormikTextField multiline
-                     rows={3}
-                     {...props}
+    <FormTextField multiline
+                   rows={3}
+                   {...props}
     />
 );
 
@@ -172,7 +187,7 @@ const FormTimestampField = ({
     form: { touched, errors, setFieldValue },
     ...custom
 }) => {
-    const errorMsg = getFormikError(field.name, touched, errors);
+    const errorMsg = getFormError(field.name, touched, errors);
     const date = value && Date.parse(value);
 
     return (
@@ -201,7 +216,7 @@ const FormTimestampField = ({
     )
 };
 
-const FormikSelectField = ({
+const FormSelectField = ({
     id,
     field: { value, ...field },
     label,
@@ -210,7 +225,7 @@ const FormikSelectField = ({
     children,
     ...custom,
 }) => {
-    const errorMsg = getFormikError(field.name, touched, errors);
+    const errorMsg = getFormError(field.name, touched, errors);
     return (
         <FormControl fullWidth error={!!errorMsg}>
             <InputLabel htmlFor={id}
@@ -230,78 +245,15 @@ const FormikSelectField = ({
     )
 };
 
-const FormTextField = ({
-    input,
-    label,
-    required,
-    meta: { touched, error },
-    ...custom
-}) => (
-    <TextField
-        label={label}
-        error={touched && !!error}
-        helperText={touched && error}
-        required={required}
-        fullWidth
-        {...input}
-        {...custom}
-    />
-);
-
-const FormCheckbox = ({ input, label, ...custom }) => (
-    <FormControlLabel
-        control={
-            <Checkbox checked={!!input.value}
-                      onChange={input.onChange}
-                      {...custom}
-            />
-        }
-        label={label}
-    />
-);
-
-const FormCheckboxTableCell = ({ input, ...custom }) => (
-    <TableCell padding="checkbox">
-        <Checkbox color="primary"
-                  checked={!!input.value}
-                  onClick={event => event.stopPropagation()}
-                  onChange={input.onChange}
-                  {...custom}
-        />
-    </TableCell>
-);
-
-const FormSelectField = ({
-    input,
-    label,
-    id,
-    children,
-    ...custom
-}) => (
-    <FormControl fullWidth>
-        <InputLabel htmlFor={id}>{label}</InputLabel>
-        <Select id={id}
-                value={input.value || ""}
-                {...input}
-                {...custom}
-        >
-            {children}
-        </Select>
-    </FormControl>
-);
-
 export {
     FormCheckbox,
     FormCheckboxTableCell,
+    FormIntegerField,
+    FormMultilineTextField,
+    FormNumberField,
+    FormSearchField,
     FormSelectField,
     FormTextField,
-    FormikCheckbox,
-    FormikIntegerField,
-    FormMultilineTextField,
-    FormikNumberField,
-    FormikSearchField,
-    FormikSelectField,
-    FormikTextField,
     FormTimestampField,
-    getFormikError,
+    getFormError,
 };

--- a/react-components/stories/metadata/MetadataTemplate.stories.js
+++ b/react-components/stories/metadata/MetadataTemplate.stories.js
@@ -228,7 +228,7 @@ class EditNestedAttrMetadataTemplateTest extends Component {
         });
 
         return (
-            <EditMetadataTemplate open presenter={presenter(logger)} initialValues={nestedAttrMetadataTemplate} />
+            <EditMetadataTemplate open presenter={presenter(logger)} template={nestedAttrMetadataTemplate} />
         );
     }
 }
@@ -1260,7 +1260,7 @@ class EditDataCiteMetadataTemplateTest extends Component {
         });
 
         return (
-            <EditMetadataTemplate open presenter={presenter(logger)} initialValues={dataciteMetadataTemplate} />
+            <EditMetadataTemplate open presenter={presenter(logger)} template={dataciteMetadataTemplate} />
         );
     }
 }


### PR DESCRIPTION
This PR will replace `redux-form` fields with `Formik` fields in the admin `EditMetadataTemplate` dialog and in `util/FormField`.

Only the `data/search/QueryBuilder` forms now use `redux-form`, but I think we can convert those in a later PR.