### PR TITLE
CORE-9 Remove includefiles param from directory endpoint calls.

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/DiskResourceServiceFacadeImpl.java
@@ -227,7 +227,7 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
         if (hasFoldersLoaded(folder)) {
             callback.onSuccess(getSubFolders(folder));
         } else {
-            String address = getDirectoryListingEndpoint(parent.getPath(), false);
+            String address = getDirectoryListingEndpoint(parent.getPath());
             ServiceCallWrapper wrapper = new ServiceCallWrapper(address);
             callService(wrapper, new DECallbackConverter<String, List<Folder>>(callback) {
 
@@ -306,12 +306,11 @@ public class DiskResourceServiceFacadeImpl extends TreeStore<Folder> implements
         return filteredFolders;
     }
 
-    private String getDirectoryListingEndpoint(final String path, boolean includeFiles) {
-        String address = deProperties.getDataMgmtBaseUrl()
-                + "directory?includefiles=" + (includeFiles ? "1" : "0"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    private String getDirectoryListingEndpoint(final String path) {
+        String address = deProperties.getDataMgmtBaseUrl() + "directory";
 
         if (!Strings.isNullOrEmpty(path)) {
-            address += "&path=" + URL.encodeQueryString(path); //$NON-NLS-1$
+            address += "?path=" + URL.encodeQueryString(path);
         }
 
         return address;


### PR DESCRIPTION
This PR will remove the `includefiles` param from `/filesystem/directory` endpoint calls.

The `data-info` directory endpoint's `includefiles` param is obsolete, so it will no longer be supported in terrain's API after cyverse-de/terrain#127 (it's already ignored anyway).