### PR TITLE
Updates to Desktop menus

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/commons/client/CommonUiConstants.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/CommonUiConstants.java
@@ -13,7 +13,7 @@ public interface CommonUiConstants extends Constants {
      * 
      * @return a string representing the URL.
      */
-    String forumsUrl();
+    String learningCenterUrl();
 
     /**
      * URL for landing page.

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/CommonUiConstants.java
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/CommonUiConstants.java
@@ -62,4 +62,6 @@ public interface CommonUiConstants extends Constants {
     String iDropDesktopClientInstructionsUrl();
 
     String faqUrl();
+
+    String emailSupport();
 }

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/CommonUiConstants.properties
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/CommonUiConstants.properties
@@ -10,3 +10,4 @@ closeKeyShortCut = Q
 iDropDesktopClientInstructionsUrl = https://pods.iplantcollaborative.org/wiki/display/DS/Using+Cyberduck+for+Uploading+and+Downloading+to+the+Data+Store
 cyverseHome = http://cyverse.org
 faqUrl = http://cyverse.github.io/UserSupport/README.html
+emailSupport= mailto:support@cyverse.org

--- a/de-lib/src/main/java/org/iplantc/de/commons/client/CommonUiConstants.properties
+++ b/de-lib/src/main/java/org/iplantc/de/commons/client/CommonUiConstants.properties
@@ -1,4 +1,4 @@
-forumsUrl = http://ask.cyverse.org
+learningCenterUrl = http://learning.cyverse.org
 supportUrl = http://www.cyverse.org/contact
 appNameRestrictedChars = :@/\\|^#;[]{}<>
 appNameRestrictedStartingChars = ~.$

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -147,6 +147,8 @@ public interface DesktopView extends IsWidget {
 
         void onFeedbackSelect();
 
+        void onEmailSupportClicked();
+
         @SuppressWarnings("unusable-by-js")
         void onNotificationSelected(final Splittable notificationMessage,
                                     final NotificationMarkAsSeenCallback callback,

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/DesktopView.java
@@ -143,7 +143,7 @@ public interface DesktopView extends IsWidget {
 
         void onDataWinBtnSelect();
 
-        void onForumsBtnSelect();
+        void onLearningCenterBtnClick();
 
         void onFeedbackSelect();
 

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -482,8 +482,8 @@ public class DesktopPresenterImpl implements DesktopView.Presenter,
     }
 
     @Override
-    public void onForumsBtnSelect() {
-        WindowUtil.open(commonUiConstants.forumsUrl());
+    public void onLearningCenterBtnClick() {
+        WindowUtil.open(commonUiConstants.learningCenterUrl());
     }
 
     @Override

--- a/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/desktop/client/presenter/DesktopPresenterImpl.java
@@ -491,6 +491,11 @@ public class DesktopPresenterImpl implements DesktopView.Presenter,
         view.onFeedbackBtnSelect();
     }
 
+    @Override
+    public void onEmailSupportClicked() {
+        Window.Location.assign(commonUiConstants.emailSupport());
+    }
+
     /**
      * FIXME REFACTOR JDS Create notifications module and move this implementation there
      */

--- a/de-webapp/src/main/webapp/WEB-INF/jsp/de.jsp
+++ b/de-webapp/src/main/webapp/WEB-INF/jsp/de.jsp
@@ -128,7 +128,8 @@ response.setDateHeader("Expires", 0);
                     app_id: APP_ID,
                     alignment: 'right',
                     horizontal_padding: 20,
-                    vertical_padding: 45
+                    vertical_padding: 45,
+                    custom_launcher_selector: '#help_menu_intercom_link',
             	};
             }
         })

--- a/react-components/src/desktop/ids.js
+++ b/react-components/src/desktop/ids.js
@@ -30,4 +30,5 @@ export default {
     USER_MENU_ANCHOR: "userMenuAnchor",
     HELP_MENU_ANCHOR: "helpMenuAnchor",
     UNSEEN_NOTIFICATION_COUNT: "unSeenCount",
+    EMAIL_SUPPORT_LINK: "emailSupport",
 };

--- a/react-components/src/desktop/ids.js
+++ b/react-components/src/desktop/ids.js
@@ -17,7 +17,7 @@ export default {
     LOGOUT_LINK: "logout",
     SUPPORT_BTN: "support",
     FAQS_LINK: "faqs",
-    FORUMS_LINK: "forum",
+    LEARNING_CENTER_LINK: "learningCenter",
     FEEDBACK_LINK: "feedback",
     NOTIFICATIONS_MENU: "notificationsMenu",
     EMPTY_NOTIFICATION: "emptyNotification",

--- a/react-components/src/desktop/messages.js
+++ b/react-components/src/desktop/messages.js
@@ -28,6 +28,8 @@ var intlData = {
         preferencesTooltip: "Preferences and Groups",
         emailSupportLink: "Email Support",
         emailSupportTooltip: "support@cyverse.org",
+        supportChatLink: "Chat With Support",
+        supportChatTooltip: "Chat may be disabled by your browser's settings",
     },
 };
 

--- a/react-components/src/desktop/messages.js
+++ b/react-components/src/desktop/messages.js
@@ -23,6 +23,9 @@ var intlData = {
         analysesTip:
             "Find the status, parameters, and results of your executed apps.",
         dot: ". ",
+        helpTooltip: "Help",
+        notificationTooltip: "Notifications",
+        preferencesTooltip: "Preferences and Groups",
     },
 };
 

--- a/react-components/src/desktop/messages.js
+++ b/react-components/src/desktop/messages.js
@@ -26,6 +26,8 @@ var intlData = {
         helpTooltip: "Help",
         notificationTooltip: "Notifications",
         preferencesTooltip: "Preferences and Groups",
+        emailSupportLink: "Email Support",
+        emailSupportTooltip: "support@cyverse.org",
     },
 };
 

--- a/react-components/src/desktop/messages.js
+++ b/react-components/src/desktop/messages.js
@@ -2,7 +2,7 @@ var intlData = {
     locales: "en-US",
     messages: {
         faqLink: "FAQs",
-        forumsLink: "Forum",
+        learningCenterLink: "Learning Center",
         feedbackLink: "Feedback",
         preferences: "Preferences",
         collaborators: "Collaborators",

--- a/react-components/src/desktop/style.js
+++ b/react-components/src/desktop/style.js
@@ -46,9 +46,7 @@ export default {
         backgroundSize: "contain",
         color: "#ffffff",
         position: "relative",
-        marginLeft: "8px",
-        marginBottom: "0px",
-        marginRight: "6px",
+        marginLeft: "15px",
         cursor: "pointer",
         "&:hover": {
             boxShadow: "0px 2px 3px #ccc",
@@ -61,7 +59,8 @@ export default {
         backgroundSize: "contain",
         color: "#ffffff",
         position: "relative",
-        marginBottom: "12px",
+        marginLeft: "15px",
+        marginBottom: "13px",
         cursor: "pointer",
         "&:hover": {
             boxShadow: "0px 2px 3px #ccc",

--- a/react-components/src/desktop/view/DesktopView.js
+++ b/react-components/src/desktop/view/DesktopView.js
@@ -335,7 +335,6 @@ class DesktopView extends Component {
                                         ids.USER_MENU_ANCHOR
                                     )}
                                     presenter={this.props.presenter}
-                                    doIntro={this.doIntro}
                                 />
                                 <Help
                                     anchor={build(
@@ -343,6 +342,7 @@ class DesktopView extends Component {
                                         ids.HELP_MENU_ANCHOR
                                     )}
                                     presenter={this.props.presenter}
+                                    doIntro={this.doIntro}
                                 />
                                 <span
                                     id={build(

--- a/react-components/src/desktop/view/Help.js
+++ b/react-components/src/desktop/view/Help.js
@@ -101,8 +101,23 @@ class Help extends Component {
                         <DEHyperlink text={getMessage("faqLink")} />
                     </MenuItem>
                     <Divider />
-                    <Tooltip title={getMessage("emailSupportTooltip")}
-                             placement="left">
+                    <Tooltip
+                        title={getMessage("supportChatTooltip")}
+                        placement="left"
+                    >
+                        <MenuItem
+                            id="help_menu_intercom_link"
+                            onClick={() => {
+                                this.handleClose();
+                            }}
+                        >
+                            <DEHyperlink text={getMessage("supportChatLink")} />
+                        </MenuItem>
+                    </Tooltip>
+                    <Tooltip
+                        title={getMessage("emailSupportTooltip")}
+                        placement="left"
+                    >
                         <MenuItem
                             id={build(ids.DESKTOP, ids.EMAIL_SUPPORT_LINK)}
                             onClick={() => {

--- a/react-components/src/desktop/view/Help.js
+++ b/react-components/src/desktop/view/Help.js
@@ -71,13 +71,13 @@ class Help extends Component {
                         <DEHyperlink text={getMessage("introduction")} />
                     </MenuItem>
                     <MenuItem
-                        id={build(ids.DESKTOP, ids.FORUMS_LINK)}
+                        id={build(ids.DESKTOP, ids.LEARNING_CENTER_LINK)}
                         onClick={() => {
-                            presenter.onForumsBtnSelect();
+                            presenter.onLearningCenterBtnClick();
                             this.handleClose();
                         }}
                     >
-                        <DEHyperlink text={getMessage("forumsLink")} />
+                        <DEHyperlink text={getMessage("learningCenterLink")} />
                     </MenuItem>
                     <MenuItem
                         id={build(ids.DESKTOP, ids.USER_MANUAL_LINK)}

--- a/react-components/src/desktop/view/Help.js
+++ b/react-components/src/desktop/view/Help.js
@@ -17,6 +17,7 @@ import Divider from "@material-ui/core/Divider";
 import HelpIcon from "@material-ui/icons/Help";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
+import Tooltip from "@material-ui/core/Tooltip";
 
 class Help extends Component {
     constructor(props) {
@@ -49,12 +50,14 @@ class Help extends Component {
         const { classes, presenter, doIntro } = this.props;
         return (
             <span>
-                <HelpIcon
-                    id={build(ids.DESKTOP, ids.HELP_MENU)}
-                    className={classes.menuIcon}
-                    onClick={this.handleClick}
-                    ref={this.helpBtn}
-                />
+                <Tooltip title={getMessage("helpTooltip")}>
+                    <HelpIcon
+                        id={build(ids.DESKTOP, ids.HELP_MENU)}
+                        className={classes.menuIcon}
+                        onClick={this.handleClick}
+                        ref={this.helpBtn}
+                    />
+                </Tooltip>
                 <Menu
                     id={build(ids.DESKTOP, ids.HELP_MENU)}
                     anchorEl={anchorEl}

--- a/react-components/src/desktop/view/Help.js
+++ b/react-components/src/desktop/view/Help.js
@@ -13,6 +13,7 @@ import { build, DEHyperlink, getMessage, withI18N } from "@cyverse-de/ui-lib";
 
 import { withStyles } from "@material-ui/core/styles";
 
+import Divider from "@material-ui/core/Divider";
 import HelpIcon from "@material-ui/icons/Help";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -45,7 +46,7 @@ class Help extends Component {
 
     render() {
         const { anchorEl } = this.state;
-        const { classes, presenter } = this.props;
+        const { classes, presenter, doIntro } = this.props;
         return (
             <span>
                 <HelpIcon
@@ -61,13 +62,13 @@ class Help extends Component {
                     onClose={this.handleClose}
                 >
                     <MenuItem
-                        id={build(ids.DESKTOP, ids.FAQS_LINK)}
+                        id={build(ids.DESKTOP, ids.INTRO_LINK)}
                         onClick={() => {
-                            presenter.onFaqSelect();
+                            doIntro();
                             this.handleClose();
                         }}
                     >
-                        <DEHyperlink text={getMessage("faqLink")} />
+                        <DEHyperlink text={getMessage("introduction")} />
                     </MenuItem>
                     <MenuItem
                         id={build(ids.DESKTOP, ids.FORUMS_LINK)}
@@ -79,6 +80,25 @@ class Help extends Component {
                         <DEHyperlink text={getMessage("forumsLink")} />
                     </MenuItem>
                     <MenuItem
+                        id={build(ids.DESKTOP, ids.USER_MANUAL_LINK)}
+                        onClick={() => {
+                            presenter.onDocumentationClick();
+                            this.handleClose();
+                        }}
+                    >
+                        <DEHyperlink text={getMessage("documentation")} />
+                    </MenuItem>
+                    <MenuItem
+                        id={build(ids.DESKTOP, ids.FAQS_LINK)}
+                        onClick={() => {
+                            presenter.onFaqSelect();
+                            this.handleClose();
+                        }}
+                    >
+                        <DEHyperlink text={getMessage("faqLink")} />
+                    </MenuItem>
+                    <Divider />
+                    <MenuItem
                         id={build(ids.DESKTOP, ids.FEEDBACK_LINK)}
                         onClick={() => {
                             presenter.onFeedbackSelect();
@@ -86,6 +106,15 @@ class Help extends Component {
                         }}
                     >
                         <DEHyperlink text={getMessage("feedbackLink")} />
+                    </MenuItem>
+                    <MenuItem
+                        id={build(ids.DESKTOP, ids.ABOUT_LINK)}
+                        onClick={() => {
+                            presenter.onAboutClick();
+                            this.handleClose();
+                        }}
+                    >
+                        <DEHyperlink text={getMessage("about")} />
                     </MenuItem>
                 </Menu>
             </span>

--- a/react-components/src/desktop/view/Help.js
+++ b/react-components/src/desktop/view/Help.js
@@ -101,6 +101,21 @@ class Help extends Component {
                         <DEHyperlink text={getMessage("faqLink")} />
                     </MenuItem>
                     <Divider />
+                    <Tooltip title={getMessage("emailSupportTooltip")}
+                             placement="left">
+                        <MenuItem
+                            id={build(ids.DESKTOP, ids.EMAIL_SUPPORT_LINK)}
+                            onClick={() => {
+                                presenter.onEmailSupportClicked();
+                                this.handleClose();
+                            }}
+                        >
+                            <DEHyperlink
+                                text={getMessage("emailSupportLink")}
+                            />
+                        </MenuItem>
+                    </Tooltip>
+                    <Divider />
                     <MenuItem
                         id={build(ids.DESKTOP, ids.FEEDBACK_LINK)}
                         onClick={() => {

--- a/react-components/src/desktop/view/Notifications.js
+++ b/react-components/src/desktop/view/Notifications.js
@@ -23,9 +23,9 @@ import Fab from "@material-ui/core/Fab";
 import Divider from "@material-ui/core/Divider";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
-
 import NotificationIcon from "@material-ui/icons/Notifications";
 import RefreshIcon from "@material-ui/icons/Refresh";
+import Tooltip from "@material-ui/core/Tooltip";
 
 import { withStyles } from "@material-ui/core/styles";
 
@@ -193,12 +193,14 @@ class Notifications extends Component {
                         root: classes.badge,
                     }}
                 >
-                    <NotificationIcon
-                        id={build(ids.DESKTOP, ids.NOTIFICATION_BUTTON)}
-                        className={classes.notificationMenuIcon}
-                        onClick={this.handleNotificationsClick}
-                        ref={this.notificationBtn}
-                    />
+                    <Tooltip title={getMessage("notificationTooltip")}>
+                        <NotificationIcon
+                            id={build(ids.DESKTOP, ids.NOTIFICATION_BUTTON)}
+                            className={classes.notificationMenuIcon}
+                            onClick={this.handleNotificationsClick}
+                            ref={this.notificationBtn}
+                        />
+                    </Tooltip>
                 </Badge>
                 <Menu
                     id={build(ids.DESKTOP, ids.NOTIFICATIONS_MENU)}

--- a/react-components/src/desktop/view/UserMenu.js
+++ b/react-components/src/desktop/view/UserMenu.js
@@ -46,7 +46,7 @@ class UserMenu extends Component {
 
     render() {
         const { anchorEl } = this.state;
-        const { classes, presenter, doIntro } = this.props;
+        const { classes, presenter } = this.props;
         return (
             <span>
                 <PersonIcon
@@ -96,34 +96,6 @@ class UserMenu extends Component {
                         }}
                     >
                         <DEHyperlink text={getMessage("communities")} />
-                    </MenuItem>
-                    <Divider />
-                    <MenuItem
-                        id={build(ids.DESKTOP, ids.USER_MANUAL_LINK)}
-                        onClick={() => {
-                            presenter.onDocumentationClick();
-                            this.handleClose();
-                        }}
-                    >
-                        <DEHyperlink text={getMessage("documentation")} />
-                    </MenuItem>
-                    <MenuItem
-                        id={build(ids.DESKTOP, ids.INTRO_LINK)}
-                        onClick={() => {
-                            doIntro();
-                            this.handleClose();
-                        }}
-                    >
-                        <DEHyperlink text={getMessage("introduction")} />
-                    </MenuItem>
-                    <MenuItem
-                        id={build(ids.DESKTOP, ids.ABOUT_LINK)}
-                        onClick={() => {
-                            presenter.onAboutClick();
-                            this.handleClose();
-                        }}
-                    >
-                        <DEHyperlink text={getMessage("about")} />
                     </MenuItem>
                     <Divider />
                     <MenuItem

--- a/react-components/src/desktop/view/UserMenu.js
+++ b/react-components/src/desktop/view/UserMenu.js
@@ -15,6 +15,7 @@ import Divider from "@material-ui/core/Divider";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import PersonIcon from "@material-ui/icons/Person";
+import Tooltip from "@material-ui/core/Tooltip";
 
 import { withStyles } from "@material-ui/core/styles";
 
@@ -49,12 +50,14 @@ class UserMenu extends Component {
         const { classes, presenter } = this.props;
         return (
             <span>
-                <PersonIcon
-                    id={build(ids.DESKTOP, ids.USER_PREF_MENU)}
-                    className={classes.menuIcon}
-                    onClick={this.onUserMenuClick}
-                    ref={this.userBtn}
-                />
+                <Tooltip title={getMessage("preferencesTooltip")}>
+                    <PersonIcon
+                        id={build(ids.DESKTOP, ids.USER_PREF_MENU)}
+                        className={classes.menuIcon}
+                        onClick={this.onUserMenuClick}
+                        ref={this.userBtn}
+                    />
+                </Tooltip>
                 <Menu
                     id={build(ids.DESKTOP, ids.USER_PREF_MENU)}
                     anchorEl={anchorEl}

--- a/react-components/stories/desktop/view/DesktopView.stories.js
+++ b/react-components/stories/desktop/view/DesktopView.stories.js
@@ -485,6 +485,12 @@ class DesktopViewTest extends Component {
             onCollaboratorsClick: () => logger("Collaborators Clicked"),
             onTeamsClick: () => logger("Teams Clicked"),
             onCommunitiesClick: () => logger("Communities Clicked"),
+            onLearningCenterBtnClick: () => logger("Learning Center Clicked"),
+            onFaqSelect: () => logger("FAQ Clicked"),
+            onFeedbackSelect: () => logger("Feedback Clicked"),
+            onDataWinBtnSelect: () => logger("Data Clicked"),
+            onAppsWinBtnSelect: () => logger("Apps Clicked"),
+            onAnalysesWinBtnSelect: () => logger("Analyses Clicked"),
         };
         return (
             <DesktopView

--- a/react-components/stories/desktop/view/DesktopView.stories.js
+++ b/react-components/stories/desktop/view/DesktopView.stories.js
@@ -491,6 +491,7 @@ class DesktopViewTest extends Component {
             onDataWinBtnSelect: () => logger("Data Clicked"),
             onAppsWinBtnSelect: () => logger("Apps Clicked"),
             onAnalysesWinBtnSelect: () => logger("Analyses Clicked"),
+            onEmailSupportClicked: () => logger("Email Support Clicked"),
         };
         return (
             <DesktopView

--- a/react-components/stories/desktop/view/DesktopView.stories.js
+++ b/react-components/stories/desktop/view/DesktopView.stories.js
@@ -492,6 +492,7 @@ class DesktopViewTest extends Component {
             onAppsWinBtnSelect: () => logger("Apps Clicked"),
             onAnalysesWinBtnSelect: () => logger("Analyses Clicked"),
             onEmailSupportClicked: () => logger("Email Support Clicked"),
+            onSupportChatClicked: () => logger("Support Chat Clicked"),
         };
         return (
             <DesktopView


### PR DESCRIPTION
* Moved About, Introduction, and User Manual under Help icon
* Changed Forum link to a link to the learning center
* Added links to email support and also to open the Intercom chat window under the Help icon
* Added tooltips to the desktop menu items and to the support menu items
* Updated the styling for the desktop menu items

![image](https://user-images.githubusercontent.com/8909156/59883398-cd7ed000-9369-11e9-8400-2800af72e7f4.png)

![image](https://user-images.githubusercontent.com/8909156/59883918-6feb8300-936b-11e9-9cde-0965f3d457d6.png)

