### PR TITLE
CORE-244 Update Grouping attributes in MetadataTemplateView.

### DIFF
--- a/react-components/src/metadata/admin/EditAttributeFormList.js
+++ b/react-components/src/metadata/admin/EditAttributeFormList.js
@@ -9,6 +9,7 @@ import { injectIntl } from "react-intl";
 
 import build from "../../util/DebugIDUtil";
 import withI18N, { formatMessage, getMessage } from "../../util/I18NWrapper";
+import constants from "../constants";
 import intlData from "../messages";
 import styles from "../style";
 import ids from "./ids";
@@ -39,21 +40,19 @@ import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import KeyboardArrowDown from "@material-ui/icons/KeyboardArrowDown";
 import KeyboardArrowUp from "@material-ui/icons/KeyboardArrowUp";
 
-const AttributeTypes = [
-    "String",
-    "Timestamp",
-    "Boolean",
-    "Number",
-    "Integer",
-    "Multiline Text",
-    "URL/URI",
-    "Enum",
-    "OLS Ontology Term",
-    "UAT Ontology Term",
-    "Grouping",
-];
-
-const AttributeTypeMenuItems = AttributeTypes.map((type, index) => (
+const AttributeTypeMenuItems = [
+    constants.ATTRIBUTE_TYPE.STRING,
+    constants.ATTRIBUTE_TYPE.TIMESTAMP,
+    constants.ATTRIBUTE_TYPE.BOOLEAN,
+    constants.ATTRIBUTE_TYPE.NUMBER,
+    constants.ATTRIBUTE_TYPE.INTEGER,
+    constants.ATTRIBUTE_TYPE.MULTILINE_TEXT,
+    constants.ATTRIBUTE_TYPE.URL,
+    constants.ATTRIBUTE_TYPE.ENUM,
+    constants.ATTRIBUTE_TYPE.ONTOLOGY_TERM_OLS,
+    constants.ATTRIBUTE_TYPE.ONTOLOGY_TERM_UAT,
+    constants.ATTRIBUTE_TYPE.GROUPING,
+].map((type, index) => (
     <MenuItem key={index} value={type}>
         {type}
     </MenuItem>
@@ -96,7 +95,9 @@ class EditAttribute extends Component {
             attribute: { settings },
         } = this.props;
 
-        if (type === "OLS Ontology Term" && (!settings || !settings.type)) {
+        const isOLSType = type === constants.ATTRIBUTE_TYPE.ONTOLOGY_TERM_OLS;
+
+        if (isOLSType && (!settings || !settings.type)) {
             setFieldValue(`${field}.settings`, { ...settings, type: "CLASS" });
         }
 
@@ -259,7 +260,7 @@ class EditAttribute extends Component {
                             <Divider />
                         </Grid>
 
-                        {type === "Enum" && (
+                        {type === constants.ATTRIBUTE_TYPE.ENUM && (
                             <Grid item>
                                 <ExpansionPanel defaultExpanded>
                                     <ExpansionPanelSummary
@@ -292,7 +293,8 @@ class EditAttribute extends Component {
                             </Grid>
                         )}
 
-                        {type === "OLS Ontology Term" && (
+                        {type ===
+                            constants.ATTRIBUTE_TYPE.ONTOLOGY_TERM_OLS && (
                             <Grid item>
                                 <ExpansionPanel defaultExpanded>
                                     <ExpansionPanelSummary
@@ -368,7 +370,7 @@ class EditAttributeFormList extends Component {
         unshift({
             name: newName,
             description: "",
-            type: "String",
+            type: constants.ATTRIBUTE_TYPE.STRING,
             required: false,
         });
     }

--- a/react-components/src/metadata/admin/EditMetadataTemplate.js
+++ b/react-components/src/metadata/admin/EditMetadataTemplate.js
@@ -9,6 +9,7 @@ import { injectIntl } from "react-intl";
 
 import build from "../../util/DebugIDUtil";
 import withI18N, { formatMessage, getMessage } from "../../util/I18NWrapper";
+import constants from "../constants";
 import intlData from "../messages";
 import styles from "../style";
 import ids from "./ids";
@@ -224,7 +225,7 @@ const validateAttributes = (attributes) => {
         }
 
         // Validate Enum values
-        if (attr.type === "Enum") {
+        if (attr.type === constants.ATTRIBUTE_TYPE.ENUM) {
             if (!attr.values || attr.values.length < 1) {
                 // Setting an attrErrors.values message allows the error to be displayed in the table header,
                 // but that component will have to check first if attrErrors.values is an array or not.

--- a/react-components/src/metadata/constants.js
+++ b/react-components/src/metadata/constants.js
@@ -1,4 +1,18 @@
 export default {
+    // Supported Metadata Template Attribute types
+    ATTRIBUTE_TYPE: {
+        BOOLEAN: "Boolean",
+        ENUM: "Enum",
+        GROUPING: "Grouping",
+        INTEGER: "Integer",
+        MULTILINE_TEXT: "Multiline Text",
+        NUMBER: "Number",
+        ONTOLOGY_TERM_OLS: "OLS Ontology Term",
+        ONTOLOGY_TERM_UAT: "UAT Ontology Term",
+        STRING: "String",
+        TIMESTAMP: "Timestamp",
+        URL: "URL/URI",
+    },
     IMPORT_IRODS_METADATA_LINK:
         "https://wiki.cyverse.org/wiki/x/pRS#UsingMetadataintheDE-irodsMetadataImport",
 };


### PR DESCRIPTION
This PR will update the `MetadataTemplateView` form with a `postProcessAVUs` function added to the `handleSubmit` action, which will update `Grouping` type AVUs by setting their values to a comma-separated list of their child AVUs' values.

This is required since users do not fill in values of `Grouping` attributes (they are mainly used to help convert AVUs into DataCite XML elements), but duplicated attributes need unique values in order for the service to save them as separate AVUs.

For example, the DataCite metadata template has a `geoLocation` attribute that is a `Grouping` type with child attributes for `geoLocationPlace`, `geoLocationPoint`, and `geoLocationBox` (and the point and box are also `Grouping` types with their own child attributes). The DataCite metadata allows multiple `geoLocation` groups, so the template needs to give each one a distinct value.

This PR also nests child AVUs of `Grouping` types into a `fieldset` in the Metadata Template View form:

![Grouping-Attr-template-updates-1-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777803-3130b680-6788-11e9-963e-d5646aeab5a2.png)
![Grouping-Attr-template-updates-2-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777806-34c43d80-6788-11e9-9ec0-004f61c372cb.png)
![Grouping-Attr-template-updates-3-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777816-3f7ed280-6788-11e9-9e49-f89f76b705b9.png)
![Grouping-Attr-template-updates-4-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777822-43aaf000-6788-11e9-8e1b-c16cbe6d0103.png)
![Grouping-Attr-template-updates-5-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777831-473e7700-6788-11e9-8cde-d608bc1af3cb.png)
![Grouping-Attr-template-updates-6-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777833-4ad1fe00-6788-11e9-8926-65d9c72c43dd.png)
![Grouping-Attr-template-updates-7-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777834-4dccee80-6788-11e9-9962-3f64c02abd73.png)
![Grouping-Attr-template-updates-8-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777838-51f90c00-6788-11e9-94f4-bf545f3edf8a.png)
![Grouping-Attr-template-updates-9-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777846-56252980-6788-11e9-8d57-a73d5b1e346a.png)
![Grouping-Attr-template-updates-10-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777851-59b8b080-6788-11e9-9906-0a00f23a03aa.png)

---


When grouping attributes are saved, their values will populate like this:

![Grouping-Attr-AVU-updates-1-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777868-7228cb00-6788-11e9-846b-427e02ca9695.png)
![Grouping-Attr-AVU-updates-2-Screenshot_2019-04-25 Discovery Environment](https://user-images.githubusercontent.com/996408/56777872-77861580-6788-11e9-9c02-111f19cac8eb.png)
