### PR TITLE
CORE-763 Fix AVU number values in Metadata Template forms.

### DIFF
--- a/react-components/src/metadata/MetadataTemplateView.js
+++ b/react-components/src/metadata/MetadataTemplateView.js
@@ -16,15 +16,15 @@ import styles from "./style";
 import {
     build,
     DEConfirmationDialog,
+    formatCurrentDate,
+    formatMessage,
     FormCheckboxStringValue,
     FormIntegerField,
-    formatMessage,
     FormMultilineTextField,
     FormNumberField,
     FormSelectField,
     FormTextField,
     FormTimestampField,
-    formatCurrentDate,
     getFormError,
     getMessage,
     withI18N,
@@ -740,11 +740,21 @@ const postProcessAVUs = (avus, attributeMap) => {
     return avus.map((avu) => {
         const attrTemplate = attributeMap[avu.attr];
 
+        const isNumberAttr =
+            attrTemplate &&
+            (attrTemplate.type === constants.ATTRIBUTE_TYPE.NUMBER ||
+                attrTemplate.type === constants.ATTRIBUTE_TYPE.INTEGER);
+
         const isGroupingAttr =
             attrTemplate &&
             attrTemplate.type === constants.ATTRIBUTE_TYPE.GROUPING;
 
         const hasChildAVUs = avu.avus && avu.avus.length > 0;
+
+        if (isNumberAttr && (avu.value || avu.value === 0)) {
+            // The API will only accept AVU values as strings.
+            avu.value = avu.value.toString();
+        }
 
         if (attrTemplate && hasChildAVUs) {
             avu = {


### PR DESCRIPTION
The metadata presenter strips number/integer values from AVUs when converting to Autobeans in prep for submission to metadata endpoints.

This fix will convert number values to strings in the metadata form's `handleSubmit` function before passing the metadata to the presenter.