### PR TITLE
Remove DiskResourceNameValidator from BulkMetadataViewImpl

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/BulkMetadataViewImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/views/metadata/BulkMetadataViewImpl.java
@@ -49,7 +49,6 @@ public class BulkMetadataViewImpl extends Composite implements BulkMetadataView 
         this.mode = mode;
         this.fileSelector = drSelectorFieldFactory.defaultFileSelector();
         fileSelector.setValidatePermissions(true);
-        fileSelector.addValidator(new DiskResourceNameValidator());
 
         initWidget(BINDER.createAndBindUi(this));
         selLbl.setHTML(appearance.selectMetadataFile());


### PR DESCRIPTION
Since the file selector includes the entire resource path, having this validation would always fail on the `/` character being present in the path (e.g. /iplant/home/username).  Considering users can only pick items from the data store and cannot manually type in a file/folder, validating the resource name is unnecessary at this stage anyway.