### PR TITLE
9282

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/AnalysesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/AnalysesView.java
@@ -97,6 +97,7 @@ public interface AnalysesView extends IsWidget {
                          Splittable filters,
                          String sortField,
                          String sortDir,
+                         boolean resetSelectedAnalyses,
                          ReactSuccessCallback callback,
                          ReactErrorCallback errorCallback);
 

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/AnalysesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/AnalysesPresenterImpl.java
@@ -62,6 +62,8 @@ import java.util.List;
  */
 public class AnalysesPresenterImpl implements AnalysesView.Presenter {
 
+    private String baseDebugId;
+
     private final class CompleteAnalysisServiceCallback extends AnalysisCallback<String> {
         private final String analysisName;
         final ReactSuccessCallback callback;
@@ -181,6 +183,7 @@ public class AnalysesPresenterImpl implements AnalysesView.Presenter {
                             Splittable filters,
                             String sortField,
                             String sortDir,
+                            boolean resetSelectedAnalyses,
                             ReactSuccessCallback callback,
                             ReactErrorCallback errorCallback) {
         AutoBean<FilterBeanList> filterList =
@@ -200,6 +203,9 @@ public class AnalysesPresenterImpl implements AnalysesView.Presenter {
                 if (errorCallback != null) {
                     errorCallback.onError(statusCode, exception.getMessage());
                 }
+                if(resetSelectedAnalyses) {
+                    view.load(AnalysesPresenterImpl.this, baseDebugId, null);
+                }
             }
 
             @Override
@@ -207,6 +213,9 @@ public class AnalysesPresenterImpl implements AnalysesView.Presenter {
                 AutoBean<AnalysesList> ret = AutoBeanCodex.decode(factory, AnalysesList.class, result);
                 if (callback != null) {
                     callback.onSuccess(AutoBeanCodex.encode(ret));
+                }
+                if(resetSelectedAnalyses) {
+                    view.load(AnalysesPresenterImpl.this, baseDebugId, null);
                 }
             }
         });
@@ -288,6 +297,7 @@ public class AnalysesPresenterImpl implements AnalysesView.Presenter {
     public void go(final HasOneWidget container,
                    String baseDebugId,
                    List<Analysis> selectedAnalyses) {
+        this.baseDebugId = baseDebugId;
         container.setWidget(view);
         if (selectedAnalyses != null && selectedAnalyses.size() > 0) {
             view.load(this, baseDebugId, selectedAnalyses.get(0));

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/MyAnalysesWindow.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/views/windows/MyAnalysesWindow.java
@@ -76,6 +76,12 @@ public class MyAnalysesWindow extends WindowBase {
     @Override
     public <C extends WindowConfig> void update(C config) {
         super.update(config);
+        AnalysisWindowConfig analysisWindowConfig = (AnalysisWindowConfig) config;
+        if(analysisWindowConfig != null && presenter != null) {
+            presenter.go(this,
+                         DeModule.WindowIds.ANALYSES_WINDOW,
+                         analysisWindowConfig.getSelectedAnalyses());
+        }
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/AnalysesViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/AnalysesViewDefaultAppearance.java
@@ -24,7 +24,7 @@ public class AnalysesViewDefaultAppearance implements AnalysesView.Appearance {
 
     @Override
     public int windowMinWidth() {
-        return 590;
+        return 950;
     }
 
     @Override

--- a/react-components/package.json
+++ b/react-components/package.json
@@ -56,5 +56,11 @@
   },
   "eslintConfig": {
     "extends": "react-app"
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/react-components/src/analysis/messages.js
+++ b/react-components/src/analysis/messages.js
@@ -42,7 +42,7 @@ var intlData = {
         "outputConditionHeader": "Select Output condition:",
         "saveToFile": "Save to file",
         "type": "App Type",
-        "permission": "Permission",
+        "permission": "View",
         "needHelp":"I still need help!",
         "noAnalysis": "No analysis to display!",
         "analysesExecDeleteWarning" : "This will remove the selected analyses and the parameters information associated with those analyses. Outputs can still be viewed in the Data window within the folder created by these analyses.",

--- a/react-components/src/analysis/style.js
+++ b/react-components/src/analysis/style.js
@@ -7,15 +7,15 @@ export default (theme) => ({
         width: "100%"
     },
     tableHead: {
-        backgroundColor: "#e2e2e2",
+        backgroundColor: Color.blue,
         position: "sticky",
-        top: 0
+        top: 0,
     },
     loadingStyle: {
         position: 'absolute',
-        top: 200,
-        left: 400,
-        color: '#DB6619',
+        top: '50%',
+        left: '50%',
+        color: Color.orange,
     },
     container: {
         width: "100%",

--- a/react-components/src/analysis/style.js
+++ b/react-components/src/analysis/style.js
@@ -33,7 +33,7 @@ export default (theme) => ({
         backgroundColor: Color.lightGray,
         borderBottom: 'solid 2px',
         borderColor: Color.gray,
-        height: 60,
+        height: 55,
     },
     dialogCloseButton: {
         position: 'absolute',

--- a/react-components/src/analysis/view/AnalysesView.js
+++ b/react-components/src/analysis/view/AnalysesView.js
@@ -362,11 +362,13 @@ class AnalysesView extends Component {
 
     handleChangePage(event, page) {
         const {rowsPerPage} = this.state;
-        this.setState({page: page, offset: rowsPerPage * page});
+        //reset selection between pages
+        this.setState({page: page, offset: rowsPerPage * page, selected: []},
+            () => this.fetchAnalyses());
     }
 
     handleChangeRowsPerPage(event) {
-        this.setState({rowsPerPage: event.target.value});
+        this.setState({rowsPerPage: event.target.value}, () => this.fetchAnalyses());
     }
 
     handleSelectAllClick(event, checked) {
@@ -826,11 +828,11 @@ class AnalysesView extends Component {
                                 orderBy={orderBy}
                                 onSelectAllClick={this.handleSelectAllClick}
                                 onRequestSort={this.handleRequestSort}
-                                rowCount={total}
                                 columnData={columnData}
                                 baseId={baseId}
                                 ids={ids}
                                 padding="none"
+                                rowInPage={data.length}
                             />
                             <TableBody>
                                 {data.map(analysis => {
@@ -943,7 +945,7 @@ class AnalysesView extends Component {
                                      onChangePage={this.handleChangePage}
                                      onChangeRowsPerPage={this.handleChangeRowsPerPage}
                                      ActionsComponent={TablePaginationActions}
-                                     rowsPerPageOptions={[100, 500, 1000]}
+                                     rowsPerPageOptions={[5, 100, 500, 1000]}
                     />
                 </div>
                 {selectedAnalysis &&

--- a/react-components/src/analysis/view/AnalysesView.js
+++ b/react-components/src/analysis/view/AnalysesView.js
@@ -973,7 +973,7 @@ class AnalysesView extends Component {
                                      onChangePage={this.handleChangePage}
                                      onChangeRowsPerPage={this.handleChangeRowsPerPage}
                                      ActionsComponent={TablePaginationActions}
-                                     rowsPerPageOptions={[5, 100, 500, 1000]}
+                                     rowsPerPageOptions={[100, 500, 1000]}
                     />
                 </div>
                 {selectedAnalysis &&

--- a/react-components/src/notifications/style.js
+++ b/react-components/src/notifications/style.js
@@ -30,6 +30,7 @@ export default (theme) => ({
         backgroundColor: Color.lightGray,
         borderBottom: 'solid 2px',
         borderColor: Color.gray,
+        height: 55,
     },
     notification: {
         textDecoration: 'underline',
@@ -37,5 +38,14 @@ export default (theme) => ({
     },
     unSeenNotificationBackground: {
         backgroundColor: Color.lightBlue,
+    },
+    dropDown: {
+        margin: 3,
+        height: 40,
+        flexDirection: 'unset',
+    },
+    dropDownLabel: {
+        paddingLeft: 5,
+        fontSize:10
     }
 });

--- a/react-components/src/notifications/style.js
+++ b/react-components/src/notifications/style.js
@@ -6,15 +6,15 @@ export default (theme) => ({
         height: "75%",
     },
     tableHead: {
-        backgroundColor: "#e2e2e2",
+        backgroundColor:  Color.blue,
         position: "sticky",
         top: 0
     },
     loadingStyle: {
         position: 'absolute',
-        top: 200,
-        left: 400,
-        color: '#DB6619',
+        top: '50%',
+        left: '50%',
+        color: Color.orange,
     },
     container: {
         width: "100%",

--- a/react-components/src/notifications/view/NotificationToolbar.js
+++ b/react-components/src/notifications/view/NotificationToolbar.js
@@ -4,11 +4,11 @@
  *  @author sriram
  * */
 import React, { Component } from "react";
-import Toolbar from "@material-ui/core/Toolbar";
 import ToolbarGroup from "@material-ui/core/Toolbar";
 import ToolbarSeparator from "@material-ui/core/Toolbar";
 import Select from "@material-ui/core/Select";
 import InputLabel from "@material-ui/core/InputLabel";
+import OutlinedInput from "@material-ui/core/OutlinedInput";
 import FormControl from "@material-ui/core/FormControl";
 import RefreshIcon from "@material-ui/icons/Refresh";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -28,19 +28,17 @@ class NotificationToolbar extends Component {
         const {classes, baseDebugId} = this.props;
         const baseId = baseDebugId + ids.TOOLBAR;
         return (
-            <Toolbar className={classes.toolbar}>
+            <div className={classes.toolbar}>
                 <ToolbarGroup>
                     <form autoComplete="off">
-                        <FormControl>
-                            <InputLabel htmlFor="filter-simple">Filter</InputLabel>
+                        <FormControl className={classes.dropDown}>
+                            <InputLabel
+                                className={classes.dropDownLabel}>{getMessage("filter")}</InputLabel>
                             <Select
                                 native
                                 value={this.props.filter}
                                 onChange={this.props.onFilterChange}
-                                inputProps={{
-                                    name: getMessage("filter"),
-                                    id: build(baseId, ids.FILTER),
-                                }}>
+                                input={<OutlinedInput name="filter"/>}>
                                 <option
                                     value={notificationCategory.new}>{notificationCategory.new}</option>
                                 <option
@@ -89,7 +87,7 @@ class NotificationToolbar extends Component {
                     </Button>
 
                 </ToolbarGroup>
-            </Toolbar>
+            </div>
 
         )
     }

--- a/react-components/src/notifications/view/NotificationView.js
+++ b/react-components/src/notifications/view/NotificationView.js
@@ -37,6 +37,7 @@ function Message(props) {
     let className = (seen) ? classes.notification : classnames(classes.notification, classes.unSeenNotificationBackground);
     return (
         <TableCell
+            padding="none"
             className={className}>
             <div
                 onClick={(event) => presenter.onMessageClicked(message)}> {message.text}</div>
@@ -232,11 +233,11 @@ class NotificationView extends Component {
                             orderBy={orderBy}
                             onSelectAllClick={this.handleSelectAllClick}
                             onRequestSort={this.handleRequestSort}
-                            rowCount={total}
                             columnData={columnData}
                             baseId={baseId}
                             ids={ids}
-
+                            rowsInPage={data.length}
+                            padding="none"
                         />
                         <TableBody>
                             {data.map(n => {
@@ -249,17 +250,17 @@ class NotificationView extends Component {
                                               selected={isSelected}
                                               hover
                                               key={n.message.id}>
-                                        <TableCell>
+                                        <TableCell padding="none">
                                             <Checkbox checked={isSelected}/>
                                         </TableCell>
-                                        <TableCell>{notificationCategory[n.type.replace(
+                                        <TableCell padding="none">{notificationCategory[n.type.replace(
                                             /\s/g,
                                             "_").toLowerCase()]}</TableCell>
                                         <Message message={n.message}
                                                  seen={n.seen}
                                                  presenter={this.props.presenter}
                                                  classes={classes}/>
-                                        <TableCell>
+                                        <TableCell padding="none">
                                             {formatDate(n.message.timestamp, constants.DATE_FORMAT)}
                                         </TableCell>
                                     </TableRow>
@@ -277,7 +278,7 @@ class NotificationView extends Component {
                     onChangePage={this.handleChangePage}
                     onChangeRowsPerPage={this.handleChangeRowsPerPage}
                     ActionsComponent={TablePaginationActions}
-                    rowsPerPageOptions={[100, 500, 1000]}
+                    rowsPerPageOptions={[5, 100, 500, 1000]}
                 />
             </div>
         )

--- a/react-components/src/util/table/EnhancedTableHead.js
+++ b/react-components/src/util/table/EnhancedTableHead.js
@@ -27,13 +27,14 @@ class EnhancedTableHead extends React.Component {
             order,
             orderBy,
             numSelected,
-            rowCount,
             columnData,
             selectable,
             classes,
             padding,
+            rowInPage
         } = this.props;
 
+        let isInDeterminate = numSelected > 0 && numSelected !== rowInPage;
         return (
             <TableHead>
                 <TableRow>
@@ -41,8 +42,8 @@ class EnhancedTableHead extends React.Component {
                         <TableCell padding={padding ? padding : "default"}
                                    className={classes.checkbox_cell}>
                             <Checkbox
-                                indeterminate={numSelected > 0 && numSelected < rowCount}
-                                checked={numSelected === rowCount}
+                                indeterminate={isInDeterminate}
+                                checked={numSelected === rowInPage}
                                 onChange={onSelectAllClick}
                                 className={classes.column_heading}
                             />

--- a/react-components/src/util/table/EnhancedTableHead.js
+++ b/react-components/src/util/table/EnhancedTableHead.js
@@ -31,10 +31,10 @@ class EnhancedTableHead extends React.Component {
             selectable,
             classes,
             padding,
-            rowInPage
+            rowsInPage
         } = this.props;
 
-        let isInDeterminate = numSelected > 0 && numSelected !== rowInPage;
+        let isInDeterminate = numSelected > 0 && numSelected !== rowsInPage;
         return (
             <TableHead>
                 <TableRow>
@@ -43,7 +43,7 @@ class EnhancedTableHead extends React.Component {
                                    className={classes.checkbox_cell}>
                             <Checkbox
                                 indeterminate={isInDeterminate}
-                                checked={numSelected === rowInPage}
+                                checked={numSelected === rowsInPage}
                                 onChange={onSelectAllClick}
                                 className={classes.column_heading}
                             />
@@ -100,7 +100,7 @@ EnhancedTableHead.propTypes = {
     onSelectAllClick: PropTypes.func,
     order: PropTypes.string,
     orderBy: PropTypes.string,
-    rowCount: PropTypes.number,
+    rowsInPage: PropTypes.number,
     baseId: PropTypes.string.isRequired,
     ids:  PropTypes.object.isRequired,
     columnData: PropTypes.arrayOf(

--- a/react-components/stories/analysis/view/AnalysesView.stories.js
+++ b/react-components/stories/analysis/view/AnalysesView.stories.js
@@ -196,6 +196,7 @@ class AnalysesViewTest extends Component {
                           filter,
                           orderBy,
                           order,
+                          resetSelectedAnalyses,
                           resultCallback,
                           errorCallback) => {
                 resultCallback(analysesList);


### PR DESCRIPTION
I want to hear thoughts on the Kludge i put together to reconfigure analyses window when an analyses notification clicked from desktop. 

Refactoring Analyses window to manage state from the GWT presenter and pass down analyses listing to react (as suggested in slack) is a big effort and will at least take 2 weeks plus testing.

Going forward we need agree upon a set methodology on how we are going to handle global state management in GWT + React.

This PR also includes fixes for the following:
* Pagination / Selection issues
* Double scrollbars in Analyses / Notification windows

