### PR TITLE
added the Internet2 InCommon intermediate CA certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ ADD de-application.yaml /etc/iplant/de/de-application.yaml
 
 RUN ln -s "/usr/bin/java" "/bin/cyverse-ui"
 
+# Add the Internet2 InCommon intermediate CA certificate.
+ADD "https://incommon.org/wp-content/uploads/2019/06/sha384-Intermediate-cert.txt" "/uyr/local/share/ca-certificates/"
+RUN "update-ca-certificates"
+
 EXPOSE 8080
 
 ENTRYPOINT ["cyverse-ui", "-Dlogging.config=file:/etc/iplant/de/logging/de-ui.xml", "-jar", "de.war", "--spring.config.location=file:/etc/iplant/de/de-application.yaml"]


### PR DESCRIPTION
NCSU uses Internet2's InCommon certificate authority. Adding it as a trusted certificate authority shouldn't pose much of a risk, and will make it easier for us to deploy to sites that use it.