### PR TITLE
CORE-877 Add mutli-select relaunch support to AnalysesView

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/AnalysesView.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/AnalysesView.java
@@ -54,6 +54,8 @@ public interface AnalysesView extends IsWidget {
 
             String deleteAnalysisError();
 
+            String relaunchAnalysesError();
+
             String stopAnalysisError(String name);
 
             String analysisStepInfoError();
@@ -126,6 +128,10 @@ public interface AnalysesView extends IsWidget {
 
         @SuppressWarnings("unusable-by-js")
         void onShareAnalysisSelected(Splittable[] analysisList);
+
+        void onAnalysesRelaunch(String[] analysesToDelete,
+                                ReactSuccessCallback callback,
+                                ReactErrorCallback errorCallback);
 
         void deleteAnalyses(String[] analysesToDelete,
                             ReactSuccessCallback callback,

--- a/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/AnalysesPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/analysis/client/presenter/AnalysesPresenterImpl.java
@@ -305,6 +305,29 @@ public class AnalysesPresenterImpl implements AnalysesView.Presenter {
     }
 
     @Override
+    public void onAnalysesRelaunch(String[] analysesToRelaunch,
+                                   ReactSuccessCallback callback,
+                                   ReactErrorCallback errorCallback) {
+        analysisService.analysesRelaunch(analysesToRelaunch, new AnalysisCallback<String>() {
+
+            @Override
+            public void onFailure(Integer statusCode, Throwable caught) {
+                ErrorHandler.post(appearance.relaunchAnalysesError(), caught);
+                if (errorCallback != null) {
+                    errorCallback.onError(statusCode, caught.getMessage());
+                }
+            }
+
+            @Override
+            public void onSuccess(String arg0) {
+                if (callback != null) {
+                    callback.onSuccess(null);
+                }
+            }
+        });
+    }
+
+    @Override
     public void deleteAnalyses(String[] analysesToDelete,
                                ReactSuccessCallback callback,
                                ReactErrorCallback errorCallback) {

--- a/de-lib/src/main/java/org/iplantc/de/client/services/AnalysisServiceFacade.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/AnalysisServiceFacade.java
@@ -29,6 +29,14 @@ public interface AnalysisServiceFacade {
     void deleteAnalyses(String[] analysesToDelete, DECallback<String> callback);
 
     /**
+     * Auto Relaunch analyses
+     *
+     * @param analysesToRelaunch the analysis IDs to be relaunch.
+     * @param callback executed when RPC call completes.
+     */
+    void analysesRelaunch(String[] analysesToRelaunch, DECallback<String> callback);
+
+    /**
      * Renames an analysis.
      *
      * @param id the analysis id which will be renamed

--- a/de-lib/src/main/java/org/iplantc/de/client/services/impl/AnalysisServiceFacadeImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/services/impl/AnalysisServiceFacadeImpl.java
@@ -216,6 +216,18 @@ public class AnalysisServiceFacadeImpl implements AnalysisServiceFacade {
     }
 
     @Override
+    public void analysesRelaunch(String[] analysesToRelaunch, DECallback<String> callback) {
+        String address = ANALYSES + "/relauncher";
+        final String jArr = JsonUtil.getInstance().buildJsonArrayString(Arrays.asList(analysesToRelaunch));
+        final Splittable stringIdListSplittable = StringQuoter.split(jArr);
+        final Splittable payload = StringQuoter.createSplittable();
+        stringIdListSplittable.assign(payload, "analyses");
+        ServiceCallWrapper wrapper = new ServiceCallWrapper(POST, address, payload.getPayload());
+
+        deServiceFacade.getServiceData(wrapper, callback);
+    }
+
+    @Override
     public void renameAnalysis(String id, String newName, DECallback<Void> callback) {
         String address = ANALYSES + "/" + id;
         Splittable body = StringQuoter.createSplittable();

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/AnalysesMessages.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/AnalysesMessages.java
@@ -24,6 +24,8 @@ public interface AnalysesMessages extends Messages {
 
     String deleteAnalysisError();
 
+    String relaunchAnalysesError();
+
     String stopAnalysisError(String name);
 
     String analysisStepInfoError();

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/AnalysesMessages.properties
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/AnalysesMessages.properties
@@ -5,6 +5,7 @@ analysisRenameFailed = Failed to rename analysis.
 analysisRenameSuccess = Successfully renamed analysis
 analysisStopSuccess = Analysis {0} stopped successfully.
 deleteAnalysisError = Error deleting analysis.
+relaunchAnalysesError = Error relaunching analyses.
 renameAnalysis = Rename Analysis
 stopAnalysisError = Unable to stop execution of analysis "{0}".
 analysesRetrievalFailure = Unable to retrieve the list of analyses.

--- a/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/presenter/AnalysesPresenterDefaultAppearance.java
+++ b/de-lib/src/main/java/org/iplantc/de/theme/base/client/analyses/presenter/AnalysesPresenterDefaultAppearance.java
@@ -66,6 +66,11 @@ public class AnalysesPresenterDefaultAppearance implements AnalysesView.Presente
     }
 
     @Override
+    public String relaunchAnalysesError() {
+        return analysesMessages.relaunchAnalysesError();
+    }
+
+    @Override
     public String stopAnalysisError(String name) {
         return analysesMessages.stopAnalysisError(name);
     }

--- a/react-components/src/analysis/messages.js
+++ b/react-components/src/analysis/messages.js
@@ -63,6 +63,12 @@ var intlData = {
             " to extend the time limit?",
         analysesExecDeleteWarning:
             "This will remove the selected analyses and the parameters information associated with those analyses. Outputs can still be viewed in the Data window within the folder created by these analyses.",
+        analysesMultiRelaunchWarning:
+            "Relaunching more than one analysis at once will relaunch all selected analyses, reusing their original parameters and analysis names." +
+            " If the selected analyses are sub-jobs of an HT analysis, then those selected analyses will still be nested under that parent HT analysis," +
+            " and their output folders will also be grouped under that parent HT analysis' output folder," +
+            " but the relaunched sub-jobs will be renamed with a `-redo-#` suffix to differentiate them from their original sub-jobs." +
+            " Otherwise, relaunched analyses will be treated as new analyses, even though they reuse the same name and parameters as their original analyses.",
 
         shareDisclaimer:
             '<span style="overflow:auto;">I agree to <a href="https://wiki.cyverse.org/wiki/x/KBfHAQ" target="_blank">share my analysis</a> details, output file(s) and logs with CyVerse Support. If you want any of the <a href="https://wiki.cyverse.org/wiki/x/XRfHAQ" target="_blank">Science Informaticians</a> to recuse themselves from assisting with this problem, please list their name(s) in comments.</span>',

--- a/react-components/src/analysis/view/AnalysesMenuItems.js
+++ b/react-components/src/analysis/view/AnalysesMenuItems.js
@@ -94,13 +94,13 @@ class AnalysesMenuItems extends Component {
                 </MenuItem>
                 <MenuItem
                     id={build(baseDebugId, ids.MENUITEM_RELAUNCH)}
-                    disabled={disableSingleSelectionMenuItem}
+                    disabled={noSelection}
                     onClick={() => {
                         handleClose();
                         handleRelaunch();
                     }}
                     className={classes.menuItem}
-                    data-disabled={disableSingleSelectionMenuItem}
+                    data-disabled={noSelection}
                 >
                     <RepeatIcon className={classes.toolbarItemColor} />
                     {getMessage("relaunch")}

--- a/react-components/src/analysis/view/AnalysesView.js
+++ b/react-components/src/analysis/view/AnalysesView.js
@@ -304,6 +304,7 @@ class AnalysesView extends Component {
             viewParamsDialogOpen: false,
             shareWithSupportDialogOpen: false,
             confirmDeleteDialogOpen: false,
+            confirmRelaunchDialogOpen: false,
             logsMessageDialogOpen: false,
             confirmExtendTimeLimitDialogOpen: false,
             currentTimeLimit: "",
@@ -317,6 +318,7 @@ class AnalysesView extends Component {
         this.handleViewParams = this.handleViewParams.bind(this);
         this.handleRelaunchSingle = this.handleRelaunchSingle.bind(this);
         this.handleRelaunchFromMenu = this.handleRelaunchFromMenu.bind(this);
+        this.handleMultiRelaunch = this.handleMultiRelaunch.bind(this);
         this.handleViewInfo = this.handleViewInfo.bind(this);
         this.handleShare = this.handleShare.bind(this);
         this.handleCancel = this.handleCancel.bind(this);
@@ -751,11 +753,31 @@ class AnalysesView extends Component {
     handleRelaunchFromMenu() {
         const { selected } = this.state;
 
-        if (selected && selected.length > 1) {
-            this.props.presenter.onAnalysisRelaunch(selected);
-        } else {
-            this.handleRelaunchSingle(this.findAnalysis(selected[0]));
+        if (selected) {
+            if (selected.length > 1) {
+                this.setState({ confirmRelaunchDialogOpen: true });
+            } else {
+                this.handleRelaunchSingle(this.findAnalysis(selected[0]));
+            }
         }
+    }
+
+    handleMultiRelaunch() {
+        this.setState({ loading: true, confirmRelaunchDialogOpen: false });
+
+        this.props.presenter.onAnalysesRelaunch(
+            this.state.selected,
+            () => {
+                this.setState({
+                    loading: false,
+                });
+            },
+            (errorCode, errorMessage) => {
+                this.setState({
+                    loading: false,
+                });
+            }
+        );
     }
 
     handleViewInfo() {
@@ -1043,6 +1065,7 @@ class AnalysesView extends Component {
             shareWithSupportDialogOpen,
             viewParamsDialogOpen,
             confirmDeleteDialogOpen,
+            confirmRelaunchDialogOpen,
             parameters,
             info,
             infoDialogOpen,
@@ -1431,6 +1454,23 @@ class AnalysesView extends Component {
                     onCancelBtnClick={() => {
                         this.setState({
                             confirmDeleteDialogOpen: false,
+                        });
+                    }}
+                    okLabel={formatMessage(intl, "okBtnText")}
+                    cancelLabel={formatMessage(intl, "cancelBtnText")}
+                />
+                <DEConfirmationDialog
+                    debugId={build(baseId, ids.MENUITEM_RELAUNCH)}
+                    dialogOpen={confirmRelaunchDialogOpen}
+                    message={formatMessage(
+                        intl,
+                        "analysesMultiRelaunchWarning"
+                    )}
+                    heading={formatMessage(intl, "relaunch")}
+                    onOkBtnClick={this.handleMultiRelaunch}
+                    onCancelBtnClick={() => {
+                        this.setState({
+                            confirmRelaunchDialogOpen: false,
                         });
                     }}
                     okLabel={formatMessage(intl, "okBtnText")}

--- a/react-components/src/analysis/view/AnalysesView.js
+++ b/react-components/src/analysis/view/AnalysesView.js
@@ -160,10 +160,7 @@ function AppName(props) {
 
     if (!isDisabled) {
         return (
-            <span
-                className={className}
-                onClick={() => handleRelaunch(analysis)}
-            >
+            <span className={className} onClick={handleRelaunch}>
                 {name}
             </span>
         );
@@ -318,7 +315,7 @@ class AnalysesView extends Component {
         this.handleGoToOutputFolder = this.handleGoToOutputFolder.bind(this);
         this.handleViewLogs = this.handleViewLogs.bind(this);
         this.handleViewParams = this.handleViewParams.bind(this);
-        this.handleRelaunch = this.handleRelaunch.bind(this);
+        this.handleRelaunchSingle = this.handleRelaunchSingle.bind(this);
         this.handleRelaunchFromMenu = this.handleRelaunchFromMenu.bind(this);
         this.handleViewInfo = this.handleViewInfo.bind(this);
         this.handleShare = this.handleShare.bind(this);
@@ -742,19 +739,23 @@ class AnalysesView extends Component {
         }
     }
 
-    handleRelaunch(analysis) {
-        let selected = analysis
-            ? analysis
-            : this.findAnalysis(this.state.selected[0]);
-        this.props.presenter.onAnalysisAppSelected(
-            selected.id,
-            selected.system_id,
-            selected.app_id
-        );
+    handleRelaunchSingle(selected) {
+        selected &&
+            this.props.presenter.onAnalysisAppSelected(
+                selected.id,
+                selected.system_id,
+                selected.app_id
+            );
     }
 
     handleRelaunchFromMenu() {
-        this.handleRelaunch(this.findAnalysis(this.state.selected[0]));
+        const { selected } = this.state;
+
+        if (selected && selected.length > 1) {
+            this.props.presenter.onAnalysisRelaunch(selected);
+        } else {
+            this.handleRelaunchSingle(this.findAnalysis(selected[0]));
+        }
     }
 
     handleViewInfo() {
@@ -1196,8 +1197,10 @@ class AnalysesView extends Component {
                                                 >
                                                     <AppName
                                                         analysis={analysis}
-                                                        handleRelaunch={
-                                                            this.handleRelaunch
+                                                        handleRelaunch={() =>
+                                                            this.handleRelaunchSingle(
+                                                                analysis
+                                                            )
                                                         }
                                                         classes={classes}
                                                     />
@@ -1259,8 +1262,10 @@ class AnalysesView extends Component {
                                                             this
                                                                 .handleViewParams
                                                         }
-                                                        handleRelaunch={
-                                                            this.handleRelaunch
+                                                        handleRelaunch={() =>
+                                                            this.handleRelaunchSingle(
+                                                                analysis
+                                                            )
                                                         }
                                                         handleViewInfo={
                                                             this.handleViewInfo

--- a/react-components/stories/analysis/view/AnalysesView.stories.js
+++ b/react-components/stories/analysis/view/AnalysesView.stories.js
@@ -256,8 +256,16 @@ class AnalysesViewTest extends Component {
             onAnalysisNameSelected: () => {
                 console.log("Analysis name selected!");
             },
-            onAnalysisAppSelected: () => {
-                console.log("Analysis app name selected!");
+            onAnalysisRelaunch: (analysisIDs) => {
+                console.log("Analyses Relaunch selected!", analysisIDs);
+            },
+            onAnalysisAppSelected: (id, system_id, app_id) => {
+                console.log(
+                    "Analysis app name selected!",
+                    id,
+                    system_id,
+                    app_id
+                );
             },
             onCancelAnalysisSelected: () => {
                 console.log("Analysis cancel selected!");

--- a/react-components/stories/analysis/view/AnalysesView.stories.js
+++ b/react-components/stories/analysis/view/AnalysesView.stories.js
@@ -256,8 +256,13 @@ class AnalysesViewTest extends Component {
             onAnalysisNameSelected: () => {
                 console.log("Analysis name selected!");
             },
-            onAnalysisRelaunch: (analysisIDs) => {
+            onAnalysesRelaunch: (
+                analysisIDs,
+                successCallback,
+                errorCallback
+            ) => {
                 console.log("Analyses Relaunch selected!", analysisIDs);
+                setTimeout(successCallback, 1000);
             },
             onAnalysisAppSelected: (id, system_id, app_id) => {
                 console.log(
@@ -273,8 +278,9 @@ class AnalysesViewTest extends Component {
             onShareAnalysisSelected: () => {
                 console.log("Analysis sharing selected!");
             },
-            deleteAnalyses: () => {
+            deleteAnalyses: (selected, successCallback, errorCallback) => {
                 console.log("Deleted Analysis selected!");
+                setTimeout(successCallback, 1000);
             },
             onAnalysisJobInfoSelected: () => {
                 console.log("Job info selected!");


### PR DESCRIPTION
This PR will add mutli-select relaunch support to the AnalysesView, allowing users to select more than 1 analysis to relaunch with the new analyses auto-relaunch endpoint (cyverse-de/apps#197).

This PR will also add range-selection support to the AnalysesView.