### PR TITLE
CORE-128 Disable Delete option for running jobs

### DIFF
--- a/react-components/src/analysis/view/AnalysesMenuItems.js
+++ b/react-components/src/analysis/view/AnalysesMenuItems.js
@@ -159,7 +159,7 @@ class AnalysesMenuItems extends Component {
                 </MenuItem>
                 <MenuItem
                     id={build(baseDebugId, ids.MENUITEM_DELETE)}
-                    disabled={noSelection || !owner}
+                    disabled={noSelection || !owner || !disableCancel}
                     onClick={() => {
                         handleClose();
                         handleDeleteClick();


### PR DESCRIPTION
Since deleting a job does not cancel it, this prevents users from accidentally deleting running jobs.