### PR TITLE
Edit comments dialog

### DIFF
--- a/react-components/src/data/edit/Comment.js
+++ b/react-components/src/data/edit/Comment.js
@@ -1,0 +1,43 @@
+import React, {Component} from "react";
+import Typography from '@material-ui/core/Typography';
+import ListItem from '@material-ui/core/ListItem';
+
+
+class Comment extends Component{
+    state = {
+        anchorEl: null
+    };
+    constructor(props){
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+
+    }
+
+    handleClick = name => event => {
+        this.setState({
+            [name]: event.target.value,
+        });
+    };
+
+    render(){
+        const {date, owner, message, id, retracted} = this.props;
+
+        return (
+            <div id={id}>
+                <ListItem button onClick={this.handleClick}>
+                    <Typography>
+                        On <b>{date}</b> {owner} wrote:
+                        <br />
+                        {retracted ? <Typography color="error">Retracted</Typography> :
+                            <Typography>{message}</Typography>}
+
+                    </Typography>
+                </ListItem>
+                <hr />
+            </div>
+        )
+    }
+
+}
+
+export default Comment

--- a/react-components/src/data/edit/DotMenu.js
+++ b/react-components/src/data/edit/DotMenu.js
@@ -1,0 +1,65 @@
+import React, {Component} from 'react';
+
+import Menu from "@material-ui/core/Menu";
+
+import IconButton from "@material-ui/core/IconButton";
+import MoreVertIcon from "@material-ui/icons/MoreVert";
+import EditCommentsMenuItems from "./EditCommentsMenuItems.js";
+
+const ITEM_HEIGHT = 48;
+
+class DotMenu extends Component {
+
+    constructor(props){
+        super(props);
+        this.state = {
+            anchorEl : null,
+        };
+    }
+
+    handleDotMenuClick = event => {
+        this.setState({anchorEl : event.currentTarget});
+    };
+
+    handleDotMenuClose = () => {
+        this.setState({anchorEl: null});
+    };
+
+    render(){
+        const {anchorEl} = this.state;
+        const open = Boolean(anchorEl);
+
+        return (
+            <div >
+                <IconButton
+                    aria-Label="More"
+                    aria-owns={open ? 'long-menu' : null}
+                    aria-haspopup="true"
+                    onClick={this.handleDotMenuClick}
+                    classes = {{root : this.props.className}}
+                >
+                    <MoreVertIcon/>
+                </IconButton>
+                <Menu
+                    anchorEl={anchorEl}
+                    open={open}
+                    onClose={this.handleDotMenuClose}
+                    PaperProps={{
+                        style: {
+                            maxHeight: ITEM_HEIGHT * 4.5,
+                            width: 200,
+                        },
+                    }}
+                >
+                    <EditCommentsMenuItems handleClose={this.handleDotMenuClose}
+                                           {...this.props}
+                    />
+
+                </Menu>
+
+            </div>
+        );
+    }
+}
+
+export default DotMenu;

--- a/react-components/src/data/edit/EditComments.js
+++ b/react-components/src/data/edit/EditComments.js
@@ -1,0 +1,207 @@
+import React, {Component} from "react";
+import Dialog from '@material-ui/core/Dialog';
+import Button from '@material-ui/core/Button';
+import DeleteIcon from '@material-ui/icons/Delete';
+import { withStyles } from '@material-ui/core/styles';
+import DEDialogHeader from  "./../../util/dialog/DEDialogHeader.js"
+import DialogContent from '@material-ui/core/DialogContent';
+import exStyles from "./style.js"
+import DotMenu from "./DotMenu.js"
+import Comment from "./Comment.js"
+import TextField from '@material-ui/core/TextField'
+import Fab from '@material-ui/core/Fab'
+import AddIcon from '@material-ui/icons/Add'
+import CyVersePalette from "../../util/CyVersePalette";
+import List from '@material-ui/core/List';
+
+
+class EditComments extends Component{
+    state = {
+        anchorEl: null,
+    };
+    constructor(props){
+        super(props);
+        this.state = {
+            open: true,
+            commentList : null,
+        };
+        this.handleClose = this.handleClose.bind(this);
+        this.handleSortMostRecent = this.handleSortMostRecent.bind(this);
+        this.handleSortLeastRecent = this.handleSortLeastRecent.bind(this);
+        this.handleSortOwner = this.handleSortOwner.bind(this);
+        this.handleChange = this.handleChange.bind(this);
+        this.createComment = this.createComment.bind(this);
+    }
+
+    componentDidMount(){
+        this.getComments(this.props.fileName)
+    }
+    getComments(input, callback){
+        new Promise((resolve, reject) => {
+            this.props.presenter.getComments(input, resolve, reject);
+        }).then(commentList => {
+            console.log("here");
+            console.log(commentList);
+            this.setState({commentList : commentList});
+        }).catch(error => {
+            console.log(error);
+            this.setState({loading : false});
+        })
+
+    }
+
+    componentWillReceiveProps(nextProps, nextContext) {
+        this.setState({open: true})
+    }
+
+    handleClose = () => {
+        this.setState({open : false});
+    };
+
+    handleSortMostRecent = () => {
+        console.log("Sort ascending");
+        let swapped;
+        let aux = 0;
+        let temp = this.state.commentList;
+        swapped = true;
+        while(swapped){
+            swapped = false;
+            for(let i = 1; i < temp.length; i++){
+                if(temp[i - 1].date > temp[i].date){
+                    swapped = true;
+                    aux = temp[i - 1];
+                    temp[i - 1] = temp[i];
+                    temp[i] = aux;
+                }
+            }
+
+        }
+        this.setState({commentList : temp});
+
+    };
+
+    handleSortLeastRecent = () => {
+        console.log("Sort descending");
+        let swapped;
+        let aux = 0;
+        let temp = this.state.commentList;
+        swapped = true;
+        while(swapped){
+            swapped = false;
+            for(let i = 1; i < temp.length; i++){
+                if(temp[i - 1].date < temp[i].date){
+                    swapped = true;
+                    aux = temp[i - 1];
+                    temp[i - 1] = temp[i];
+                    temp[i] = aux;
+                }
+            }
+
+        }
+        this.setState({commentList : temp});
+    };
+
+    handleSortOwner = () => {
+        console.log("Sort User");
+        let swapped;
+        let aux = 0;
+        let temp = this.state.commentList;
+        swapped = true;
+        while(swapped){
+            swapped = false;
+            for(let i = 1; i < temp.length; i++){
+                if(temp[i - 1].owner.charAt(0) > temp[i].owner.charAt(0)){
+                    swapped = true;
+                    aux = temp[i - 1];
+                    temp[i - 1] = temp[i];
+                    temp[i] = aux;
+                }
+            }
+
+        }
+        this.setState({commentList : temp});
+    };
+
+    handleChange = name => event => {
+        this.setState({
+            [name]: event.target.value,
+        });
+    };
+
+    createComment = () => {
+      const text = document.getElementById("addCommentTextField").value;
+      console.log(text);
+    };
+
+
+    render(){
+        const {classes} = this.props;
+        let commentItems = this.state.commentList ? this.state.commentList.map((comment, index) =>
+            <Comment message={comment.message} id={comment.id} retracted={comment.retracted}
+                    date={comment.date} owner={comment.owner}/>
+    ) : [];
+        return(
+            <div className={classes.root}>
+                <Dialog
+                    open={this.state.open}
+                    onClose={this.handleClose}
+                    id={"edit-comments-dialog"}
+                    className={classes.main}
+                >
+                    <DEDialogHeader
+                        id={"edit-comments-dialog-title"}
+                        heading={"Comments"}
+                        onClose={this.handleClose}
+                    >
+
+                    </DEDialogHeader>
+                    <hr></hr>
+
+                    <Button variant="contained" color="secondary" className={classes.deleteButton}
+
+                    >
+                        Retract
+                        <DeleteIcon />
+                    </Button>
+
+                        <label id={"editCommentsDropDownLabel"} className={classes.dropDownLabel}>  Comments</label>
+                        <DotMenu
+                            handleSortMostRecent={this.handleSortMostRecent}
+                            handleSortLeastRecent={this.handleSortLeastRecent}
+                            handleSortOwner={this.handleSortOwner}
+                            className={this.props.classes.dropDownDots}
+                        />
+
+                    <DialogContent id="editCommentsCommentList" className={classes.dContent}>
+                        <List component="nav">
+                            {commentItems}
+                        </List>
+                    </DialogContent>
+                    <TextField
+                        value={this.state.multiline}
+                        onChange={this.handleChange('multiline')}
+                        className={classes.addCommentTextField}
+                        label="Add a Comment"
+                        margin="normal"
+                        multiline
+                        variant="filled"
+                        rows="5"
+                        id="addCommentTextField"
+                    />
+                    <Fab
+                        size="medium"
+                        color={CyVersePalette.blue}
+                        aria-label="Add"
+                        onClick={this.createComment}
+                        className={classes.addCommentButton}
+                    >
+                        <AddIcon/>
+                    </Fab>
+                </Dialog>
+            </div>
+        );
+    }
+}
+
+export default withStyles(exStyles)(EditComments)
+

--- a/react-components/src/data/edit/EditCommentsMenuItems.js
+++ b/react-components/src/data/edit/EditCommentsMenuItems.js
@@ -1,0 +1,61 @@
+import React, {Component} from 'react';
+
+import MenuItem from "@material-ui/core/MenuItem";
+import RecentIcon from "@material-ui/icons/Update";
+import OwnerIcon from "@material-ui/icons/SupervisedUserCircleRounded"
+import exStyles from "./style.js";
+import { withStyles } from "@material-ui/core/styles";
+
+class EditCommentsMenuItems extends Component {
+    render() {
+        const {
+            classes,
+            handleSortMostRecent,
+            handleSortLeastRecent,
+            handleSortOwner,
+            handleClose,
+        } = this.props;
+
+        return (
+            <React.Fragment>
+                <MenuItem
+                    onClick={() => {
+                        handleClose();
+                        handleSortMostRecent();
+                    }}
+                    className={classes.MenuItem}
+                >
+                    <RecentIcon/>
+                    Most Recent
+                </MenuItem>
+
+                <MenuItem
+                    onClick={() => {
+                        handleClose();
+                        handleSortLeastRecent();
+                    }}
+                    className={classes.MenuItem}
+                >
+                    <RecentIcon/>
+                    Least Recent
+                </MenuItem>
+
+
+                <MenuItem
+                    onClick={() => {
+                        handleClose();
+                        handleSortOwner();
+                    }}
+                    className={classes.MenuItem}
+                >
+                    <OwnerIcon/>
+                    By Owner
+                </MenuItem>
+
+
+            </React.Fragment>
+        );
+    }
+}
+
+export default withStyles(exStyles)(EditCommentsMenuItems);

--- a/react-components/src/data/edit/style.js
+++ b/react-components/src/data/edit/style.js
@@ -1,0 +1,55 @@
+//import CyVersePalette from "../../util/CyVersePalette";
+
+import CyVersePalette from "../../util/CyVersePalette";
+
+export default {
+    main: {
+        margin: 0,
+        width: 500,
+    },
+
+    root: {
+        width: 700,
+    },
+
+    dropDownLabel: {
+        float: "left",
+        marginLeft: 10,
+    },
+
+    dropDownDots:{
+        float: "right",
+    },
+
+    deleteButton: {
+      height: 35,
+      float: 'left',
+        marginBottom: 10,
+        width: 100,
+        marginLeft: 10,
+    },
+
+    addCommentButton: {
+        float: 'right',
+        marginBottom: 5,
+        marginLeft: 315,
+        color: CyVersePalette.blue,
+    },
+
+    addCommentTextField: {
+      position: 'relative',
+        width: "93%",
+        marginLeft: 11,
+
+
+    },
+
+    dContent: {
+        width: 320,
+    },
+
+    comment: {
+
+    }
+
+}

--- a/react-components/stories/data/edit/EditComments.stories.js
+++ b/react-components/stories/data/edit/EditComments.stories.js
@@ -1,0 +1,58 @@
+import React, {Component} from "react";
+import EditComments from "./../../../src/data/edit/EditComments";
+
+class EditCommentsTest extends Component {
+    render(){
+        const presenter = {
+            getComments: (input, resolve, reject) => {
+                resolve(commentList);
+            }
+        };
+
+        const commentList = [
+            {
+                owner: "ipctest",
+                message: "This is a test comment",
+                id: "1",
+                date: "today",
+                retracted: true,
+
+            },
+            {
+                owner: "a scientist",
+                message: "I am writting this long comment because i am a scientist and that is what i do",
+                id: "2",
+                date: "04/1/2019",
+
+            },
+            {
+                owner: "donald j trump",
+                message: "thank you cyverse, very cool!",
+                id: "3",
+                date: "MM/DD/YYYY"
+            },
+            {
+                owner: "retracted commentet",
+                message: "doesn't really matter",
+                id:"4",
+                date:"12/12/2012",
+                retracted: true
+            },
+            {
+                owner: "creator",
+                message: "i created this file, please comment and say things. javascript",
+                id: "5",
+                date:"the/dawn/oftime",
+
+            },
+        ];
+
+        const fileName = "someFileName";
+
+        return <EditComments presenter={presenter}
+                             fileName={fileName}
+                            />
+    }
+}
+
+export default EditCommentsTest

--- a/react-components/stories/index.stories.js
+++ b/react-components/stories/index.stories.js
@@ -62,6 +62,8 @@ import ErrorHandlerTest from "./util/ErrorHandler.stories";
 import ErrorExpansionPanelTest from "./util/ErrorExpansionPanel.stories";
 import TriggerFieldTest from "./util/TriggerField.stories";
 import DEPromptDialogTest from "./util/dialog/DEPromptDialog.stories";
+import EditCommentsTest from "./data/edit/EditComments.stories";
+
 
 storiesOf("analysis/view", module).add("with test analyses", () => (
     <AnalysesViewTest />
@@ -142,6 +144,7 @@ storiesOf("data/Tag", module).add("with test diskresource details", () => (
 storiesOf("data/TagPanel", module).add("with test diskresource details", () => (
     <TagPanelTest logger={action("tagpanel")} />
 ));
+storiesOf('data/edit', module).add('Edit Comments Dialogue', () => <EditCommentsTest />);
 
 storiesOf("desktop/view", module).add("with test desktop view", () => (
     <DesktopViewTest logger={action("desktop")} />


### PR DESCRIPTION

<img width="216" alt="editcomments1" src="https://user-images.githubusercontent.com/27375399/56840588-2b48dd00-683d-11e9-8b8a-ec3b8d595f4e.png">

This is the edit comments dialog written in react. This pull request only contains the UI portion of this element. Currently the "Retract" and "+" buttons do nothing, but in the future will make API requests to retract or add a comment respectively. The comments can be sorted by recency (dates will all have the same format once api is implemented) and by owner, these sorts can be seen after clicking the dot menu.

<img width="204" alt="editcommentsdd" src="https://user-images.githubusercontent.com/27375399/56840668-a4e0cb00-683d-11e9-919c-95c3552d1f2e.png">

The comment section itself is in a Dialog Content element and is therefore scrollable, there is a max width so longer comments will wrap.






