### PR TITLE
Make sure query parameter windows are on top

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/RuntimeCallbacks.java
@@ -47,6 +47,7 @@ class RuntimeCallbacks {
             final SafeHtml message = SafeHtmlUtils.fromTrustedString(appearance.loadSessionFailed());
             announcer.schedule(new ErrorAnnouncementConfig(message, true, 5000));
             presenter.setUserSessionConnection(false);
+            presenter.checkRemainingQueryStrings();
             progressMessageBox.hide();
         }
 
@@ -55,6 +56,7 @@ class RuntimeCallbacks {
             presenter.setUserSessionConnection(true);
             presenter.restoreWindows(result.getWindowConfigs());
             presenter.doPeriodicSessionSave();
+            presenter.checkRemainingQueryStrings();
             progressMessageBox.hide();
         }
     }


### PR DESCRIPTION
Basically:
1. If there's a DATA parameter, only the Data window will open regardless of saved session (this is the original functionality for "data only" viewer that I'm maintaining)
1. The user's session is fetched
1. Any other parameters are then parsed (apps, error, state)