### PR TITLE
Enable any JSON obj to show in ErrorHandler messages

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/commons/client/ErrorHandler.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/ErrorHandler.java
@@ -12,6 +12,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Window;
@@ -259,9 +260,9 @@ public class ErrorHandler {
 
     private static String getErrorMessage(JSONObject jsonError) {
         for (String s : messageStrings) {
-            String error = jsonUtil.getString(jsonError, s);
-            if (!Strings.isNullOrEmpty(error)) {
-                return error;
+            JSONValue error = jsonError.get(s);
+            if (error != null && !Strings.isNullOrEmpty(error.toString())) {
+                return error.toString();
             }
         }
         return "";


### PR DESCRIPTION
The logic I wrote assumed the messages would be strings, but they're sometimes json objects.  Should fix issues like this:

![image](https://user-images.githubusercontent.com/8909156/57255292-41f2ef00-7008-11e9-9829-946be8223f25.png)

![image](https://user-images.githubusercontent.com/8909156/57255316-50410b00-7008-11e9-8feb-4d873a339623.png)
