### PR TITLE
CORE-120 Fix EnhancedTableHead rendering with FAB and Checkboxes.

### DIFF
--- a/react-components/src/analysis/view/AnalysesView.js
+++ b/react-components/src/analysis/view/AnalysesView.js
@@ -889,18 +889,6 @@ class AnalysesView extends Component {
                     />
                     <div className={classes.table}>
                         <Table>
-                            <EnhancedTableHead
-                                selectable={true}
-                                numSelected={selected.length}
-                                order={order}
-                                orderBy={orderBy}
-                                onSelectAllClick={this.handleSelectAllClick}
-                                onRequestSort={this.handleRequestSort}
-                                columnData={columnData}
-                                baseId={baseId}
-                                padding="none"
-                                rowsInPage={data.length}
-                            />
                             <TableBody>
                                 {data.map(analysis => {
                                     const id = analysis.id;
@@ -997,6 +985,17 @@ class AnalysesView extends Component {
 
                                 }
                             </TableBody>
+                            <EnhancedTableHead selectable={true}
+                                               numSelected={selected.length}
+                                               order={order}
+                                               orderBy={orderBy}
+                                               onSelectAllClick={this.handleSelectAllClick}
+                                               onRequestSort={this.handleRequestSort}
+                                               columnData={columnData}
+                                               baseId={baseId}
+                                               padding="none"
+                                               rowsInPage={data.length}
+                            />
                         </Table>
                         {
                             !hasData &&

--- a/react-components/src/analysis/view/dialogs/AnalysisInfoDialog.js
+++ b/react-components/src/analysis/view/dialogs/AnalysisInfoDialog.js
@@ -45,10 +45,6 @@ class AnalysisInfoDialog extends Component {
                     onClose={onInfoDialogClose}/>
                 <DialogContent>
                     <Table>
-                        <EnhancedTableHead
-                            columnData={columnData}
-                            baseId="analysis"
-                        />
                         <TableBody>
                             {info.steps.map(n => {
                                 return (
@@ -59,6 +55,9 @@ class AnalysisInfoDialog extends Component {
                                 );
                             })}
                         </TableBody>
+                        <EnhancedTableHead columnData={columnData}
+                                           baseId="analysis"
+                        />
                     </Table>
                 </DialogContent>
                 <DialogActions>

--- a/react-components/src/analysis/view/dialogs/AnalysisParametersDialog.js
+++ b/react-components/src/analysis/view/dialogs/AnalysisParametersDialog.js
@@ -100,12 +100,6 @@ class AnalysisParametersDialog extends Component {
                     onClose={onViewParamDialogClose}/>
                 <DialogContent>
                     <Table>
-                        <EnhancedTableHead
-                            columnData={columnData}
-                            baseId="analysis"
-                            order={order}
-                            orderBy={orderBy}
-                        />
                         <TableBody>
                             {parameters.map(n => {
                                 return (
@@ -123,6 +117,11 @@ class AnalysisParametersDialog extends Component {
                                 );
                             })}
                         </TableBody>
+                        <EnhancedTableHead columnData={columnData}
+                                           baseId="analysis"
+                                           order={order}
+                                           orderBy={orderBy}
+                        />
                     </Table>
                 </DialogContent>
                 <DialogActions>

--- a/react-components/src/apps/listing/AppGridListing.js
+++ b/react-components/src/apps/listing/AppGridListing.js
@@ -102,17 +102,6 @@ class AppGridListing extends Component {
 
         return (
             <Table>
-                <EnhancedTableHead selectable={selectable}
-                                   numSelected={selected.length}
-                                   rowCount={data ? data.length : 0}
-                                   order={order}
-                                   orderBy={orderBy}
-                                   baseId={parentId}
-                                   ids={ids.TABLE_HEADER}
-                                   columnData={columnData}
-                                   onRequestSort={this.onRequestSort}
-                                   onSelectAllClick={this.handleSelectAllClick}
-                />
                 <TableBody>
                     {(!data || data.length === 0) && <EmptyTable message={getMessage("noApps")} numColumns={columnData.length}/>}
                     {data && data.length > 0 && stableSort(data, getSorting(order, orderBy)).map(app => {
@@ -151,6 +140,17 @@ class AppGridListing extends Component {
                         )
                     })}
                 </TableBody>
+                <EnhancedTableHead selectable={selectable}
+                                   numSelected={selected.length}
+                                   rowCount={data ? data.length : 0}
+                                   order={order}
+                                   orderBy={orderBy}
+                                   baseId={parentId}
+                                   ids={ids.TABLE_HEADER}
+                                   columnData={columnData}
+                                   onRequestSort={this.onRequestSort}
+                                   onSelectAllClick={this.handleSelectAllClick}
+                />
             </Table>
         )
     }

--- a/react-components/src/collaborators/CollaboratorListing.js
+++ b/react-components/src/collaborators/CollaboratorListing.js
@@ -3,7 +3,7 @@ import EnhancedTableHead from "../util/table/EnhancedTableHead";
 import { getSorting, stableSort } from "../util/table/TableSort";
 import ids from "./ids";
 import messages from "./messages";
-import withI18N, { getMessage } from "../util/I18NWrapper";
+import withI18N from "../util/I18NWrapper";
 
 import PropTypes from "prop-types";
 import Checkbox from "@material-ui/core/Checkbox";
@@ -104,17 +104,6 @@ class CollaboratorListing extends Component {
 
         return (
             <Table>
-                <EnhancedTableHead selectable={selectable}
-                                   numSelected={selected.length}
-                                   rowCount={data ? data.length : 0}
-                                   order={order}
-                                   orderBy={orderBy}
-                                   baseId={parentId}
-                                   ids={ids.TABLE_HEADER}
-                                   columnData={columnData}
-                                   onRequestSort={this.onRequestSort}
-                                   onSelectAllClick={this.handleSelectAllClick}
-                />
                 <TableBody>
                     {(!data || data.length === 0) && <EmptyTable message={emptyTableMsg} numColumns={columnData.length}/>}
                     {data && data.length > 0 && stableSort(data, getSorting(order, orderBy)).map(subject => {
@@ -148,6 +137,17 @@ class CollaboratorListing extends Component {
                         )
                     })}
                 </TableBody>
+                <EnhancedTableHead selectable={selectable}
+                                   numSelected={selected.length}
+                                   rowCount={data ? data.length : 0}
+                                   order={order}
+                                   orderBy={orderBy}
+                                   baseId={parentId}
+                                   ids={ids.TABLE_HEADER}
+                                   columnData={columnData}
+                                   onRequestSort={this.onRequestSort}
+                                   onSelectAllClick={this.handleSelectAllClick}
+                />
             </Table>
         )
     }

--- a/react-components/src/communities/view/CommunityListing.js
+++ b/react-components/src/communities/view/CommunityListing.js
@@ -66,15 +66,6 @@ class CommunityListing extends Component {
                 }
                 <div className={classes.table}>
                     <Table>
-                        <EnhancedTableHead selectable={false}
-                                           rowCount={data ? data.length : 0}
-                                           order={order}
-                                           orderBy={orderBy}
-                                           baseId={parentId}
-                                           ids={ids.TABLE_HEADER}
-                                           columnData={tableColumns}
-                                           onRequestSort={this.onRequestSort}
-                        />
                         <TableBody>
                             {(!data || data.length === 0) &&
                             <EmptyTable message={getMessage("noCommunities")}
@@ -95,6 +86,15 @@ class CommunityListing extends Component {
                                 )
                             })}
                         </TableBody>
+                        <EnhancedTableHead selectable={false}
+                                           rowCount={data ? data.length : 0}
+                                           order={order}
+                                           orderBy={orderBy}
+                                           baseId={parentId}
+                                           ids={ids.TABLE_HEADER}
+                                           columnData={tableColumns}
+                                           onRequestSort={this.onRequestSort}
+                        />
                     </Table>
                 </div>
             </Fragment>

--- a/react-components/src/notifications/view/NotificationView.js
+++ b/react-components/src/notifications/view/NotificationView.js
@@ -241,17 +241,6 @@ class NotificationView extends Component {
                                      onDeleteClicked={this.handleDeleteClick}/>
                 <div className={classes.table}>
                     <Table>
-                        <EnhancedTableHead
-                            selectable={true}
-                            numSelected={selected.length}
-                            order={order}
-                            orderBy={orderBy}
-                            onSelectAllClick={this.handleSelectAllClick}
-                            onRequestSort={this.handleRequestSort}
-                            columnData={columnData}
-                            baseId={baseId}
-                            rowsInPage={data.length}
-                        />
                         <TableBody>
                             {data.map(n => {
                                 const isSelected = this.isSelected(n.message.id);
@@ -263,7 +252,7 @@ class NotificationView extends Component {
                                               selected={isSelected}
                                               hover
                                               key={n.message.id}>
-                                        <TableCell>
+                                        <TableCell padding="checkbox">
                                             <Checkbox checked={isSelected}/>
                                         </TableCell>
                                         <TableCell>{notificationCategory[n.type.replace(
@@ -280,6 +269,16 @@ class NotificationView extends Component {
                                 );
                             })}
                         </TableBody>
+                        <EnhancedTableHead selectable={true}
+                                           numSelected={selected.length}
+                                           order={order}
+                                           orderBy={orderBy}
+                                           onSelectAllClick={this.handleSelectAllClick}
+                                           onRequestSort={this.handleRequestSort}
+                                           columnData={columnData}
+                                           baseId={baseId}
+                                           rowsInPage={data.length}
+                        />
                     </Table>
                 </div>
                 <TablePagination

--- a/react-components/src/notifications/view/dialogs/RequestHistoryDialog.js
+++ b/react-components/src/notifications/view/dialogs/RequestHistoryDialog.js
@@ -76,13 +76,6 @@ class RequestHistoryDialog extends Component {
                 </DialogTitle>
                 <DialogContent>
                     <Table>
-                        <EnhancedTableHead
-                            columnData={columnData}
-                            selectable={false}
-                            order={this.state.order}
-                            orderBy={this.state.orderBy}
-                            baseId={baseId}
-                        />
                         <TableBody>
                             {history.map(n => {
                                 return (
@@ -97,6 +90,12 @@ class RequestHistoryDialog extends Component {
                                 );
                             })}
                         </TableBody>
+                        <EnhancedTableHead columnData={columnData}
+                                           selectable={false}
+                                           order={this.state.order}
+                                           orderBy={this.state.orderBy}
+                                           baseId={baseId}
+                        />
                     </Table>
                 </DialogContent>
                 <DialogActions>

--- a/react-components/src/util/table/EnhancedTableHead.js
+++ b/react-components/src/util/table/EnhancedTableHead.js
@@ -40,7 +40,7 @@ class EnhancedTableHead extends React.Component {
             <TableHead>
                 <TableRow>
                     {selectable && (
-                        <TableCell padding={padding ? padding : "default"}
+                        <TableCell padding={padding ? padding : "checkbox"}
                                    className={classes.checkbox_cell}>
                             <Checkbox
                                 indeterminate={isInDeterminate}


### PR DESCRIPTION
Something about MUI's CSS for `Fab` and `Checkbox` components make them float over our stickied `EnhancedTableHead` when scrolling through tables. Adding the `EnhancedTableHead` to a `Table` after a `TableBody` prevents this odd behavior.

Also updated `EnhancedTableHead` and `NotificationView` checkbox column padding.