### PR TITLE
CORE-103 Enhance EnhancedTableHead

### DIFF
--- a/react-components/src/analysis/view/AnalysesView.js
+++ b/react-components/src/analysis/view/AnalysesView.js
@@ -122,13 +122,53 @@ function Status(props) {
 }
 
 const columnData = [
-    {name: "Name", numeric: false, enableSorting: true, key: "name"},
-    {name: "Owner", numeric: false, enableSorting: false, key: "owner"},
-    {name: "App", numeric: false, enableSorting: false, key: "app"},
-    {name: "Start Date", numeric: false, enableSorting: true, key: "startdate"},
-    {name: "End Date", numeric: false, enableSorting: true, key: "enddate"},
-    {name: "Status", numeric: false, enableSorting: true, key: "status"},
-    {name: "", numeric: false, enableSorting: false},
+    {
+        id: ids.NAME,
+        name: "Name",
+        numeric: false,
+        enableSorting: true,
+        key: "name",
+    },
+    {
+        id: ids.OWNER,
+        name: "Owner",
+        numeric: false,
+        enableSorting: false,
+        key: "owner",
+    },
+    {
+        id: ids.APP,
+        name: "App",
+        numeric: false,
+        enableSorting: false,
+        key: "app",
+    },
+    {
+        id: ids.START_DATE,
+        name: "Start Date",
+        numeric: false,
+        enableSorting: true,
+        key: "startdate",
+    },
+    {
+        id: ids.END_DATE,
+        name: "End Date",
+        numeric: false,
+        enableSorting: true,
+        key: "enddate",
+    },
+    {
+        id: ids.STATUS,
+        name: "Status",
+        numeric: false,
+        enableSorting: true,
+        key: "status",
+    },
+    {
+        name: "",
+        numeric: false,
+        enableSorting: false,
+    },
 ];
 
 const IPLANT = "iplantcollaborative";
@@ -829,7 +869,6 @@ class AnalysesView extends Component {
                                 rowCount={total}
                                 columnData={columnData}
                                 baseId={baseId}
-                                ids={ids}
                                 padding="none"
                             />
                             <TableBody>

--- a/react-components/src/analysis/view/dialogs/AnalysisInfoDialog.js
+++ b/react-components/src/analysis/view/dialogs/AnalysisInfoDialog.js
@@ -21,8 +21,18 @@ import { withStyles } from "@material-ui/core/styles";
 import { injectIntl } from "react-intl";
 
 const columnData = [
-    {name: "Job Id", numeric: false, enableSorting: false},
-    {name: "Type", numeric: false, enableSorting: false},
+    {
+        id: ids.JOB_ID,
+        name: "Job Id",
+        numeric: false,
+        enableSorting: false,
+    },
+    {
+        id: ids.TYPE,
+        name: "Type",
+        numeric: false,
+        enableSorting: false,
+    },
 ];
 
 class AnalysisInfoDialog extends Component {
@@ -37,7 +47,6 @@ class AnalysisInfoDialog extends Component {
                     <Table>
                         <EnhancedTableHead
                             columnData={columnData}
-                            ids={ids}
                             baseId="analysis"
                         />
                         <TableBody>

--- a/react-components/src/analysis/view/dialogs/AnalysisParametersDialog.js
+++ b/react-components/src/analysis/view/dialogs/AnalysisParametersDialog.js
@@ -61,9 +61,24 @@ function ParameterValue(props) {
 }
 
 const columnData = [
-    {name: "Name", numeric: false, enableSorting: true},
-    {name: "Type", numeric: false, enableSorting: true},
-    {name: "Value", numeric: false, enableSorting: false},
+    {
+        id: ids.NAME,
+        name: "Name",
+        numeric: false,
+        enableSorting: true,
+    },
+    {
+        id: ids.TYPE,
+        name: "Type",
+        numeric: false,
+        enableSorting: true,
+    },
+    {
+        id: ids.VALUE,
+        name: "Value",
+        numeric: false,
+        enableSorting: false,
+    },
 ];
 
 class AnalysisParametersDialog extends Component {
@@ -87,7 +102,6 @@ class AnalysisParametersDialog extends Component {
                     <Table>
                         <EnhancedTableHead
                             columnData={columnData}
-                            ids={ids}
                             baseId="analysis"
                             order={order}
                             orderBy={orderBy}

--- a/react-components/src/notifications/view/NotificationView.js
+++ b/react-components/src/notifications/view/NotificationView.js
@@ -26,9 +26,24 @@ import formatDate from "../../util/DateFormatter";
 import constants from "../../constants";
 
 const columnData = [
-    {name: "Category", numeric: false, enableSorting: false,},
-    {name: "Message", numeric: false, enableSorting: false},
-    {name: "Created Date", numeric: false, enableSorting: true},
+    {
+        id: ids.CATEGORY,
+        name: "Category",
+        numeric: false,
+        enableSorting: false,
+    },
+    {
+        id: ids.MESSAGE,
+        name: "Message",
+        numeric: false,
+        enableSorting: false,
+    },
+    {
+        id: ids.CREATED_DATE,
+        name: "Created Date",
+        numeric: false,
+        enableSorting: true,
+    },
 ];
 
 
@@ -235,8 +250,6 @@ class NotificationView extends Component {
                             rowCount={total}
                             columnData={columnData}
                             baseId={baseId}
-                            ids={ids}
-
                         />
                         <TableBody>
                             {data.map(n => {

--- a/react-components/src/notifications/view/dialogs/RequestHistoryDialog.js
+++ b/react-components/src/notifications/view/dialogs/RequestHistoryDialog.js
@@ -28,9 +28,24 @@ import build from "../../../util/DebugIDUtil";
 import ids from "../../ids";
 
 const columnData = [
-    {name: "Status", numeric: false, enableSorting: false},
-    {name: "Date", numeric: false, enableSorting: true},
-    {name: "Comment", numeric: false, enableSorting: false},
+    {
+        id: ids.STATUS,
+        name: "Status",
+        numeric: false,
+        enableSorting: false,
+    },
+    {
+        id: ids.CREATED_DATE,
+        name: "Date",
+        numeric: false,
+        enableSorting: true,
+    },
+    {
+        id: ids.COMMENT,
+        name: "Comment",
+        numeric: false,
+        enableSorting: false,
+    },
 ];
 
 
@@ -66,7 +81,6 @@ class RequestHistoryDialog extends Component {
                             selectable={false}
                             order={this.state.order}
                             orderBy={this.state.orderBy}
-                            ids={ids}
                             baseId={baseId}
                         />
                         <TableBody>

--- a/react-components/src/util/table/EnhancedTableHead.js
+++ b/react-components/src/util/table/EnhancedTableHead.js
@@ -1,20 +1,21 @@
 /**
- *
- * @author Sriram
- *
- **/
+ * @author Sriram, psarando
+ */
 import React from "react";
+import PropTypes from "prop-types";
+
+import Color from "../CyVersePalette";
+import build from "../DebugIDUtil";
+
+import exStyles from "./style";
+
+import Checkbox from "@material-ui/core/Checkbox";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
-import Checkbox from "@material-ui/core/Checkbox";
 import Tooltip from "@material-ui/core/Tooltip";
-import Color from "../CyVersePalette";
-import PropTypes from "prop-types";
-import build from "../../util/DebugIDUtil";
 import { withStyles } from "@material-ui/core/styles";
-import exStyles from "./style";
 
 class EnhancedTableHead extends React.Component {
     createSortHandler = property => event => {
@@ -50,16 +51,17 @@ class EnhancedTableHead extends React.Component {
                     )
                     }
                     {columnData.map(column => {
+                        const key = column.key || column.name;
+
                         return (
                             <TableCell
-                                key={column.key ? column.key : column.name}
+                                key={key}
+                                id={build(this.props.baseId, column.id)}
                                 variant="head"
                                 numeric={column.numeric}
-                                padding={padding || "default"}
-                                sortDirection={orderBy === column.name ? order : false}
+                                padding={column.padding || padding || "default"}
+                                sortDirection={orderBy === key ? order : false}
                                 className={classes.column_heading}
-                                id={build(this.props.baseId,
-                                    this.props.ids[column.name.replace(/\s/g, "_").toUpperCase()])}
                             >
                                 {column.enableSorting ? (
                                         <Tooltip
@@ -68,13 +70,9 @@ class EnhancedTableHead extends React.Component {
                                             enterDelay={300}
                                         >
                                             <TableSortLabel
-                                                active={column.key ?
-                                                    orderBy === column.key :
-                                                    orderBy === column.name}
+                                                active={orderBy === key}
                                                 direction={order.toLowerCase()}
-                                                onClick={this.createSortHandler(column.key ?
-                                                    column.key :
-                                                    column.name)}
+                                                onClick={this.props.onRequestSort && this.createSortHandler(key)}
                                                 style={{color: Color.white}}
                                             >
                                                 {column.name}
@@ -101,10 +99,11 @@ EnhancedTableHead.propTypes = {
     orderBy: PropTypes.string,
     rowCount: PropTypes.number,
     baseId: PropTypes.string.isRequired,
-    ids:  PropTypes.object.isRequired,
     columnData: PropTypes.arrayOf(
         PropTypes.shape({
+            id: PropTypes.string,
             name: PropTypes.string,
+            padding: PropTypes.string,
             numeric: PropTypes.bool,
             enableSorting: PropTypes.bool,
             key: PropTypes.string
@@ -115,4 +114,5 @@ EnhancedTableHead.propTypes = {
 EnhancedTableHead.defaultProps = {
     selectable: false,
 };
+
 export default withStyles(exStyles)(EnhancedTableHead);


### PR DESCRIPTION
This PR will enhance `EnhancedTableHead` with changes that will be used for CORE-7743, plus some minor refactoring for code readability: 

* Added `id` field to `columnData` props, instead of auto generating based on name/key and the `ids` prop, which also fixed a bug in `RequestHistoryDialog`.
* Added an optional `padding` field to `columnData` props, which can override the overall `padding` prop.
* Check `onRequestSort` prop before setting a column sort handler (fixes NPE in `analysis` stories).
