### PR TITLE
Update ManageTools table to use DETableRow

### DIFF
--- a/react-components/package-lock.json
+++ b/react-components/package-lock.json
@@ -902,13 +902,14 @@
             "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
         },
         "@cyverse-de/ui-lib": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@cyverse-de/ui-lib/-/ui-lib-0.3.7.tgz",
-            "integrity": "sha512-2TnFFyDX0E0X3tMR/oyhBBjYI4VQcFEb7w5BLRHtOyaAqGB8GfFEP6vH/mhmtPWflicSXKRvfaJrEdiwavkWOA==",
+            "version": "0.3.12",
+            "resolved": "https://registry.npmjs.org/@cyverse-de/ui-lib/-/ui-lib-0.3.12.tgz",
+            "integrity": "sha512-cpvbJw/Ac+re7DmY8BOZKYF2yH13xojlkq0I6HV6Pe2g9ClHXCT3v/UcLeq0NDfOKpHRQ6SkOFzmfDJ+mGIbNg==",
             "requires": {
                 "classnames": "^2.2.6",
                 "date-fns": "^1.30.1",
                 "md5": "^2.2.1",
+                "numeral": "^2.0.6",
                 "react-highlighter": "^0.4.3",
                 "react-loading-overlay": "^1.0.1",
                 "react-scripts": "2.1.8"
@@ -15315,6 +15316,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "numeral": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+            "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
         },
         "nwsapi": {
             "version": "2.1.4",

--- a/react-components/package.json
+++ b/react-components/package.json
@@ -20,7 +20,7 @@
         "prop-types": "^15.6.2"
     },
     "dependencies": {
-        "@cyverse-de/ui-lib": "^0.3.7",
+        "@cyverse-de/ui-lib": "^0.3.12",
         "@material-ui/core": "^4.4.0",
         "@material-ui/icons": "^4.2.1",
         "@material-ui/lab": "^4.0.0-alpha.25",

--- a/react-components/src/tools/ManageTools.js
+++ b/react-components/src/tools/ManageTools.js
@@ -10,6 +10,7 @@ import styles from "./styles";
 
 import {
     build,
+    DETableRow,
     EmptyTable,
     EnhancedTableHead,
     formatMessage,
@@ -21,7 +22,6 @@ import {
 } from "@cyverse-de/ui-lib";
 import {
     Button,
-    Checkbox,
     IconButton,
     Menu,
     MenuItem,
@@ -448,7 +448,7 @@ function ToolListing(props) {
                 toolList.tools.length > 0 &&
                 toolList.tools.map((tool) => {
                     return (
-                        <TableRow
+                        <DETableRow
                             tabIndex={-1}
                             hover
                             key={tool.id}
@@ -477,7 +477,7 @@ function ToolListing(props) {
                                     ? getMessage("public")
                                     : tool.permission}
                             </TableCell>
-                        </TableRow>
+                        </DETableRow>
                     );
                 })}
         </TableBody>


### PR DESCRIPTION
Selected in blue, hover in gray:
![image](https://user-images.githubusercontent.com/8909156/66680947-8709f580-ec26-11e9-85f2-3d6c6fa4cb16.png)

I'm now leaning towards not adding the checkboxes back because we also use this view in the App Editor to select a tool for the app.  Having the checkboxes in that case might be confusing, as if you can create a workflow of tools.  We could add a flag to toggle having the checkboxes, but, as Sriram said, probably it's unlikely users are trying to select/deal with multiple tools in the Manage Tools window anyway.