### PR TITLE
CORE-968 Fix Analysis View statusClick and handleRowClick.

### DIFF
--- a/react-components/src/analysis/view/AnalysesView.js
+++ b/react-components/src/analysis/view/AnalysesView.js
@@ -566,8 +566,8 @@ class AnalysesView extends Component {
         return this.state.selected.indexOf(id) !== -1;
     }
 
-    statusClick(analysis) {
-        this.handleRowClick(analysis.id);
+    statusClick(index) {
+        this.handleRowClick(index);
         this.setState((prevState, props) => {
             return { shareWithSupportDialogOpen: true };
         });
@@ -601,16 +601,10 @@ class AnalysesView extends Component {
 
     handleRowClick(index) {
         this.setState((prevState, props) => {
-            const { data, selected } = prevState;
+            const { data } = prevState;
             const id = data[index].id;
 
-            const newState = { lastSelectedIndex: index };
-
-            if (selected.indexOf(id) < 0) {
-                newState.selected = [id];
-            }
-
-            return newState;
+            return { lastSelectedIndex: index, selected: [id] };
         });
     }
 
@@ -1296,7 +1290,7 @@ class AnalysesView extends Component {
                                                         baseId={baseId}
                                                         onClick={() =>
                                                             this.statusClick(
-                                                                analysis
+                                                                index
                                                             )
                                                         }
                                                         username={username}
@@ -1314,6 +1308,11 @@ class AnalysesView extends Component {
                                                             id +
                                                                 ids.ANALYSIS_DOT_MENU
                                                         )}
+                                                        handleAnalysisSelected={() =>
+                                                            this.handleRowClick(
+                                                                index
+                                                            )
+                                                        }
                                                         handleGoToOutputFolder={
                                                             this
                                                                 .handleGoToOutputFolder

--- a/react-components/src/analysis/view/DotMenu.js
+++ b/react-components/src/analysis/view/DotMenu.js
@@ -21,6 +21,7 @@ class DotMenu extends Component {
     }
 
     handleDotMenuClick = (event) => {
+        this.props.handleAnalysisSelected();
         this.setState({ anchorEl: event.currentTarget });
     };
 
@@ -29,6 +30,7 @@ class DotMenu extends Component {
     };
 
     render() {
+        const { handleAnalysisSelected, ...props } = this.props;
         const { anchorEl } = this.state;
         const open = Boolean(anchorEl);
 
@@ -51,7 +53,7 @@ class DotMenu extends Component {
                 >
                     <AnalysesMenuItems
                         handleClose={this.handleDotMenuClose}
-                        {...this.props}
+                        {...props}
                     />
                 </Menu>
             </div>

--- a/react-components/src/analysis/view/dialogs/ShareWithSupportDialog.js
+++ b/react-components/src/analysis/view/dialogs/ShareWithSupportDialog.js
@@ -38,7 +38,7 @@ function AnalysisInfo(props) {
     const { analysis, name, email } = props;
     if (analysis) {
         return (
-            <Grid container spacing={24} style={{ marginTop: 2, fontSize: 12 }}>
+            <Grid container spacing={3} style={{ marginTop: 2, fontSize: 12 }}>
                 <Grid item xs={6}>
                     {getMessage("analysis")}: {analysis.name}
                 </Grid>

--- a/react-components/stories/analysis/view/AnalysesView.stories.js
+++ b/react-components/stories/analysis/view/AnalysesView.stories.js
@@ -121,7 +121,7 @@ class AnalysesViewTest extends Component {
                 },
                 {
                     description: "",
-                    name: "Word_Count_analysis1",
+                    name: "Word_Count_analysis2",
                     can_share: true,
                     username: "sriram@iplantcollaborative.org",
                     app_id: "c7f05682-23c8-4182-b9a2-e09650a5f49b",
@@ -138,12 +138,12 @@ class AnalysesViewTest extends Component {
                         "https://pods.iplantcollaborative.org/wiki/display/DEapps/Word%20Count",
                     notify: true,
                     resultfolderid:
-                        "/iplant/home/sriram/analyses/Word_Count_analysis1-2018-08-03-16-40-48.7",
+                        "/iplant/home/sriram/analyses/Word_Count_analysis2-2018-08-03-16-40-48.7",
                     app_name: "Word Count",
                 },
                 {
                     description: "",
-                    name: "Word_Count_analysis1",
+                    name: "Word_Count_analysis3",
                     can_share: true,
                     username: "sriram@iplantcollaborative.org",
                     app_id: "c7f05682-23c8-4182-b9a2-e09650a5f49b",
@@ -160,12 +160,12 @@ class AnalysesViewTest extends Component {
                         "https://pods.iplantcollaborative.org/wiki/display/DEapps/Word%20Count",
                     notify: true,
                     resultfolderid:
-                        "/iplant/home/sriram/analyses/Word_Count_analysis1-2018-08-03-16-40-48.7",
+                        "/iplant/home/sriram/analyses/Word_Count_analysis3-2018-08-03-16-40-48.7",
                     app_name: "Word Count",
                 },
                 {
                     description: "",
-                    name: "Word_Count_analysis1",
+                    name: "Word_Count_analysis4",
                     can_share: true,
                     username: "sriram@iplantcollaborative.org",
                     app_id: "c7f05682-23c8-4182-b9a2-e09650a5f49b",
@@ -182,7 +182,7 @@ class AnalysesViewTest extends Component {
                         "https://pods.iplantcollaborative.org/wiki/display/DEapps/Word%20Count",
                     notify: true,
                     resultfolderid:
-                        "/iplant/home/sriram/analyses/Word_Count_analysis1-2018-08-03-16-40-48.7",
+                        "/iplant/home/sriram/analyses/Word_Count_analysis4-2018-08-03-16-40-48.7",
                     app_name: "Word Count",
                 },
                 {
@@ -204,7 +204,7 @@ class AnalysesViewTest extends Component {
                         "https://pods.iplantcollaborative.org/wiki/display/DEapps/Word%20Count",
                     notify: true,
                     resultfolderid:
-                        "/iplant/home/sriram/analyses/Word_Count_analysis1-2018-08-03-16-40-48.7",
+                        "/iplant/home/sriram/analyses/Interactive_analysis1-2018-08-03-16-40-48.7",
                     app_name: "Word Count",
                     interactive_urls: ["https://a60068256.cyverse.run"],
                 },
@@ -227,7 +227,7 @@ class AnalysesViewTest extends Component {
                         "https://pods.iplantcollaborative.org/wiki/display/DEapps/Word%20Count",
                     notify: true,
                     resultfolderid:
-                        "/iplant/home/sriram/analyses/Word_Count_analysis1-2018-08-03-16-40-48.7",
+                        "/iplant/home/sriram/analyses/Interactive_analysis2-2018-08-03-16-40-48.7",
                     app_name: "Word Count",
                     interactive_urls: ["https://a60068256.cyverse.run"],
                 },
@@ -247,14 +247,16 @@ class AnalysesViewTest extends Component {
             ) => {
                 resultCallback(analysesList);
             },
-            renameAnalysis: () => {
-                console.log("Rename called!");
+            renameAnalysis: (id, newName, successCallback) => {
+                console.log("Rename called!", id, newName);
+                setTimeout(successCallback, 1000);
             },
-            updateAnalysisComments: () => {
-                console.log("Update Comments called!");
+            updateAnalysisComments: (id, comments, successCallback) => {
+                console.log("Update Comments called!", id, comments);
+                setTimeout(successCallback, 1000);
             },
-            onAnalysisNameSelected: () => {
-                console.log("Analysis name selected!");
+            onAnalysisNameSelected: (resultfolderid) => {
+                console.log("Analysis name selected!", resultfolderid);
             },
             onAnalysesRelaunch: (
                 analysisIDs,
@@ -272,21 +274,24 @@ class AnalysesViewTest extends Component {
                     app_id
                 );
             },
-            onCancelAnalysisSelected: () => {
-                console.log("Analysis cancel selected!");
-            },
-            onShareAnalysisSelected: () => {
-                console.log("Analysis sharing selected!");
-            },
-            deleteAnalyses: (selected, successCallback, errorCallback) => {
-                console.log("Deleted Analysis selected!");
+            onCancelAnalysisSelected: (id, name, successCallback) => {
+                console.log("Analysis cancel selected!", id, name);
                 setTimeout(successCallback, 1000);
             },
-            onAnalysisJobInfoSelected: () => {
-                console.log("Job info selected!");
+            onShareAnalysisSelected: (selectedAnalyses) => {
+                console.log("Analysis sharing selected!", selectedAnalyses);
             },
-            onUserSupportRequested: () => {
-                console.log("User support requested!");
+            deleteAnalyses: (selected, successCallback, errorCallback) => {
+                console.log("Deleted Analysis selected!", selected);
+                setTimeout(successCallback, 1000);
+            },
+            onAnalysisJobInfoSelected: (id, successCallback) => {
+                console.log("Job info selected!", id);
+                setTimeout(successCallback, 1000);
+            },
+            onUserSupportRequested: (analysis, comment, successCallback) => {
+                console.log("User support requested!", analysis, comment);
+                setTimeout(successCallback, 1000);
             },
             handleViewAndTypeFilterChange: (viewFilter, appTypeFilter) => {
                 console.log(
@@ -305,11 +310,14 @@ class AnalysesViewTest extends Component {
             handleViewAllIconClick: () => {
                 console.log("View All");
             },
+            getVICELogs: (analysisId, name) => {
+                console.log("Get VICE Logs", analysisId, name);
+            },
         };
 
         const paramPresenter = {
             fetchAnalysisParameters: (selected, resolve, reject) => {
-                console.log("fetch parameters");
+                console.log("fetch parameters", selected);
                 setTimeout(
                     () =>
                         resolve({


### PR DESCRIPTION
* Updating `statusClick` to use `index` instead of an `analysis` object was missed in #478.
* The `handleRowClick` logic also should have been updated in #478 to set the selected items to only the row clicked.
* The `DotMenu` was also updated to select that row when clicked, so that the single-item actions are available in that menu.
* The `AnalysesView` story `presenter` was updated to also log analysis info in console logs for various methods.