### PR TITLE
Fix NPE and loading mask issues with Collaborators window/dialog

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/CollaborationPresenterImpl.java
@@ -65,8 +65,10 @@ public class CollaborationPresenterImpl implements CollaborationView.Presenter {
     }
 
     List<Subject> convertTeamsToSubjects(List<Group> teams) {
-        return teams.stream()
-                    .map(team -> factory.convertGroupToSubject(team))
-                    .collect(Collectors.toList());
+        if (teams != null) {
+            return teams.stream().map(team -> factory.convertGroupToSubject(team)).collect(Collectors.toList());
+        } else {
+            return Lists.newArrayList();
+        }
     }
 }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/presenter/ManageCollaboratorsPresenter.java
@@ -11,7 +11,6 @@ import org.iplantc.de.client.models.groups.GroupAutoBeanFactory;
 import org.iplantc.de.client.models.groups.UpdateMemberResult;
 import org.iplantc.de.client.services.CollaboratorsServiceFacade;
 import org.iplantc.de.client.services.GroupServiceFacade;
-import org.iplantc.de.collaborators.client.CollaborationView;
 import org.iplantc.de.collaborators.client.ManageCollaboratorsView;
 import org.iplantc.de.collaborators.client.events.AddGroupSelected;
 import org.iplantc.de.collaborators.client.events.CollaboratorsLoadedEvent;
@@ -487,6 +486,7 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
                     public void onGroupSaved(GroupSaved event) {
                         Group group = event.getGroup();
                         view.addCollaborators(wrapSubjectInList(groupFactory.convertGroupToSubject(group)));
+                        result.hide();
                     }
                 });
             }
@@ -508,6 +508,7 @@ public class ManageCollaboratorsPresenter implements ManageCollaboratorsView.Pre
                     public void onGroupSaved(GroupSaved event) {
                         Group group = event.getGroup();
                         view.updateCollabList(groupFactory.convertGroupToSubject(group));
+                        result.hide();
                     }
                 });
             }

--- a/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
+++ b/de-lib/src/main/java/org/iplantc/de/collaborators/client/views/dialogs/GroupDetailsDialog.java
@@ -40,7 +40,6 @@ public class GroupDetailsDialog extends IPlantDialog implements GroupSaved.HasGr
             public void onSelect(SelectEvent event) {
                 if (presenter.isViewValid()) {
                     presenter.saveGroupSelected();
-                    hide();
                 } else {
                     AlertMessageBox alertMsgBox =
                             new AlertMessageBox("Warning", appearance.completeRequiredFieldsError());


### PR DESCRIPTION
* Fix NPE when attempting to add a collaborator for sharing via the "Choose Collaborators" option in the sharing dialog
* Fix Collaborators List dialog hiding automatically after clicking OK to save a Collaborator List.  The user was getting no feedback on whether the List didn't save or whether it was still in the process of saving.