### PR TITLE
Fix weird transition to Boolean objects in Apps window

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java
@@ -24,6 +24,7 @@ import org.iplantc.de.client.models.UserInfo;
 import org.iplantc.de.client.models.apps.App;
 import org.iplantc.de.client.models.apps.AppAutoBeanFactory;
 import org.iplantc.de.client.models.apps.AppCategory;
+import org.iplantc.de.client.models.apps.AppList;
 import org.iplantc.de.client.models.apps.proxy.AppListLoadResult;
 import org.iplantc.de.client.models.avu.Avu;
 import org.iplantc.de.client.models.groups.Group;
@@ -178,11 +179,7 @@ public class AppsListPresenterImpl implements AppsListView.Presenter,
 
     @Override
     public void onAppSelectionChanged(Splittable splittableSelectedApps) {
-        selectedApps.clear();
-        for (int i = 0; i < splittableSelectedApps.size(); i++) {
-            App app = splittableToApp(splittableSelectedApps.get(i));
-            selectedApps.add(app);
-        }
+        selectedApps = AutoBeanCodex.decode(factory, AppList.class, splittableSelectedApps.getPayload()).as().getApps();
         AppSelectionChangedEvent event = new AppSelectionChangedEvent(selectedApps);
         fireEvent(event);
     }

--- a/react-components/src/apps/listing/AppListingView.js
+++ b/react-components/src/apps/listing/AppListingView.js
@@ -66,7 +66,7 @@ export default function AppListingView(props) {
     };
 
     const onAppInfoClick = (app) => {
-        presenter.onAppInfoSelected(app, false);
+        presenter.onAppInfoSelected({ ...app }, false);
     };
 
     const onCommentsClick = (app) => {
@@ -74,7 +74,7 @@ export default function AppListingView(props) {
     };
 
     const onFavoriteClick = (app) => {
-        presenter.onAppFavoriteSelected(app);
+        presenter.onAppFavoriteSelected({ ...app });
     };
 
     const onAppNameClick = (app) => {
@@ -90,7 +90,7 @@ export default function AppListingView(props) {
     };
 
     const onQuickLaunchClick = (app) => {
-        presenter.onAppInfoSelected(app, true);
+        presenter.onAppInfoSelected({ ...app }, true);
     };
 
     if (viewType === view.TILE) {

--- a/react-components/src/apps/listing/AppListingView.js
+++ b/react-components/src/apps/listing/AppListingView.js
@@ -38,7 +38,7 @@ export default function AppListingView(props) {
             );
         }
         setSelectedApps(newSelected);
-        presenter.onAppSelectionChanged(newSelected);
+        presenter.onAppSelectionChanged({ apps: newSelected });
     };
 
     const handleSelectAll = (checked) => {
@@ -47,7 +47,7 @@ export default function AppListingView(props) {
 
     const resetAppSelection = () => {
         setSelectedApps([]);
-        presenter.onAppSelectionChanged([]);
+        presenter.onAppSelectionChanged({ apps: [] });
     };
 
     const onTypeFilterChange = (filter) => {


### PR DESCRIPTION
I have no idea why converting the AppList splittable doesn't modify any booleans to Boolean objects while converting each App object in an array does in `onAppSelectionChanged`, but it seems to be working for me.

The other change is sending a shallow copy of an app via destructuring to the presenter whenever the presenter ends up modifying the app object. 

For the App Info dialog, there's a modification here: 
https://github.com/cyverse-de/ui/blob/master/de-lib/src/main/java/org/iplantc/de/client/services/impl/AppUserServiceFacadeImpl.java#L244

For app favorites, there's a modification here (though I'm not sure it's necessary since the window does a refresh of the listing afterwards anyway):
https://github.com/cyverse-de/ui/blob/master/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java#L338