### PR TITLE
Disable adding agave apps to communities

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
@@ -1,5 +1,6 @@
 package org.iplantc.de.apps.client;
 
+import org.iplantc.de.apps.client.events.selection.AppSelectionChangedEvent;
 import org.iplantc.de.client.models.HasId;
 import org.iplantc.de.client.models.IsMaskable;
 import org.iplantc.de.client.models.apps.App;
@@ -81,7 +82,9 @@ public interface AppsView extends IsWidget,
 
         void setWestPanelWidth(String width);
 
-        public boolean isDetailsCollapsed();
+        boolean isDetailsCollapsed();
+
+        void addAppSelectionChangedHandler(AppSelectionChangedEvent.AppSelectionChangedEventHandler handler);
     }
 
     DETabPanel getCategoryTabPanel();

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
@@ -7,6 +7,8 @@ import org.iplantc.de.apps.client.AppsView;
 import org.iplantc.de.apps.client.CommunitiesView;
 import org.iplantc.de.apps.client.OntologyHierarchiesView;
 import org.iplantc.de.apps.client.WorkspaceView;
+import org.iplantc.de.apps.client.events.selection.AppCategorySelectionChangedEvent;
+import org.iplantc.de.apps.client.events.selection.AppSelectionChangedEvent;
 import org.iplantc.de.apps.client.events.selection.RefreshAppsSelectedEvent;
 import org.iplantc.de.apps.client.gin.factory.AppsViewFactory;
 import org.iplantc.de.client.models.HasId;
@@ -205,4 +207,8 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
         return view.isNavPanelCollapsed();
     }
 
+    @Override
+    public void addAppSelectionChangedHandler(AppSelectionChangedEvent.AppSelectionChangedEventHandler handler) {
+        appsListPresenter.addAppSelectionChangedEventHandler(handler);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/communities/client/ManageCommunitiesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/communities/client/ManageCommunitiesView.java
@@ -32,6 +32,8 @@ public interface ManageCommunitiesView extends IsWidget {
         String windowBackground();
 
         String appSelectionHeader();
+
+        String agaveAppsNotSupportedToolTip();
     }
 
     @JsType

--- a/de-lib/src/main/java/org/iplantc/de/communities/client/presenter/ManageCommunitiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/communities/client/presenter/ManageCommunitiesPresenterImpl.java
@@ -2,6 +2,7 @@ package org.iplantc.de.communities.client.presenter;
 
 import org.iplantc.de.admin.desktop.client.communities.views.dialogs.RetagAppsConfirmationDialog;
 import org.iplantc.de.apps.client.AppsView;
+import org.iplantc.de.client.models.AppTypeFilter;
 import org.iplantc.de.client.models.HasStringList;
 import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.apps.App;
@@ -27,6 +28,7 @@ import org.iplantc.de.shared.AppsCallback;
 import org.iplantc.de.shared.AsyncProviderWrapper;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasOneWidget;
@@ -320,6 +322,14 @@ public class ManageCommunitiesPresenterImpl implements ManageCommunitiesView.Pre
         appSelectView.addDialogHideHandler(event -> selectAppsCallback.onSuccess(null));
         appSelectView.setPresenter(this);
         appsPresenter.hideAppMenu().hideWorkflowMenu().go(appSelectView, null, null, null, false);
+        appsPresenter.addAppSelectionChangedHandler(event -> {
+            App selectedApp = appsPresenter.getSelectedApp();
+            if (selectedApp != null && App.EXTERNAL_APP.equalsIgnoreCase(selectedApp.getAppType())) {
+                appSelectView.disableAddAppBtn(appearance.agaveAppsNotSupportedToolTip());
+            } else {
+                appSelectView.enableAddAppBtn();
+            }
+        });
         appSelectView.show();
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/pipelines/client/views/AppSelectionDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/pipelines/client/views/AppSelectionDialog.java
@@ -16,6 +16,7 @@ import com.sencha.gxt.widget.core.client.button.TextButton;
 import com.sencha.gxt.widget.core.client.container.BoxLayoutContainer;
 import com.sencha.gxt.widget.core.client.event.SelectEvent;
 import com.sencha.gxt.widget.core.client.event.SelectEvent.SelectHandler;
+import com.sencha.gxt.widget.core.client.tips.ToolTipConfig;
 import com.sencha.gxt.widget.core.client.toolbar.FillToolItem;
 
 /**
@@ -34,6 +35,7 @@ public class AppSelectionDialog extends Dialog {
 
     private Status appCountStatus;
     private Status lastAppStatus;
+    TextButton okBtn;
 
     public AppSelectionDialog() {
         this(true);
@@ -49,7 +51,7 @@ public class AppSelectionDialog extends Dialog {
         setHideOnButtonClick(false);
         ButtonBar btnBar = getButtonBar();
 
-        TextButton okBtn = (TextButton)btnBar.getItemByItemId(PredefinedButton.OK.name());
+        okBtn = (TextButton)btnBar.getItemByItemId(PredefinedButton.OK.name());
         okBtn.setText(I18N.DISPLAY.add());
         okBtn.addSelectHandler(new SelectHandler() {
 
@@ -94,5 +96,18 @@ public class AppSelectionDialog extends Dialog {
             SuccessAnnouncementConfig config = new SuccessAnnouncementConfig(builder.toSafeHtml(), true);
             IplantAnnouncer.getInstance().schedule(config);
         }
+    }
+
+    public void disableAddAppBtn(String tooltip) {
+        okBtn.disable();
+        ToolTipConfig config = new ToolTipConfig();
+        config.setShowDelay(0);
+        config.setBody(tooltip);
+        okBtn.setToolTipConfig(config);
+    }
+
+    public void enableAddAppBtn() {
+        okBtn.enable();
+        okBtn.removeToolTip();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/communities/CommunitiesDisplayStrings.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/communities/CommunitiesDisplayStrings.java
@@ -8,4 +8,6 @@ public interface CommunitiesDisplayStrings extends Messages {
     String communitiesHelp();
 
     String appSelectionHeader();
+
+    String agaveAppsNotSupportedToolTip();
 }

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/communities/CommunitiesDisplayStrings.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/communities/CommunitiesDisplayStrings.properties
@@ -1,3 +1,4 @@
+agaveAppsNotSupportedToolTip=Adding Agave apps to a community is not currently supported
 appSelectionHeader=Add apps to your community
 communitiesHelp=Communities are public groups of apps. Creating a community allows you to create a custom collection of apps, and other CyVerse members can join that community. When joining a community, that community''s app listing becomes available via the Apps window.
 windowHeading=Communities

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/communities/ManageCommunitiesViewDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/communities/ManageCommunitiesViewDefaultAppearance.java
@@ -72,4 +72,9 @@ public class ManageCommunitiesViewDefaultAppearance implements ManageCommunities
     public String appSelectionHeader() {
         return displayStrings.appSelectionHeader();
     }
+
+    @Override
+    public String agaveAppsNotSupportedToolTip() {
+        return displayStrings.agaveAppsNotSupportedToolTip();
+    }
 }

--- a/react-components/src/communities/messages.js
+++ b/react-components/src/communities/messages.js
@@ -19,6 +19,7 @@ export default {
         editCommunityTitle: "Edit {name}",
         emptyField: "This field is required",
         explainCommunityAdmin: "A community admin has the ability to help manage the community. Admins can add or remove other community admins and add or remove apps to the community.",
+        explainCommunityApps: "NOTE: Adding Agave/HPC apps is not currently supported.",
         invalidColonChar: "Invalid character: ':'",
         joinCommunity: "Join",
         leaveCommunity: "Leave",

--- a/react-components/src/communities/view/EditCommunity.js
+++ b/react-components/src/communities/view/EditCommunity.js
@@ -501,6 +501,9 @@ class EditCommunity extends Component {
                                 <AddIcon/>
                                 {getMessage('apps')}
                             </Fab>
+                            <Typography variant='caption' className={classes.textBlurb}>
+                                {getMessage('explainCommunityApps')}
+                            </Typography>
                         </Toolbar>
                         }
                         <AppGridListing parentId={parentId}


### PR DESCRIPTION
The `Add` button becomes disabled and there's a tooltip indicating that Agave apps cannot be added to communities at this time. 

![image](https://user-images.githubusercontent.com/8909156/54394353-d9bc0880-4669-11e9-955a-1656e25fd929.png)

![image](https://user-images.githubusercontent.com/8909156/54395218-7089c480-466c-11e9-8b85-337feed35bd7.png)
