### PR TITLE
CORE-234 Fixes for Metadata Template checkboxes

### DIFF
--- a/react-components/src/metadata/MetadataTemplateView.js
+++ b/react-components/src/metadata/MetadataTemplateView.js
@@ -167,6 +167,10 @@ class MetadataTemplateAttributeView extends Component {
                         switch (attribute.type) {
                             case "Boolean":
                                 FieldComponent = FormCheckboxStringValue;
+                                fieldProps = {
+                                    ...fieldProps,
+                                    disabled: !writable,
+                                };
                                 break;
                             case "Number":
                                 FieldComponent = FormNumberField;

--- a/react-components/src/metadata/MetadataTemplateView.js
+++ b/react-components/src/metadata/MetadataTemplateView.js
@@ -16,7 +16,7 @@ import intlData from "./messages";
 import styles from "./style";
 
 import {
-    FormCheckbox,
+    FormCheckboxStringValue,
     FormIntegerField,
     FormMultilineTextField,
     FormNumberField,
@@ -166,7 +166,7 @@ class MetadataTemplateAttributeView extends Component {
 
                         switch (attribute.type) {
                             case "Boolean":
-                                FieldComponent = FormCheckbox;
+                                FieldComponent = FormCheckboxStringValue;
                                 break;
                             case "Number":
                                 FieldComponent = FormNumberField;

--- a/react-components/src/util/FormField.js
+++ b/react-components/src/util/FormField.js
@@ -121,6 +121,22 @@ const FormCheckboxTableCell = ({
     </TableCell>
 );
 
+const FormCheckboxStringValue = ({
+    field: { value, onChange, ...field },
+    form: { setFieldValue, ...form },
+    ...custom
+}) => (
+    <FormCheckbox
+        checked={value && value !== "false"}
+        onChange={(event, checked) => {
+            setFieldValue(field.name, checked ? "true" : "false");
+        }}
+        field={field}
+        form={form}
+        {...custom}
+    />
+);
+
 const onNumberChange = (onChange) => (event) => {
     const newValue = event.target.value;
     let intVal = Number(newValue);
@@ -243,6 +259,7 @@ const FormSelectField = ({
 
 export {
     FormCheckbox,
+    FormCheckboxStringValue,
     FormCheckboxTableCell,
     FormIntegerField,
     FormMultilineTextField,

--- a/react-components/stories/metadata/MetadataTemplate.stories.js
+++ b/react-components/stories/metadata/MetadataTemplate.stories.js
@@ -1417,6 +1417,12 @@ class MetadataTemplateReadOnlyViewTest extends Component {
                 value: "choice 3",
                 unit: "",
             },
+            {
+                id: "12",
+                attr: "Boolean Attr",
+                value: "true",
+                unit: "",
+            },
         ];
 
         return (

--- a/react-components/stories/metadata/MetadataTemplate.stories.js
+++ b/react-components/stories/metadata/MetadataTemplate.stories.js
@@ -1686,6 +1686,11 @@ const dataciteMetadata = {
                 },
             ],
         },
+        {
+            attr: "is_deprecated",
+            value: "true",
+            unit: "",
+        },
     ],
 };
 


### PR DESCRIPTION
This PR will add a `FormCheckboxStringValue` component that saves and parses existing metadata
values as a "true" or "false" string, since metadata AVU values must be strings, and the service will throw the validation error `ERR_ILLEGAL_ARGUMENT` for non-string values set in the AVU's `value` field.

We have existing metadata AVUs with "true" or "false" values for some template attributes with `Boolean` types, since the previous GXT component saved these attribute values as "true" or "false".

Also included a fix for read-only checkboxes in templates.