### PR TITLE
Remove totalBad field from all usage, since it isn't really being used anyway

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/Folder.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/diskResources/Folder.java
@@ -22,12 +22,6 @@ public interface Folder extends DiskResource {
     
     int getTotal();
     
-    @PropertyName("totalBad")
-    void setTotalFiltered(int total_filtered);
-
-    @PropertyName("totalBad")
-    int getTotalFiltered();
-
     @PropertyName("dir-count")
     int getDirCount();
 

--- a/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/proxy/FolderContentsRpcProxyImpl.java
+++ b/de-lib/src/main/java/org/iplantc/de/diskResource/client/presenters/grid/proxy/FolderContentsRpcProxyImpl.java
@@ -120,9 +120,6 @@ public class FolderContentsRpcProxyImpl extends RpcProxy<FolderContentsLoadConfi
             }
             // Create list of all items within the result folder
             List<DiskResource> list = Lists.newArrayList(Iterables.concat(result.getFolders(), result.getFiles()));
-            // Update the loadConfig folder with the totalFiltered count.
-
-            loadConfig.getFolder().setTotalFiltered(result.getTotalFiltered());
 
             callback.onSuccess(new PagingLoadResultBean<>(list, result.getTotal(), loadConfig.getOffset()));
 

--- a/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/grid/proxy/FolderContentsRpcProxyTest.java
+++ b/de-lib/src/test/java/org/iplantc/de/diskResource/client/presenters/grid/proxy/FolderContentsRpcProxyTest.java
@@ -172,7 +172,6 @@ public class FolderContentsRpcProxyTest {
         Folder f = mock(Folder.class);
         f.setName("test");
         callBackCaptor.getValue().onSuccess(f);
-        verify(mockFolder).setTotalFiltered(anyInt());
         verify(pagingAsyncMock).onSuccess(any(PagingLoadResultBean.class));
 
         verifyNoMoreInteractions(mockHasSafeHtml, diskResourceService, pagingAsyncMock);


### PR DESCRIPTION
Pretty straightforward, hopefully, if it's me putting up an old-ui PR :laughing:

Just trying to make it so the UI doesn't use that field at all, so that it won't care if it's there or not.