### PR TITLE
Community fixes

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsListView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsListView.java
@@ -131,6 +131,8 @@ public interface AppsListView extends IsWidget {
         @SuppressWarnings("unusable-by-js")
         void onAppRatingSelected(final Splittable appSplittable,
                                  int score);
+
+        void setSingleAppSelection(boolean singleAppSelection);
     }
 
     void load(AppsListView.Presenter presenter,
@@ -163,4 +165,5 @@ public interface AppsListView extends IsWidget {
 
     void setSortInfo(String sortField, String sortDir);
 
+    void setSingleAppSelection(boolean singleSelection);
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/AppsView.java
@@ -79,6 +79,8 @@ public interface AppsView extends IsWidget,
         boolean isDetailsCollapsed();
 
         void addAppSelectionChangedHandler(AppSelectionChangedEvent.AppSelectionChangedEventHandler handler);
+
+        void setSingleAppSelection(boolean singleAppSelection);
     }
 
     DETabPanel getCategoryTabPanel();

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/AppsViewPresenterImpl.java
@@ -202,4 +202,9 @@ public class AppsViewPresenterImpl implements AppsView.Presenter,
     public void addAppSelectionChangedHandler(AppSelectionChangedEvent.AppSelectionChangedEventHandler handler) {
         appsListPresenter.addAppSelectionChangedEventHandler(handler);
     }
+
+    @Override
+    public void setSingleAppSelection(boolean singleAppSelection) {
+        appsListPresenter.setSingleAppSelection(singleAppSelection);
+    }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/presenter/list/AppsListPresenterImpl.java
@@ -193,6 +193,11 @@ public class AppsListPresenterImpl implements AppsListView.Presenter,
     }
 
     @Override
+    public void setSingleAppSelection(boolean singleAppSelection) {
+        listView.setSingleAppSelection(singleAppSelection);
+    }
+
+    @Override
     public void onBeforeAppSearch(BeforeAppSearchEvent event) {
         filter = AppTypeFilter.ALL.getFilterString();
         listView.setTypeFilter(filter);

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/list/AppListViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/list/AppListViewImpl.java
@@ -45,6 +45,7 @@ public class AppListViewImpl implements AppsListView {
         props.selectedAppId = null;
         props.viewType = activeView;
         props.loading = true;
+        props.singleSelection = false;
         render();
     }
 
@@ -114,6 +115,12 @@ public class AppListViewImpl implements AppsListView {
     public void setSortInfo(String sortField, String sortDir) {
         props.sortField = sortField;
         props.sortDir = sortDir;
+        render();
+    }
+
+    @Override
+    public void setSingleAppSelection(boolean singleSelection) {
+        props.singleSelection = singleSelection;
         render();
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/apps/client/views/list/ReactAppListing.java
+++ b/de-lib/src/main/java/org/iplantc/de/apps/client/views/list/ReactAppListing.java
@@ -33,5 +33,6 @@ public class ReactAppListing {
         public String viewType;
         public boolean loading;
         public String baseId;
+        public boolean singleSelection;
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Subject.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/collaborators/Subject.java
@@ -22,7 +22,7 @@ public interface Subject extends HasSettableId, HasName {
     String GROUP_NAME_DELIMITER = ":";
     String LIST_LONG_NAME_REGEX = ".*collaborator-lists:(.+)";
     String TEAM_LONG_NAME_REGEX = ".*teams:.+:(.+)";
-    String COMMUNITY_LONG_NAME_REGEX = ".*communities:.+:(.+)";
+    String COMMUNITY_LONG_NAME_REGEX = ".*communities:(.+)";
 
     @AutoBean.PropertyName("first_name")
     String getFirstName();

--- a/de-lib/src/main/java/org/iplantc/de/client/services/converters/SubjectListCallbackConverter.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/converters/SubjectListCallbackConverter.java
@@ -35,12 +35,13 @@ public class SubjectListCallbackConverter extends AsyncCallbackConverter<String,
 
     /**
      * Filter the results so that the user never sees the "default" collaborator list in their search results
+     * or any communities
      * @param result
      * @return
      */
     List<Subject> getFilteredResults(List<Subject> result) {
         return result.stream()
-                     .filter(subject -> !Group.DEFAULT_GROUP.equals(subject.getName()))
+                     .filter(subject -> !Group.DEFAULT_GROUP.equals(subject.getName()) && !subject.isCommunity())
                      .collect(Collectors.toList());
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/communities/client/presenter/ManageCommunitiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/communities/client/presenter/ManageCommunitiesPresenterImpl.java
@@ -377,7 +377,9 @@ public class ManageCommunitiesPresenterImpl implements ManageCommunitiesView.Pre
     @Override
     public void onAddAppClick() {
         App selectedApp = appsPresenter.getSelectedApp();
-        selectAppsCallback.onSuccess(AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(selectedApp)));
+        if (selectedApp != null) {
+            selectAppsCallback.onSuccess(AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(selectedApp)));
+        }
         appSelectView.hide();
     }
 

--- a/de-lib/src/main/java/org/iplantc/de/communities/client/presenter/ManageCommunitiesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/communities/client/presenter/ManageCommunitiesPresenterImpl.java
@@ -346,6 +346,7 @@ public class ManageCommunitiesPresenterImpl implements ManageCommunitiesView.Pre
         appSelectView.addDialogHideHandler(event -> selectAppsCallback.onSuccess(null));
         appSelectView.setPresenter(this);
         appsPresenter.hideAppMenu().hideWorkflowMenu().go(appSelectView, null, null, null, false);
+        appsPresenter.setSingleAppSelection(true);
         appsPresenter.addAppSelectionChangedHandler(event -> {
             App selectedApp = appsPresenter.getSelectedApp();
             if (selectedApp != null && App.EXTERNAL_APP.equalsIgnoreCase(selectedApp.getAppType())) {

--- a/de-lib/src/main/java/org/iplantc/de/pipelines/client/presenter/PipelineViewPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/pipelines/client/presenter/PipelineViewPresenter.java
@@ -159,6 +159,7 @@ public class PipelineViewPresenter implements Presenter,
 
         // TODO Possibly inject with annotation to replace with a different toolbar impl
         appsPresenter.hideAppMenu().hideWorkflowMenu().go(appSelectView, null, null, null, false);
+        appsPresenter.setSingleAppSelection(true);
     }
 
 /*    private void initAppsDragHandlers(List<DragSource> sources) {

--- a/react-components/src/apps/listing/AppListingView.js
+++ b/react-components/src/apps/listing/AppListingView.js
@@ -13,7 +13,13 @@ import ids from "./ids";
  */
 
 export default function AppListingView(props) {
-    const { viewType, presenter, apps, baseId } = props;
+    const {
+        viewType,
+        presenter,
+        apps,
+        baseId,
+        singleSelection,
+    } = props;
     const [selectedApps, setSelectedApps] = useState([]);
 
     //reset selection when categories /  Hierarchy / search results change
@@ -22,6 +28,12 @@ export default function AppListingView(props) {
     }, [apps]);
 
     const handleAppSelection = (app) => {
+        if (singleSelection) {
+            setSelectedApps([app]);
+            presenter.onAppSelectionChanged([app]);
+            return;
+        }
+
         const selectedIndex = selectedApps.indexOf(app);
         let newSelected = [];
 


### PR DESCRIPTION
This will:
* Disable communities showing up in search results for sharing.
* Enable opening the apps window with single selection or multi selection.  Single selection will fix the bug where it looks like you can add multiple apps to communities or workflows at a time. This will then also fix the bug in communities where you had to deselect the previously selected app in order to add a new app to a community.